### PR TITLE
Fixed charge dispersion equation typo in LOM analysis

### DIFF
--- a/qiskit_metal/analyses/quantization/lumped_capacitive.py
+++ b/qiskit_metal/analyses/quantization/lumped_capacitive.py
@@ -101,7 +101,7 @@ def transmon_props(Ic: float, Cq: float):
     wq = 1 / np.sqrt(LJ * Cq) - EC
 
     # charge dispersion
-    eps1 = EC * 2**9 * (2/np.sqrt(np.pi)) * \
+    eps1 = EC * 2**9 * (np.sqrt(2/np.pi)) * \
         (EJ/2/EC)**(1.25) * np.exp(-np.sqrt(8*EJ/EC))
 
     return LJ, EJ, Zqp, EC, wq, wq0, eps1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### What are the issues this pull addresses (issue numbers / links)?

Fixes #851 

The dispersion equation in `qiskit_metal\analyses\quantization\lumped_capacitive.py` miscalculated charge dispersion $\epsilon$ by not including a 2 under the square root. Now the calculation matches analytical calculations according to [Charge-insensitive qubit design derived from the Cooper pair box, PhysRevA.76.042319](https://link.aps.org/doi/10.1103/PhysRevA.76.042319).

Before:
<img width="463" alt="Screen Shot 2023-06-13 at 1 54 34 PM" src="https://github.com/qiskit-community/qiskit-metal/assets/77815553/8809434f-1a9b-48c4-bf02-6345a75087e1">

After:
<img width="463" alt="Screen Shot 2023-06-13 at 1 54 15 PM" src="https://github.com/qiskit-community/qiskit-metal/assets/77815553/81a2b928-933c-48f4-a254-872804c9e5f0">


### Did you add tests to cover your changes (yes/no)?

I did not add any tests as `test_analyses_2_functionality.py` covers this change. My changes pass `run_all_tests.py`, `test_analyses_2_functionality.py` and `test_analyses_1_inst_options.py`.

### Did you update the documentation accordingly (yes/no)?

I did not update the documentation as the documentation does not pertain to this change. The functionality of the `transmon_props()` method remains the same.

### Did you read the CONTRIBUTING document (yes/no)?
Yes I did.

### Summary

This brief commit fixes the charge dispersion calculation in the `transmon_props()` function within the file `qiskit_metal\analyses\quantization\lumped_capacitive.py`. This calculation is important as it contributes to the calculation of a device T1 time, an important metric of quantum devices.


### Details and comments


