### PR TITLE
QHFSSPyaedt now updates Ljs

### DIFF
--- a/qiskit_metal/config.py
+++ b/qiskit_metal/config.py
@@ -38,14 +38,11 @@ renderers_to_load = Dict(
         path_name=
         'qiskit_metal.renderers.renderer_ansys_pyaedt.q3d_renderer_aedt',
         class_name='QQ3DPyaedt'),
-    aedt_hfss_drivenmodal=Dict(
+    aedt_hfss=Dict(
         path_name=
-        'qiskit_metal.renderers.renderer_ansys_pyaedt.hfss_renderer_drivenmodal_aedt',
-        class_name='QHFSSDrivenmodalPyaedt'),
-    aedt_hfss_eigenmode=Dict(
-        path_name=
-        'qiskit_metal.renderers.renderer_ansys_pyaedt.hfss_renderer_eigenmode_aedt',
-        class_name='QHFSSEigenmodePyaedt'))
+        'qiskit_metal.renderers.renderer_ansys_pyaedt.hfss_renderer_aedt',
+        class_name='QHFSSPyaedt'
+    ))
 """
 Define the renderes to load. Just provide the module names here.
 """

--- a/qiskit_metal/config.py
+++ b/qiskit_metal/config.py
@@ -41,8 +41,7 @@ renderers_to_load = Dict(
     aedt_hfss=Dict(
         path_name=
         'qiskit_metal.renderers.renderer_ansys_pyaedt.hfss_renderer_aedt',
-        class_name='QHFSSPyaedt'
-    ))
+        class_name='QHFSSPyaedt'))
 """
 Define the renderes to load. Just provide the module names here.
 """

--- a/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
+++ b/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
@@ -589,7 +589,7 @@ class QHFSSPyaedt(QPyaedt):
             jj_geom_table = self.design.qgeometry.tables['junction']
             jj_of_interest = jj_geom_table[jj_geom_table['name'] == qc_elt]
             Lvalue = parse_entry(jj_of_interest['aedt_hfss_inductance'][0])
-            Cvalue = parse_entry(jj_of_interest['aedt_hfss_capacitance'][0])  
+            Cvalue = parse_entry(jj_of_interest['aedt_hfss_capacitance'][0])
 
             lumped_rlc_boundary = self.current_app.assign_lumped_rlc_to_sheet(
                 sheet_name=poly_sheet.name,

--- a/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
+++ b/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
@@ -73,7 +73,7 @@ class QHFSSPyaedt(QPyaedt):
 
     def __init__(self,
                  multilayer_design: 'MultiPlanar',
-                 renderer_type: str,
+                 renderer_type: str = 'HFSS',
                  project_name: Union[str, None] = None,
                  design_name: Union[str, None] = None,
                  initiate=False,
@@ -585,16 +585,18 @@ class QHFSSPyaedt(QPyaedt):
                     axisdir=endpoints_3d,
                     impedance=impedance)
         else:
-            ####### MUST CHANGE Lvalue should come from qgeometry table.
-            lj_value = parse_entry(qgeom['hfss_inductance'])
-            #### Need to register the renderer to Qiskit Metal.
+            # Looks QGeometry table to pull Lj and Cj
+            jj_geom_table = self.design.qgeometry.tables['junction']
+            jj_of_interest = jj_geom_table[jj_geom_table['name'] == qc_elt]
+            Lvalue = parse_entry(jj_of_interest['aedt_hfss_inductance'][0])
+            Cvalue = parse_entry(jj_of_interest['aedt_hfss_capacitance'][0])  
 
             lumped_rlc_boundary = self.current_app.assign_lumped_rlc_to_sheet(
                 sheet_name=poly_sheet.name,
                 sourcename=f'rlc_{poly_sheet.name}',
                 axisdir=endpoints_3d,
-                Lvalue=10e-9)
-        a = 5
+                Lvalue=Lvalue,
+                Cvalue=Cvalue)
 
     def draw_sample_holder(self):
         """Adds a vacuum box to HFSS design.  The xy coordinates are determined by

--- a/qiskit_metal/tests/test_designs.py
+++ b/qiskit_metal/tests/test_designs.py
@@ -503,7 +503,7 @@ class TestDesign(unittest.TestCase, AssertionsMixin):
 
         result = q1._get_table_values_from_renderers(design)
 
-        self.assertEqual(len(result), 20)
+        self.assertEqual(len(result), 17)
         self.assertEqual(result['hfss_inductance'], '10nH')
         self.assertEqual(result['hfss_capacitance'], 0)
         self.assertEqual(result['hfss_resistance'], 0)
@@ -515,6 +515,8 @@ class TestDesign(unittest.TestCase, AssertionsMixin):
         self.assertEqual(result['gds_cell_name'], 'my_other_junction')
         self.assertEqual(result['hfss_wire_bonds'], False)
         self.assertEqual(result['q3d_wire_bonds'], False)
+        self.assertEqual(result['aedt_hfss_inductance'], '10nH')
+        self.assertEqual(result['aedt_hfss_capacitance'], 0)
 
 
 if __name__ == '__main__':

--- a/qiskit_metal/tests/test_designs.py
+++ b/qiskit_metal/tests/test_designs.py
@@ -515,7 +515,7 @@ class TestDesign(unittest.TestCase, AssertionsMixin):
         self.assertEqual(result['gds_cell_name'], 'my_other_junction')
         self.assertEqual(result['hfss_wire_bonds'], False)
         self.assertEqual(result['q3d_wire_bonds'], False)
-        self.assertEqual(result['aedt_hfss_inductance'], '10nH')
+        self.assertEqual(result['aedt_hfss_inductance'], 10e-9)
         self.assertEqual(result['aedt_hfss_capacitance'], 0)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
https://github.com/qiskit-community/qiskit-metal/issues/954

### Did you add tests to cover your changes (yes/no)?
Yes- updated method `test_design_get_list_of_tables_in_metadata` in `test_designs.py` 


### Did you update the documentation accordingly (yes/no)?
No - not applicable. Changes are not exposed to front-end user / any function input-output.

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
When calling `QHFSSPyaedt.render_design()` it now will update the Ljs in ANSYS.

To reduce confusion for the front-end user, I removed the `QHFSSEigenmodePyaedt` and `QHFSSDrivenmodalPyaedt` from `qiskit_metal.config.py`. Meaning when calling `QComponent.default_options` the user will know only to prompt `options = dict(aedt_hfss_inductance = 10E-9)`


### Details and comments


