### PR TITLE
Fixed `run_epr` coming from moving renderers

### DIFF
--- a/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
+++ b/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
@@ -361,8 +361,8 @@ class QHFSSEigenmodePyaedt(QHFSSPyaedt):
             ### Parsing Data ###
             component = str(row['component'])
             name = str(row['name'])
-            inductance = row['aedt_hfss_eigenmode_inductance']  # Lj in Henries
-            capacitance = row['aedt_hfss_eigenmode_capacitance']  # Cj in Farads
+            inductance = row['aedt_hfss_inductance']  # Lj in Henries
+            capacitance = row['aedt_hfss_capacitance']  # Cj in Farads
 
             # Get ANSYS > Model > Sheet corresponding to JJs
             rect_name = 'JJ_rect_Lj_' + component + '_' + name


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?


### Did you add tests to cover your changes (yes/no)?
No - internal change.

### Did you update the documentation accordingly (yes/no)?
No - internal change.

### Did you read the CONTRIBUTING document (yes/no)?
Yes

### Summary
In https://github.com/qiskit-community/qiskit-metal/pull/955, there were left over calls to `aedt_hfss_eigenmode_inductance` and `aedt_hfss_eigenmode_capacitance`. This PR is to fix that mistake.

Doing a global search through the code reveals that changes included are the only leftover `aedt_hfss_eigenmode_inductance` and `aedt_hfss_eigenmode_capacitance`.

Sorry! Will be more vigilant next time.

### Details and comments


