### PR TITLE
Upgrade nbpshinx to fix circuit-examples docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,6 +166,7 @@ nbsphinx_thumbnails = {
         '_static/4-15-kappa-calc.png',
     'tut/1-Overview/1.3-Saving-Your-Chip-Design':
         '_static/1-3-save.png',
+    "**": "_static/images/logo.png",  # The default.
 }
 
 # -----------------------------------------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,22 +2,19 @@
 jupyter==1.0.0
 jupyterlab==3.6.1
 
-# Build tools
-wheel==0.38.4
-
 # Formatters
 pylint==2.16.2
 yapf==0.32.0
 
 # Doc Build
 sphinx~=7.0.1
-numpydoc==1.5.0
-sphinx-automodapi==0.14.1
-jupyter_sphinx==0.4.0
-nbsphinx==0.8.6
+numpydoc~=1.5.0
+sphinx-automodapi~=0.14.1
+jupyter_sphinx~=0.4.0
+nbsphinx~=0.9.2
 qiskit-sphinx-theme~=1.12.0
-jupyter_nbgallery==2.0.0
+jupyter_nbgallery~=2.0.0
 sphinx-intl~=2.1.0
 
 # Unit tests
-pytest==7.2.1
+pytest~=7.2.1


### PR DESCRIPTION
Upgrading fixes a weird issue where the nbsphinx tutorials gallery were covering each other.

<img width="883" alt="Screenshot 2023-06-22 at 3 51 41 PM" src="https://github.com/qiskit-community/qiskit-metal/assets/14852634/cdde5dd0-9f61-4b85-bb2a-5f490b7ca64e">
