### PR TITLE
Add requirement for cython and update docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -77,7 +77,7 @@ Once you are in the folder that contains the `environment.yml` file, execute the
 
 ::
 
-    conda env create -n <env_name> environment.yml
+    conda env create -n <env_name> -f environment.yml
     conda activate <env_name>
     python -m pip install --no-deps -e .
 

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - scqubits==3.1.0
   - pyyaml==6.0
   - pip==23.0
+  - cython<3.0.0
   - pip:
       - pyaedt==0.6.46
       - gmsh==4.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,5 @@ scqubits==3.1.0
 gmsh==4.11.1
 pyaedt==0.6.46
 pyyaml==6.0
+cython<3.0.0
 # jupyter (if you need a fresh install) or ipykernel (if you prefer to make of this a new kernel to use from an existing jupyter install)


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?
- Documentation of installation was not up date: newest python version 3.11 requires the use of `-f` flag for specifying the environment.yml file.
- Using the latest anaconda installation (as of 07-08-2023), you will get the following error when importing qiskit_metal after installation:

   ```File "C:\ProgramData\anaconda3\envs\test\Lib\site-packages\qutip\cy\pyxbuilder.py", line 17, in <module>
       old_get_distutils_extension = pyximport.pyximport.get_distutils_extension
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   AttributeError: module 'pyximport.pyximport' has no attribute 'get_distutils_extension'
   ```

   Which is due to the new cython version 3.0.0 which just came out.

### Did you add tests to cover your changes (yes/no)?
No, this is not needed since there are no code changes but only an added requirement.

### Did you update the documentation accordingly (yes/no)?
yes

### Did you read the CONTRIBUTING document (yes/no)?
yes

### Summary
Updated documentation of installation according to newest python version 3.11
Added requirement to not use the latest version of cython (3.0.0)

### Details and comments


