### PR TITLE
GDS renderer: changed criterion for rounding paths

### DIFF
--- a/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -2337,7 +2337,8 @@ class QGDSRenderer(QRenderer):
 
                 if (math.isnan(qgeometry_element.fillet) or
                         qgeometry_element.fillet <= 0 or
-                        qgeometry_element.fillet < qgeometry_element.width):
+                        qgeometry_element.fillet <
+                                      0.5 * qgeometry_element.width):
 
                     to_return = gdspy.FlexPath(list(geom.coords),
                                                use_width,


### PR DESCRIPTION
Method QGDSRenderer._qgeometry_to_gds() checks several conditions to decide whether a shapely.geometry.LineString is drawn with rounded or sharp corners. One of them takes into account that if the fillet radius gets too small relative to the width of the line, the rounding cannot be applied correctly anymore, hence drawing the line with sharp corners.

Before this commit, this was implemented via the criterion

  `qgeometry_element.fillet < qgeometry_element.width`;

however, this criterion is too strict because corners can well be rounded also if 0.5*width < fillet radius < width. Therefore, this commit changes this criterion to

  `qgeometry_element.fillet < 0.5 * qgeometry_element.width`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?


### Did you add tests to cover your changes (yes/no)?

### Did you update the documentation accordingly (yes/no)?

### Did you read the CONTRIBUTING document (yes/no)?

### Summary



### Details and comments


