### PR TITLE
[WIP] Fix broken CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip==23.0
-          pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
           sudo apt update
           sudo apt install graphviz=2.42.2-6 pandoc=2.9.2.1-3ubuntu2 qtbase5-dev=5.15.3+dfsg-2ubuntu0.2 qt5-qmake=5.15.3+dfsg-2ubuntu0.2
       - name: Build and publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip==23.0
-          pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
+          pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
           sudo apt update
           sudo apt install graphviz=2.42.2-6 pandoc=2.9.2.1-3ubuntu2 qtbase5-dev=5.15.3+dfsg-2ubuntu0.2 qt5-qmake=5.15.3+dfsg-2ubuntu0.2
       - name: Build and publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip==23.0
-          pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          pip install -U tox==4.11.0 setuptools==67.3.1 virtualenv==20.24.3 wheel==0.38.4
           sudo apt update
           sudo apt install graphviz=2.42.2-6 pandoc=2.9.2.1-3ubuntu2 qtbase5-dev=5.15.3+dfsg-2ubuntu0.2 qt5-qmake=5.15.3+dfsg-2ubuntu0.2
       - name: Build and publish

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             ubuntu-latest-${{ matrix.python-version }}
       - name: Install Deps
         run: |
-          python -m pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
+          python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
           sudo apt install libglu1-mesa=9.0.2-1 libglu1-mesa-dev=9.0.2-1
       - name: Install and Run Tests
         run: tox -e py
@@ -66,7 +66,7 @@ jobs:
             macOS-latest-${{ matrix.python-version }}-pip-
             macOS-latest-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
+        run: python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
       - name: Install and Run Tests
         run: tox -e py
   windows-tests:
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install deps
         run: |
-          python -m pip install -U tox cvxopt==1.3.0 setuptools==67.3.1 virtualenv wheel==0.38.4
+          python -m pip install -U tox==4.4.5 cvxopt==1.3.0 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
         shell: pwsh
       - name: Install and Run Tests
         run: tox --sitepackages -e py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             ubuntu-latest-${{ matrix.python-version }}
       - name: Install Deps
         run: |
-          python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          python -m pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
           sudo apt install libglu1-mesa=9.0.2-1 libglu1-mesa-dev=9.0.2-1
       - name: Install and Run Tests
         run: tox -e py
@@ -66,7 +66,7 @@ jobs:
             macOS-latest-${{ matrix.python-version }}-pip-
             macOS-latest-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+        run: python -m pip install -U tox setuptools==67.3.1 virtualenv wheel==0.38.4
       - name: Install and Run Tests
         run: tox -e py
   windows-tests:
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install deps
         run: |
-          python -m pip install -U tox==4.4.5 cvxopt==1.3.0 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          python -m pip install -U tox cvxopt==1.3.0 setuptools==67.3.1 virtualenv wheel==0.38.4
         shell: pwsh
       - name: Install and Run Tests
         run: tox --sitepackages -e py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
             ubuntu-latest-${{ matrix.python-version }}
       - name: Install Deps
         run: |
-          python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          python -m pip install -U tox==4.11.0 setuptools==67.3.1 virtualenv==20.24.3 wheel==0.38.4
           sudo apt install libglu1-mesa=9.0.2-1 libglu1-mesa-dev=9.0.2-1
       - name: Install and Run Tests
         run: tox -e py
@@ -66,7 +66,7 @@ jobs:
             macOS-latest-${{ matrix.python-version }}-pip-
             macOS-latest-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox==4.4.5 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+        run: python -m pip install -U tox==4.11.0 setuptools==67.3.1 virtualenv==20.24.3 wheel==0.38.4
       - name: Install and Run Tests
         run: tox -e py
   windows-tests:
@@ -92,7 +92,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install deps
         run: |
-          python -m pip install -U tox==4.4.5 cvxopt==1.3.0 setuptools==67.3.1 virtualenv==20.19.0 wheel==0.38.4
+          python -m pip install -U tox==4.11.0 cvxopt==1.3.0 setuptools==67.3.1 virtualenv==20.24.3 wheel==0.38.4
         shell: pwsh
       - name: Install and Run Tests
         run: tox --sitepackages -e py
@@ -116,7 +116,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox==4.4.5
+        run: python -m pip install -U tox==4.11.0
       - name: Run lint
         run: tox -elint
   docs:
@@ -141,7 +141,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install Deps
         run: |
-          python -m pip install -U tox==4.4.5
+          python -m pip install -U tox==4.11.0
           sudo apt update
           sudo apt install -y graphviz=2.42.2-6 pandoc=2.9.2.1-3ubuntu2 qtbase5-dev=5.15.3+dfsg-2ubuntu0.2 qt5-qmake=5.15.3+dfsg-2ubuntu0.2
       - name: Build Docs

--- a/qiskit_metal/qlibrary/user_components/BridgeFreeJJ.py
+++ b/qiskit_metal/qlibrary/user_components/BridgeFreeJJ.py
@@ -1,13 +1,10 @@
-
 import qiskit_metal as metal
 import numpy as np
 from qiskit_metal import Dict, draw
 from qiskit_metal.qlibrary.core import QComponent
 
 
-
 class BridgeFreeJunction(QComponent):
-
     """
     Bridge-free Josephson Junction.
     Reference: F. Lecocq, et al., Nanotechnology, 22, 302-315, (2011).
@@ -25,42 +22,37 @@ class BridgeFreeJunction(QComponent):
 
     """
 
-    default_options = Dict(JJ_width='4. um',
-                           JJ_height='4. um',
-                           teta_1='30',  #
-                           teta_2='30',  #
-                           wire_length='30um', #
-                           wire_width='0.5 um', #
-                           resist_t1='.3um',  # Thickness of the first (lower) resist layer. Option is 200 nm.
-                           resist_t2='.2um',
-                           orientation='0',
-                           layer='53',
-                           layer_2='545.',
-                           layer_3='55.',
-                           layer_4='1.',
-                           pos_x='0',
-                           pos_y='0'
-
-                           )
+    default_options = Dict(
+        JJ_width='4. um',
+        JJ_height='4. um',
+        teta_1='30',  #
+        teta_2='30',  #
+        wire_length='30um',  #
+        wire_width='0.5 um',  #
+        resist_t1=
+        '.3um',  # Thickness of the first (lower) resist layer. Option is 200 nm.
+        resist_t2='.2um',
+        orientation='0',
+        layer='53',
+        layer_2='545.',
+        layer_3='55.',
+        layer_4='1.',
+        pos_x='0',
+        pos_y='0')
 
     component_metadat = Dict(short_name='Bf_JJ',
                              _qgeometry_table_poly='True',
                              _qgeometry_table_junction='True',
-                             _qgeometry_table_path='True'
-                             )
-
-
-
+                             _qgeometry_table_path='True')
 
     def make(self):
         name = 'bf_JJ'
         p = self.parse_options()  # Parse the string options into numbers
         resist_t1 = p.resist_t1
         resist_t2 = p.resist_t2
-        teta_1 = p.teta_1      # This angle is considered as the angle between the beam in
-                                # the area (-x,y) and the vertical line
+        teta_1 = p.teta_1  # This angle is considered as the angle between the beam in
+        # the area (-x,y) and the vertical line
         teta_2 = p.teta_2
-
 
         # We need different openings for wires. For the purpose, we define hight_total and hight_bottom.
         # The bottom is required for the undercut layer, corresponding to the low dose.
@@ -82,52 +74,57 @@ class BridgeFreeJunction(QComponent):
             raise ValueError
 
         #Define the wire at the left side of the junction.
-        wire_l = draw.box(-(p.wire_length + p.JJ_width / 2.), - p.wire_width / 2. - shift_2_t, -p.JJ_width / 2.,
+        wire_l = draw.box(-(p.wire_length + p.JJ_width / 2.),
+                          -p.wire_width / 2. - shift_2_t, -p.JJ_width / 2.,
                           p.wire_width / 2. - shift_2_b)
 
         # Define the wire at the right side of the junction.
-        wire_r = draw.box(p.JJ_width / 2., - p.wire_width / 2. + shift_1_b, p.JJ_width / 2. + p.wire_length,
+        wire_r = draw.box(p.JJ_width / 2., -p.wire_width / 2. + shift_1_b,
+                          p.JJ_width / 2. + p.wire_length,
                           p.wire_width / 2. + shift_1_t)
 
         # Draw the Junction area as a box
-        JJ = draw.box(-p.JJ_width / 2., -p.JJ_height / 2. - shift_2_t, p.JJ_width / 2., p.JJ_height / 2. + shift_1_t)
+        JJ = draw.box(-p.JJ_width / 2., -p.JJ_height / 2. - shift_2_t,
+                      p.JJ_width / 2., p.JJ_height / 2. + shift_1_t)
 
         # Define the feature as a union of the Josephson Junction and the wires.
         Junction = draw.union(JJ, wire_l, wire_r)
 
         # Define undercut layer at the left wire
-        undercut_l = draw.box(-(p.wire_length + p.JJ_width / 2.), p.wire_width / 2.,
-                              -p.JJ_width / 2., p.wire_width / 2. + shift_2_b
-                              )
+        undercut_l = draw.box(-(p.wire_length + p.JJ_width / 2.),
+                              p.wire_width / 2., -p.JJ_width / 2.,
+                              p.wire_width / 2. + shift_2_b)
 
         # Define undercut layer at the right wire
-        undercut_r = draw.box(p.JJ_width / 2., - p.wire_width / 2.,
-                              p.JJ_width / 2. + p.wire_length, - p.wire_width / 2. - shift_1_b)
+        undercut_r = draw.box(p.JJ_width / 2., -p.wire_width / 2.,
+                              p.JJ_width / 2. + p.wire_length,
+                              -p.wire_width / 2. - shift_1_b)
 
         # Define undercut layer below the junction (for the bottom electrode)
-        undercut_jj_low = draw.box(-p.JJ_width / 2., -p.JJ_height / 2. - shift_2_t,
-                                   p.JJ_width / 2, -p.JJ_height / 2. - shift_2_t - shift_1_b)
+        undercut_jj_low = draw.box(-p.JJ_width / 2.,
+                                   -p.JJ_height / 2. - shift_2_t,
+                                   p.JJ_width / 2,
+                                   -p.JJ_height / 2. - shift_2_t - shift_1_b)
 
         # Define undercut layer above the junction (for the top electrode)
-        undercut_jj_up = draw.box(-p.JJ_width / 2., p.JJ_height / 2. + shift_1_t,
-                                  p.JJ_width / 2, p.JJ_height / 2. + shift_1_t + shift_2_b)
+        undercut_jj_up = draw.box(-p.JJ_width / 2.,
+                                  p.JJ_height / 2. + shift_1_t, p.JJ_width / 2,
+                                  p.JJ_height / 2. + shift_1_t + shift_2_b)
 
         #Define undercut layer as a union of the all undercuts.
-        undercut = draw.union(undercut_jj_low, undercut_jj_up, undercut_l, undercut_r)
+        undercut = draw.union(undercut_jj_low, undercut_jj_up, undercut_l,
+                              undercut_r)
 
         Junction_items = [Junction, undercut]
-        Junction_items = draw.rotate(Junction_items, p.orientation, origin=(0, 0))
+        Junction_items = draw.rotate(Junction_items,
+                                     p.orientation,
+                                     origin=(0, 0))
 
         Junction_items = draw.translate(Junction_items, p.pos_x, p.pos_y)
 
         [Junction, undercut] = Junction_items
 
-
         #Add features to the geometery
-        self.add_qgeometry('poly', {'undercut': undercut
-
-                                    }, layer=p.layer_3)
+        self.add_qgeometry('poly', {'undercut': undercut}, layer=p.layer_3)
 
         self.add_qgeometry('poly', {'Junction': Junction}, layer=p.layer)
-
-

--- a/qiskit_metal/tests/test_qlibrary_3_options.py
+++ b/qiskit_metal/tests/test_qlibrary_3_options.py
@@ -288,7 +288,7 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
             design, 'my_name')
         options = my_transmon_concentric.default_options
 
-        self.assertEqual(len(options), 16)
+        self.assertEqual(len(options), 17)
         self.assertEqual(options['width'], '1000um')
         self.assertEqual(options['height'], '1000um')
         self.assertEqual(options['rad_o'], '170um')
@@ -487,7 +487,7 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         self.assertEqual(_options['cross_length'], '200um')
         self.assertEqual(_options['cross_gap'], '20um')
 
-        self.assertEqual(len(_options['_default_connection_pads']), 6)
+        self.assertEqual(len(_options['_default_connection_pads']), 8)
         self.assertEqual(_options['_default_connection_pads']['connector_type'],
                          '0')
         self.assertEqual(_options['_default_connection_pads']['claw_length'],
@@ -496,6 +496,10 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
                          '5um')
         self.assertEqual(_options['_default_connection_pads']['claw_width'],
                          '10um')
+        self.assertEqual(_options['_default_connection_pads']['claw_cpw_length'],
+                    '40um')
+        self.assertEqual(_options['_default_connection_pads']['claw_cpw_width'],
+                    '10um')
         self.assertEqual(_options['_default_connection_pads']['claw_gap'],
                          '6um')
         self.assertEqual(

--- a/qiskit_metal/tests/test_qlibrary_3_options.py
+++ b/qiskit_metal/tests/test_qlibrary_3_options.py
@@ -786,20 +786,29 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         def test_qlibrary_BridgeFreeJunction_options(self):
             """Test the default options of JJ_Manhattan were not accidentially changed."""
             design = designs.DesignPlanar()
-            my_jj_BridgeFree = BridgeFreeJunction(design,
-                                           name='test_BridgeFreeJunction',
-                                           options={})
+            my_jj_BridgeFree = BridgeFreeJunction(
+                design, name='test_BridgeFreeJunction', options={})
             options = my_jj_BridgeFree.default_options
 
             self.assertEqual(len(options), 7)
-            self.assertEqual(options['The width of lower JJ metal region'], '4um')
-            self.assertEqual(options['The height of lower JJ metal region'], '4um')
-            self.assertEqual(options['Evaporation angle of the first evaporation (˚)'], '30')
-            self.assertEqual(options['Evaporation angle of the second evaporation (˚)'], '30')
-            self.assertEqual(options['The length of the connecting wires'], '30um')
-            self.assertEqual(options['The width of the connecting wires.'], '0.5um')
-            self.assertEqual(options['Thickness of the first (bottom) resist layer.'], '0.3um')
-            self.assertEqual(options['Thickness of the second (top) resist layer.'], '0.2um')
+            self.assertEqual(options['The width of lower JJ metal region'],
+                             '4um')
+            self.assertEqual(options['The height of lower JJ metal region'],
+                             '4um')
+            self.assertEqual(
+                options['Evaporation angle of the first evaporation (˚)'], '30')
+            self.assertEqual(
+                options['Evaporation angle of the second evaporation (˚)'],
+                '30')
+            self.assertEqual(options['The length of the connecting wires'],
+                             '30um')
+            self.assertEqual(options['The width of the connecting wires.'],
+                             '0.5um')
+            self.assertEqual(
+                options['Thickness of the first (bottom) resist layer.'],
+                '0.3um')
+            self.assertEqual(
+                options['Thickness of the second (top) resist layer.'], '0.2um')
 
 
 if __name__ == '__main__':

--- a/qiskit_metal/tests/test_qlibrary_3_options.py
+++ b/qiskit_metal/tests/test_qlibrary_3_options.py
@@ -496,10 +496,10 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
                          '5um')
         self.assertEqual(_options['_default_connection_pads']['claw_width'],
                          '10um')
-        self.assertEqual(_options['_default_connection_pads']['claw_cpw_length'],
-                    '40um')
+        self.assertEqual(
+            _options['_default_connection_pads']['claw_cpw_length'], '40um')
         self.assertEqual(_options['_default_connection_pads']['claw_cpw_width'],
-                    '10um')
+                         '10um')
         self.assertEqual(_options['_default_connection_pads']['claw_gap'],
                          '6um')
         self.assertEqual(


### PR DESCRIPTION
### Summary
This PR fixes the broken CI.

**Summary of the changes:**

- Update the tox version -> tox==4.11.0
- Update the virtualenv version to match the new tox version -> virtualenv==20.19.0
- Fix unit test `test_qlibrary_3_options.py` (line 291, line 490, and lines 499-502)
- Fix the style of `BridgeFreeJJ.py` and `test_qlibrary_3_options.py` for the lint test

### Details

The main problem with the CI was that tox wasn't able to set up the test environment. If we look at the errors, tox finds an error when calling the `prepare_metadata_for_build_editable` function. We had that problem because we were pinning tox to use an old version, and the pyproject-api version that we are using (`pyproject-api==1.6.1`) is not able to work with old versions of tox. The solution for this first problem was to change the CI to use a more recent version of tox. This update forces us to also use a more recent version of virtualenv because of the tox requirements.

Useful links to find more information about the problem:

1. https://www.github.com/tox-dev/tox/issues/3110
2. https://www.github.com/pypa/setuptools/issues/4031

Once we have the CI working again, we can discover another error, but this time with two tests in `test_qlibrary_3_options.py`. The two tests were also fixed and extended to validate two more attributes of the default options of `transmon_cross` in `transmon_cross.py` that weren't taken into account before.

The last change is regarding the lint test for the files `BridgeFreeJJ.py` and `test_qlibrary_3_options.py`.