### PR TITLE
modify the requirements & environments: pyepr-quantum 0.8.5.7 -> 0.9.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - numpy==1.24.2
   - pandas==1.5.3
   - pint==0.20.1
-  - pyepr-quantum==0.8.5.7
+  - pyepr-quantum==0.9.0
   - pygments==2.14.0
   - pyside2==5.15.8
   - qdarkstyle==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ matplotlib==3.7.0
 numpy==1.24.2
 pandas==1.5.3
 pint==0.20.1
-pyEPR-quantum==0.8.5.7
+pyEPR-quantum==0.9.0
 pygments==2.14.0
 pyside2==5.15.2.1
 qdarkstyle==3.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
The issues occur due to AttributeError: module `numpy` has no attribute `float`.
`np.float` was a deprecated alias for the builtin `float`.


### Did you add tests to cover your changes (yes/no)?

### Did you update the documentation accordingly (yes/no)?

### Did you read the CONTRIBUTING document (yes/no)?

### Summary



### Details and comments

This error happens due the pyepr-quantum package when running `run_epr()`
Thanks to [this PR]( https://github.com/zlatko-minev/pyEPR/pull/150 ) this problem is solved since pyepr-quantum==0.9.0
