### PR TITLE
Bug fix lumped_capacitive.py

### DIFF
--- a/qiskit_metal/analyses/quantization/lumped_capacitive.py
+++ b/qiskit_metal/analyses/quantization/lumped_capacitive.py
@@ -502,7 +502,7 @@ def levels_vs_ng_real_units(Cq, IC, N=301, do_disp=0, do_plots=0):
                      3,
                  ] / h / 1e9,
                  'g',
-                 LineWidth=2)
+                 linewidth=2)
         plt.xlabel('Gate charge, n_g [2e]')
         plt.ylabel('Energy, E_n [GHz]')
         plt.subplot(1, 2, 2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### What are the issues this pull addresses (issue numbers / links)?
Error when running lumped_capacitive.levels_vs_ng_real_units with do_plot = 1.

### Did you add tests to cover your changes (yes/no)?

None. Default setting of the function is do_plots=0, which is the only reason this issue hasn't broken out before. Adjusting this single argument in a plt.plot() call should have no bearing on any other function.

### Did you update the documentation accordingly (yes/no)?
No, since this is covered in the documentation of matplotlib.

### Did you read the CONTRIBUTING document (yes/no)?

Yes, although this seems like such a tiny change, and most of the guidelines overkill in this case.

### Summary

Changing plt.plot() argument from "LineWidth" to "linewidth" to avoid run error. Specifically the function levels_vs_ng_real_units inside the file lumped_capacitive.py.

### Details and comments
Tiny fix for an aggravating bug.

