### PR TITLE
Fix qutip>=5 compatibility in states_energies and add tests

### DIFF
--- a/src/qiskit_metal/analyses/hamiltonian/states_energies.py
+++ b/src/qiskit_metal/analyses/hamiltonian/states_energies.py
@@ -79,9 +79,11 @@ def extract_energies(esys_array: np.ndarray,
     chis = np.empty((N, N))
 
     # Reformat the set of eigenvectors as a matrix where each row of the matrix
-    # is the hermitian conjugate of the original eigenvector
+    # is the hermitian conjugate of the original eigenvector. Calling `.full()`
+    # before stacking is required for qutip>=5, where `np.array([Qobj, ...])`
+    # produces an object-dtype ndarray instead of stacking the underlying data.
     evecs_dag_mat = np.squeeze(
-        np.array([evecs[ii].dag() for ii in range(evecs.size)]))
+        np.array([evecs[ii].dag().full() for ii in range(evecs.size)]))
 
     single_excitation_states = [state_on({i: 1}) for i in range(N)]
 
@@ -104,22 +106,24 @@ def extract_energies(esys_array: np.ndarray,
 
     single_excitation_states_mat = np.squeeze(
         np.array([
-            single_excitation_states[ii]
+            single_excitation_states[ii].full()
             for ii in range(len(single_excitation_states))
         ])).T
 
     double_excitation_states_mat = np.squeeze(
         np.array([
-            double_excitation_states[ii]
+            double_excitation_states[ii].full()
             for ii in range(len(double_excitation_states))
         ])).T
 
     # Find the inner product of each of the target state with each of the
-    # eigenvector; hence overlap has dimension of number of eigenvectors x number of target states
+    # eigenvector; hence overlap has dimension of number of eigenvectors x
+    # number of target states. `.full()` converts the Qobj product to a numpy
+    # array; required for qutip>=5 where Qobj no longer supports np.absolute.
     overlap_single = np.absolute(
-        np.array((Qobj(evecs_dag_mat) * Qobj(single_excitation_states_mat))))
+        (Qobj(evecs_dag_mat) * Qobj(single_excitation_states_mat)).full())
     overlap_double = np.absolute(
-        np.array((Qobj(evecs_dag_mat) * Qobj(double_excitation_states_mat))))
+        (Qobj(evecs_dag_mat) * Qobj(double_excitation_states_mat)).full())
 
     # find the index of the eigenvector that is closest to each target state
     # hence evec_idx has shape of (number of target states, )

--- a/tests/test_analyses_2_functionality.py
+++ b/tests/test_analyses_2_functionality.py
@@ -27,6 +27,8 @@ import pandas as pd
 from qiskit_metal import designs
 from qiskit_metal.analyses.em import cpw_calculations, kappa_calculation
 from qiskit_metal.analyses.hamiltonian.HO_wavefunctions import wavefunction
+from qiskit_metal.analyses.hamiltonian.states_energies import (basis_state_on,
+                                                               extract_energies)
 from qiskit_metal.analyses.hamiltonian.transmon_charge_basis import Hcpb
 from qiskit_metal.analyses.quantization import lumped_capacitive
 from qiskit_metal.analyses.sweep_and_optimize.sweeper import Sweeper
@@ -768,6 +770,141 @@ class TestAnalyses(unittest.TestCase, AssertionsMixin):
         """Test the n_ij function in the Hcpb class."""
         hcpb = Hcpb(nlevels=15, Ej=13971.3, Ec=295.2, ng=0.001)
         self.assertAlmostEqual(hcpb.n_ij(1, 2), 1.4670047579229986)
+
+    def test_analysis_transmon_charge_basis_h0_to_qutip(self):
+        """Test the h0_to_qutip function in the Hcpb class returns a qutip Qobj
+        whose diagonal is the eigenvalues, zeroed at the ground state."""
+        import qutip
+        hcpb = Hcpb(nlevels=15, Ej=13971.3, Ec=295.2, ng=0.001)
+        n = 4
+        h0 = hcpb.h0_to_qutip(n)
+
+        self.assertIsInstance(h0, qutip.Qobj)
+        self.assertEqual(h0.shape, (n, n))
+        self.assertEqual(h0.dims, [[n], [n]])
+        self.assertTrue(h0.isherm)
+
+        diag = np.diag(h0.full()).real
+        # Ground state must be zero (the method subtracts evals[0]).
+        self.assertAlmostEqual(diag[0], 0.0)
+        # The remaining diagonal entries must equal hcpb.fij(0, k).
+        for k in range(1, n):
+            self.assertAlmostEqualRel(diag[k],
+                                      hcpb.fij(0, k),
+                                      rel_tol=1e-10)
+        # Off-diagonal entries must be zero.
+        full = h0.full()
+        for i in range(n):
+            for j in range(n):
+                if i != j:
+                    self.assertAlmostEqual(full[i, j], 0.0)
+
+    def test_analysis_transmon_charge_basis_n_to_qutip(self):
+        """Test the n_to_qutip function in the Hcpb class returns a qutip Qobj
+        of the number operator in the energy eigen-basis."""
+        import qutip
+        hcpb = Hcpb(nlevels=15, Ej=13971.3, Ec=295.2, ng=0.001)
+        n = 3
+        n_op = hcpb.n_to_qutip(n)
+
+        self.assertIsInstance(n_op, qutip.Qobj)
+        self.assertEqual(n_op.shape, (n, n))
+        self.assertEqual(n_op.dims, [[n], [n]])
+
+        full = n_op.full()
+        # Diagonal entries are zeroed by construction.
+        for k in range(n):
+            self.assertAlmostEqual(full[k, k], 0.0)
+        # Off-diagonal magnitudes match hcpb.n_ij(i, j).
+        for i in range(n):
+            for j in range(n):
+                if i != j:
+                    self.assertAlmostEqualRel(abs(full[i, j]),
+                                              hcpb.n_ij(i, j),
+                                              rel_tol=1e-10)
+
+    def test_analysis_transmon_charge_basis_n_to_qutip_thresh(self):
+        """Test the n_to_qutip thresh argument zeroes small entries."""
+        hcpb = Hcpb(nlevels=15, Ej=13971.3, Ec=295.2, ng=0.001)
+        # Use a threshold larger than the |0><2| element (~1e-7) but smaller
+        # than the |0><1| element (~1.07).
+        n_op = hcpb.n_to_qutip(3, thresh=0.5).full()
+        self.assertAlmostEqual(n_op[0, 2], 0.0)
+        self.assertAlmostEqual(n_op[2, 0], 0.0)
+        self.assertGreater(abs(n_op[0, 1]), 0.5)
+
+    def test_analysis_states_energies_basis_state_on(self):
+        """Test basis_state_on returns the correct qutip tensor product."""
+        import qutip
+        # Two modes of size 3, with 1 photon in mode 0 and 2 photons in mode 1.
+        state = basis_state_on([3, 3], {0: 1, 1: 2})
+
+        self.assertIsInstance(state, qutip.Qobj)
+        self.assertEqual(state.shape, (9, 1))
+        # qutip 4 used dims [[3, 3], [1]], qutip 5 uses [[3, 3], [1, 1]];
+        # accept either to keep this test backwards compatible.
+        self.assertIn(state.dims, ([[3, 3], [1, 1]], [[3, 3], [1]]))
+        self.assertAlmostEqualRel(state.norm(), 1.0, rel_tol=1e-12)
+
+        # The only non-zero amplitude must be at index 1*3 + 2 = 5.
+        vec = state.full().flatten()
+        self.assertAlmostEqual(abs(vec[5]), 1.0)
+        for k, amp in enumerate(vec):
+            if k != 5:
+                self.assertAlmostEqual(amp, 0.0)
+
+    def test_analysis_states_energies_basis_state_on_default_ground(self):
+        """Test basis_state_on defaults missing modes to 0 photons."""
+        # Mode 0 gets 1 photon; mode 1 is omitted from the dict (defaults to 0).
+        state = basis_state_on([2, 2], {0: 1})
+        vec = state.full().flatten()
+        # |1, 0> sits at index 1*2 + 0 = 2.
+        self.assertAlmostEqual(abs(vec[2]), 1.0)
+        for k, amp in enumerate(vec):
+            if k != 2:
+                self.assertAlmostEqual(amp, 0.0)
+
+    def test_analysis_states_energies_extract_energies(self):
+        """Test extract_energies on a synthetic two-mode diagonal Hamiltonian.
+
+        Build a diagonal Hamiltonian H = sum_i w_i n_i + sum_{i<=j} chi_ij n_i n_j
+        on two 3-level modes; extract_energies should recover the {w_i} and
+        {chi_ij}.
+        """
+        import qutip
+        N1, N2 = 3, 3
+        w = [5.0, 7.0]
+        chi_self = [-0.30, -0.25]  # self-Kerr per mode
+        chi_cross = -0.10  # cross-Kerr
+
+        ham_diag = []
+        for i in range(N1):
+            for j in range(N2):
+                ham_diag.append(w[0] * i + w[1] * j + chi_self[0] * i *
+                                (i - 1) / 2 + chi_self[1] * j *
+                                (j - 1) / 2 + chi_cross * i * j)
+        ham = qutip.Qobj(np.diag(ham_diag), dims=[[N1, N2], [N1, N2]])
+        evals, evecs = ham.eigenstates()
+
+        esys = np.empty(2, dtype=object)
+        esys[0] = np.array(evals)
+        esys[1] = evecs
+
+        freqs, chis = extract_energies(esys, [N1, N2])
+
+        # The recovered |1, 0> and |0, 1> excitation energies must equal w.
+        self.assertAlmostEqualRel(freqs[0], w[0], rel_tol=1e-10)
+        self.assertAlmostEqualRel(freqs[1], w[1], rel_tol=1e-10)
+
+        # Chi matrix shape and symmetry.
+        self.assertEqual(chis.shape, (2, 2))
+        self.assertAlmostEqual(chis[0, 1], chis[1, 0])
+
+        # Diagonal chi entries are the self-Kerrs.
+        self.assertAlmostEqualRel(chis[0, 0], chi_self[0], rel_tol=1e-10)
+        self.assertAlmostEqualRel(chis[1, 1], chi_self[1], rel_tol=1e-10)
+        # Off-diagonal chi entry is the cross-Kerr.
+        self.assertAlmostEqualRel(chis[0, 1], chi_cross, rel_tol=1e-10)
 
     def test_analysis_kappa_calculation_kappa_in(self):
         """Test the kappa_in function in kappa_calculation.py."""


### PR DESCRIPTION
### What are the issues this pull addresses?

Fixes compatibility issues with qutip>=5 in the `states_energies.py` module where `np.array()` behavior changed for stacking Qobj instances, and `Qobj` no longer supports `np.absolute()` directly.

### Did you add tests to cover your changes?

Yes. Added comprehensive unit tests covering:
- `Hcpb.h0_to_qutip()` - verifies qutip Qobj structure and diagonal eigenvalue properties
- `Hcpb.n_to_qutip()` - verifies number operator matrix elements and threshold filtering
- `basis_state_on()` - verifies tensor product state construction and normalization
- `extract_energies()` - verifies frequency and chi parameter extraction from Hamiltonians

### Did you update the documentation accordingly?

Yes. Added inline comments explaining the qutip>=5 compatibility fixes:
- Clarified that `.full()` is required before stacking Qobj instances in numpy arrays
- Documented that `.full()` conversion is needed for qutip>=5 where Qobj no longer supports `np.absolute()`

### Did you read the CONTRIBUTING document?

Yes.

### Summary

This PR fixes qutip>=5 compatibility issues in `states_energies.py` by:

1. **Calling `.full()` before stacking Qobj instances**: In qutip>=5, `np.array([Qobj, ...])` produces an object-dtype ndarray instead of stacking the underlying data. Fixed by explicitly calling `.full()` on each Qobj before stacking.

2. **Converting Qobj products to numpy arrays**: In qutip>=5, `Qobj` no longer supports `np.absolute()` directly. Fixed by calling `.full()` on the product result before passing to `np.absolute()`.

3. **Added comprehensive test coverage**: New tests validate the `Hcpb` class methods (`h0_to_qutip`, `n_to_qutip`) and the `states_energies` module functions (`basis_state_on`, `extract_energies`).

### Details and comments

The changes maintain backward compatibility with qutip 4 while enabling support for qutip>=5. All modifications are localized to the `extract_energies()` function in `states_energies.py` and the new test cases in `test_analyses_2_functionality.py`.

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj