### PR TITLE
chore: bump version to 0.6.1 (recover from failed v0.6.0 release)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
     readme = { file = "README.md", content-type = "text/markdown" }
     requires-python = ">=3.10,<3.13"
     urls = { bugtracker = "https://github.com/qiskit-community/qiskit-metal/issues", documentation = "https://qiskit-community.github.io/qiskit-metal/", source = "https://github.com/qiskit-community/qiskit-metal" }
-    version = "0.5.4"
+    version = "0.6.1"
     dependencies = [
         "addict>=2.4.0",
         "gdstk>=0.9",

--- a/uv.lock
+++ b/uv.lock
@@ -2747,7 +2747,7 @@ wheels = [
 
 [[package]]
 name = "quantum-metal"
-version = "0.5.4"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },


### PR DESCRIPTION
## Summary

Recovers from the failed `v0.6.0` release by bumping to **v0.6.1** in `pyproject.toml` and `uv.lock`.

### What happened

The bump-version workflow ran today, but the **commit-and-tag** step failed:

```
HTTP 409: Could not update file: Changes must be made through a pull request.
12 of 12 required status checks are expected.
```

The workflow tries to push the version commit directly via the GitHub Contents API, which `main`'s branch protection disallows.

As a result:
- Tag `v0.6.0` exists, but points at commit `63c90ec` where `pyproject.toml` still says `0.5.4`
- The GitHub Release page for v0.6.0 exists (with the curated notes)
- **PyPI was never updated** — `uv publish` from `release.yml` would have failed with *"version 0.5.4 already exists"*

### Why v0.6.1 instead of re-tagging v0.6.0

Going to 0.6.1 avoids a destructive force-recreate of the existing tag. The v0.6.0 GitHub release page stays as the canonical record of release notes; 0.6.1 is the PyPI-shipped artifact.

### After this merges

1. **Create tag `v0.6.1`** to trigger `release.yml` → PyPI publish:
   ```bash
   git tag v0.6.1 <merge-commit-sha>
   git push origin v0.6.1
   ```
   Or via GitHub UI: *Releases → Draft a new release → tag `v0.6.1` targeting `main`*.

2. **Fix the bump-version workflow for future releases.** Add `github-actions[bot]` to the branch-protection bypass list:
   *Settings → Branches → Edit rule for `main` → "Allow specified actors to bypass required pull requests"*.
   Once this is set, the bump-version workflow works as-written for v0.6.2 onwards.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.6.1` created and `release.yml` succeeds
- [ ] `pip install quantum-metal==0.6.1` works from PyPI

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_