### PR TITLE
chore: tier-0 maintenance — contributing guide, ruff triage, env drift gate, docs warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,5 +65,21 @@ jobs:
           ## TODO: Remove --exit-zero once linting is finalized.
           args: "check --exit-zero"
 
+  env-consistency:
+    name: env.yml ↔ pyproject.toml drift
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_COLOR: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      - name: Check environment.yml against pyproject.toml
+        run: uv run --quiet scripts/check_env_consistency.py
+
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,44 +36,35 @@ Opening an issue initiates a discussion with the team about your idea, how it fi
 
 ## Contributing Code
 ### Code Formatting
-To enforce a consistent code style in the project, we use customized [Pylint](https://www.pylint.org) for linting and
-[YAPF](https://github.com/google/yapf) with the [Google style](
-https://google.github.io/styleguide/pyguide.html) for auto formatting. The custom
-`.pylintrc` and `.style.yapf` files are located in the root of the repository. Our CI pipeline will enforce these styles when you make the pull request.
+We use [Ruff](https://docs.astral.sh/ruff/) for both linting and auto formatting. Configuration lives under `[tool.ruff.lint]` in the root `pyproject.toml`; there are no separate `.pylintrc` or `.style.yapf` files. Our CI pipeline runs `tox -e lint` on every pull request — please run it locally before pushing.
+
+Common commands:
+- `tox -e lint` — lint the `qiskit_metal/` source tree
+- `tox -e format` — auto-format the `qiskit_metal/` source tree
+- `uvx ruff check src` — lint without tox (faster, same result)
+- `uvx ruff format src` — format without tox
 
 #### VSCode Setup
 
 Steps:
-1. Install the following extensions: `python` and `yapf` if you have not yet.
-2. Add the following workspace setting in the workspace `settings.json`.
+1. Install the [Ruff extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) (publisher `charliermarsh`).
+2. Add the following workspace setting in the workspace `settings.json` so format-on-save and lint-on-save both go through Ruff:
 
-If you are using VSCode for your code editor, you can add these settings
-to your `settings.json` to enforce your code to our style. Make sure to add PySide2 to the linter:
-```json
-{
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "python.formatting.provider": "yapf",
-    "editor.formatOnSave": true,
-    "files.trimTrailingWhitespace": true,
-    "files.trimFinalNewlines": true
-}
-```
-
-
-In newer versions of VS Code:
 ```json
 {
     "editor.formatOnSave": true,
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,
-    "editor.defaultFormatter": "eeyore.yapf",
-    "notebook.defaultFormatter": "eeyore.yapf",
     "[python]": {
-        "editor.defaultFormatter": "eeyore.yapf"
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports.ruff": "explicit"
+        }
     }
 }
 ```
+
+(If you previously had `python.linting.pylintEnabled` or `python.formatting.provider = yapf` in your settings, remove them — they are no longer used by this project.)
 
 ### Code Review
 Code review is done in the open and open to anyone. While only maintainers have access to merge commits, providing feedback on pull requests is very valuable and helpful. It is also a good mechanism to learn about the code base. You can view a list of all open pull requests to review any open pull requests and provide feedback on it.
@@ -85,13 +76,18 @@ If you would like to contribute to Qiskit Metal, but aren't sure of where to get
 
 Once you've made a code change, it is important to verify that your change does not break any existing tests and that any new tests that you've added also run successfully. Before you open a new pull request for your change, you'll want to run the test suite locally.
 
-The easiest way to do this is to execute the `run_all_tests.py` script in the `tests` directory.  It executes all test files in that directory.  You'll receive a message informing you if the tests were successful or not.  Alternatively you may run an individual suite of tests by executing individual `test_XYZ.py` files individually.  All test files utilize the `unittest` module - no further setup is needed.
+The easiest way to do this is `tox` (which builds an isolated environment and runs the full suite the same way CI does):
 
-Additionally, CI will run the test suite on all pushes made to any branch in the repository.
+- `tox` — run the test suite on every supported Python (3.10, 3.11, 3.12)
+- `tox -e py3.12` — run on a specific Python only
+- `pytest tests/` — run tests in your current environment (faster iteration; use this once you've confirmed the env is set up)
+- `pytest tests/test_<file>.py` — run a single test file
+
+CI also runs the suite on every push to any branch in the repository.
 
 ### Pull Requests
 
-To submit your contribution, make a pull request from your forked repository to the `master` branch of Metal. Please ensure
+To submit your contribution, make a pull request from your forked repository to the `main` branch of Metal. Please ensure
 
 -  The code follows the code style of the project (discussed above) and
    successfully passes all tests.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -299,6 +299,18 @@ The goal of Qiskit Metal is to allow for easy quantum hardware modeling with red
 
     Code of Conduct<https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md>
 
+.. Hidden glob toctree so every auto-generated per-class stub in
+   ``apidocs/`` is reachable from the document tree. Without this,
+   Sphinx emits one "document isn't included in any toctree" warning
+   per stub (currently ~100). The stubs are linked from the module
+   pages listed in the API References toctree above; this hidden
+   entry just satisfies Sphinx's reachability check.
+.. toctree::
+    :hidden:
+    :glob:
+
+    apidocs/*
+
 .. Hiding - Indices and tables
    :ref:`genindex`
    :ref:`modindex`

--- a/environment.yml
+++ b/environment.yml
@@ -5,23 +5,23 @@ dependencies:
   - python>=3.10 # Let's see if we can float higher in future.
   - scqubits>=4.1.0 # Synced with pyproject.toml floor.
   - addict~=2.4
-  - geopandas>=0.12.2
+  - geopandas>=1.0 # Synced with pyproject.toml floor.
   - ipython>=8.10.0
   - matplotlib~=3.7
   - numpy>=1.24.2,<2
-  - pandas>=1.5.3
-  - pint~=0.20
+  - pandas>=2.1.1 # Synced with pyproject.toml floor.
+  - pint>=0.21.0 # Synced with pyproject.toml floor.
   - pyEPR-quantum~=0.9.5
   - pygments~=2.14
   - qdarkstyle~=3.1
   - qutip>=5.0.0 # Synced with pyproject.toml floor.
   - scipy~=1.10
-  - shapely~=2.0
+  - shapely>=2.0.1 # Synced with pyproject.toml floor.
   - jupyter
   - cython<3.0.0
   - pip
   - pip:
-      - pyaedt~=0.21
+      - pyaedt>=0.21,<0.24 # Synced with pyproject.toml ceiling (pyaedt 0.24 has bugs).
       - gmsh>=4.11.1
       - gdstk~=0.9 # Used to be gdspy>=1.6.12
       - pyside6~=6.8 # Critical to building gui, can causes lots of problems, careful.

--- a/scripts/check_env_consistency.py
+++ b/scripts/check_env_consistency.py
@@ -1,0 +1,198 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "pyyaml>=6.0",
+#     "packaging>=23.0",
+# ]
+# ///
+"""Check that ``environment.yml`` and ``pyproject.toml`` agree on
+version constraints for shared dependencies.
+
+Both files declare dependency floors and ceilings independently. When
+they drift, conda users (who follow ``environment.yml``) end up with a
+different supported version range than pip users (who follow
+``pyproject.toml``). This silently broke ``qutip`` and ``scqubits``
+support in past releases.
+
+The script extracts the floor (lowest version allowed) and ceiling
+(highest, if any) from each spec, then for every package present in
+both files asserts:
+
+    env_floor   >= pyproject_floor
+    env_ceiling <= pyproject_ceiling  (if pyproject has one)
+
+Exits 0 if consistent, 1 otherwise. Designed to run in CI; also
+runnable locally as ``uv run scripts/check_env_consistency.py``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import yaml
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_pyproject() -> dict[str, SpecifierSet]:
+    """Map package name (normalised, lowercase) to its SpecifierSet
+    from ``pyproject.toml``'s ``[project.dependencies]``."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    result = {}
+    for raw in data["project"]["dependencies"]:
+        req = Requirement(raw)
+        result[normalise(req.name)] = req.specifier
+    return result
+
+
+def load_environment_yml() -> dict[str, SpecifierSet]:
+    """Map package name (normalised, lowercase) to its SpecifierSet
+    from ``environment.yml`` (both the top-level conda deps and the
+    nested ``pip:`` deps)."""
+    data = yaml.safe_load((REPO_ROOT / "environment.yml").read_text())
+    result = {}
+    for entry in data["dependencies"]:
+        if isinstance(entry, str):
+            parsed = parse_conda_spec(entry)
+            if parsed is not None:
+                name, spec = parsed
+                result[normalise(name)] = spec
+        elif isinstance(entry, dict) and "pip" in entry:
+            for raw in entry["pip"]:
+                req = Requirement(raw)
+                result[normalise(req.name)] = req.specifier
+    return result
+
+
+def parse_conda_spec(entry: str) -> tuple[str, SpecifierSet] | None:
+    """Parse a single conda-style dependency string into
+    ``(name, SpecifierSet)``.
+
+    Handles PEP-440-compatible operators (``>=``, ``~=``, ``<``, etc.).
+    Returns ``None`` for entries that aren't real package specs
+    (``python``, channel-like ``pip``).
+    """
+    # Strip inline comments.
+    spec_str = entry.split("#", 1)[0].strip()
+    if not spec_str:
+        return None
+    # Skip bare package names with no operator like "jupyter" — we have
+    # no version to compare. Skip "python" entirely (handled by
+    # `requires-python` in pyproject.toml, not project deps).
+    match = re.match(r"^([A-Za-z0-9_.\-]+)\s*(.*)$", spec_str)
+    if not match:
+        return None
+    name, rest = match.group(1), match.group(2).strip()
+    if name.lower() == "python":
+        return None
+    if not rest:
+        return name, SpecifierSet("")
+    # conda allows commas and PEP-440 operators; packaging.SpecifierSet
+    # handles all of these.
+    try:
+        return name, SpecifierSet(rest)
+    except Exception:
+        return None
+
+
+def normalise(name: str) -> str:
+    return name.lower().replace("_", "-")
+
+
+def floor_of(spec: SpecifierSet) -> Version | None:
+    """Return the smallest version allowed by ``spec``, or ``None`` if
+    the spec has no lower bound."""
+    candidates: list[Version] = []
+    for s in spec:
+        if s.operator in (">=", "==", "~="):
+            candidates.append(Version(s.version))
+        elif s.operator == ">":
+            # Approximate: next patch above s.version.
+            candidates.append(Version(s.version))
+    return max(candidates) if candidates else None
+
+
+def ceiling_of(spec: SpecifierSet) -> Version | None:
+    """Return the largest version *not* allowed by ``spec`` (the upper
+    bound), or ``None`` if the spec has no upper bound."""
+    candidates: list[Version] = []
+    for s in spec:
+        if s.operator == "<":
+            candidates.append(Version(s.version))
+        elif s.operator == "<=":
+            candidates.append(Version(s.version))
+        elif s.operator == "~=":
+            # ~=X.Y means >=X.Y, <X+1.0. ~=X.Y.Z means >=X.Y.Z, <X.Y+1.0.
+            v = Version(s.version)
+            parts = v.release
+            if len(parts) >= 2:
+                # Bump the second-to-last component.
+                new_parts = parts[:-1]
+                new_parts = new_parts[:-1] + (new_parts[-1] + 1,)
+                candidates.append(Version(".".join(str(p) for p in new_parts)))
+    return min(candidates) if candidates else None
+
+
+def main() -> int:
+    pyproject = load_pyproject()
+    env = load_environment_yml()
+
+    shared = sorted(set(pyproject) & set(env))
+    if not shared:
+        print("No shared packages between pyproject.toml and environment.yml.",
+              file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+
+    for pkg in shared:
+        pp_spec = pyproject[pkg]
+        env_spec = env[pkg]
+
+        pp_floor = floor_of(pp_spec)
+        env_floor = floor_of(env_spec)
+        if pp_floor and env_floor and env_floor < pp_floor:
+            failures.append(
+                f"  {pkg}: environment.yml floor {env_floor} < "
+                f"pyproject.toml floor {pp_floor}"
+                f"  (env={env_spec}, pyproject={pp_spec})")
+        if pp_floor and not env_floor:
+            failures.append(
+                f"  {pkg}: pyproject.toml requires >={pp_floor} but "
+                f"environment.yml has no floor"
+                f"  (env={env_spec}, pyproject={pp_spec})")
+
+        pp_ceil = ceiling_of(pp_spec)
+        env_ceil = ceiling_of(env_spec)
+        if pp_ceil and not env_ceil:
+            failures.append(
+                f"  {pkg}: pyproject.toml requires <{pp_ceil} but "
+                f"environment.yml has no ceiling"
+                f"  (env={env_spec}, pyproject={pp_spec})")
+        elif pp_ceil and env_ceil and env_ceil > pp_ceil:
+            failures.append(
+                f"  {pkg}: environment.yml ceiling {env_ceil} > "
+                f"pyproject.toml ceiling {pp_ceil}"
+                f"  (env={env_spec}, pyproject={pp_spec})")
+
+    if failures:
+        print("environment.yml drifts from pyproject.toml:\n"
+              + "\n".join(failures),
+              file=sys.stderr)
+        print("\nFix the constraints in environment.yml so a conda "
+              "install picks up the same versions a pip install does.",
+              file=sys.stderr)
+        return 1
+
+    print(f"OK: {len(shared)} shared packages, no drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/qiskit_metal/analyses/em/kappa_calculation.py
+++ b/src/qiskit_metal/analyses/em/kappa_calculation.py
@@ -21,7 +21,7 @@ https://aip.scitation.org/doi/10.1063/1.5089550
 """
 
 import numpy as np
-from math import *
+from math import pi
 from scipy.special import ellipk
 
 __all__ = ['kappa_in']

--- a/src/qiskit_metal/toolbox_metal/about.py
+++ b/src/qiskit_metal/toolbox_metal/about.py
@@ -32,8 +32,7 @@ import qutip
 from qiskit_metal.toolbox_python.display import Color, style_colon_list
 
 __all__ = [
-    'about', 'open_docs', 'orient_me', 'get_platform_info',
-    'get_module_doc_page'
+    'about', 'open_docs', 'get_platform_info', 'get_module_doc_page'
 ]
 
 

--- a/src/qiskit_metal/toolbox_metal/exceptions.py
+++ b/src/qiskit_metal/toolbox_metal/exceptions.py
@@ -16,8 +16,6 @@
 # pylint: disable=unused-import
 """Custom Exceptions."""
 
-from sys import prefix
-
 
 class QiskitMetalExceptions(Exception):
     """Custom Exception super-class. Every Exception raised by qiskit-metal

--- a/src/qiskit_metal/toolbox_metal/layer_stack_handler.py
+++ b/src/qiskit_metal/toolbox_metal/layer_stack_handler.py
@@ -2,7 +2,7 @@
 
 from re import search
 import pandas as pd
-from typing import List, Tuple, Dict
+from typing import List, Tuple
 from typing import Union
 from addict import Dict
 import os

--- a/src/qiskit_metal/toolbox_python/utility_functions.py
+++ b/src/qiskit_metal/toolbox_python/utility_functions.py
@@ -80,10 +80,10 @@ def dict_start_with(my_dict, start_with, as_=list):
         my_dict = {'name': 'Klauss', 'age': 26, 'Date of birth': '15th july'}
         dict_start_with(my_dict, 'Date')
     """
-    if as_ == list:
+    if as_ is list:
         # start_with in k]
         return [v for k, v in my_dict.items() if k.startswith(start_with)]
-    elif as_ == dict:
+    elif as_ is dict:
         return {k: v for k, v in my_dict.items() if k.startswith(start_with)}
 
 


### PR DESCRIPTION
## Summary

Four maintenance commits, each independent and low-risk. None touch HFSS/Q3D/`_gui/`/pyEPR.

### 1. `docs(contributing)`: replace pylint+yapf instructions with ruff
- `CONTRIBUTING.md` told new contributors to install pylint and yapf with VSCode extensions for them, and to use `.pylintrc` and `.style.yapf` files that no longer exist. Following the old guide produced wrongly-formatted code that then failed CI.
- Replaced with ruff (`tox -e lint`, `tox -e format`, `uvx ruff …`) and the matching VSCode `charliermarsh.ruff` settings.
- Also fixed two adjacent stale references: `tests/run_all_tests.py` (gone — replaced with the tox/pytest commands actually used) and PR target branch `master` → `main`.

### 2. `chore`: triage remaining safe ruff findings (9 of 22)
Hand-fixed the leftover ruff findings outside the HFSS/Q3D and `_gui/` do-not-touch zones. 22 → 13 remaining. Each:

| File | Rule | Fix |
|---|---|---|
| `exceptions.py` (×3) | F811 | Removed dead `from sys import prefix`; each `__init__` defines a local `prefix` string |
| `layer_stack_handler.py` | F811 | Removed unused `Dict` from `typing`; module uses `addict.Dict` everywhere |
| `about.py` | F822 | Removed `'orient_me'` from `__all__` — referenced function was commented out |
| `kappa_calculation.py` (×2) | F405 | `from math import *` → `from math import pi` (only symbol used) |
| `utility_functions.py` (×2) | E721 | `as_ == list/dict` → `as_ is list/dict` (correct identity check on type params) |

**Intentionally skipped** (need HFSS/Qt validation): 6× E711 in `hfss_renderer_eigenmode_aedt.py`, 1× F811 in `ansys_renderer.py`, 6× E721 in `_gui/widgets/create_component_window/`.

### 3. `ci`: add environment.yml ↔ pyproject.toml drift gate
Past releases shipped with `environment.yml` constraints that let conda users pull older versions than `pyproject.toml` allowed — silently breaking pip vs conda parity. This is the same class of bug that broke `qutip 4 → 5` support and got fixed manually in v0.6.x.

- New `scripts/check_env_consistency.py` — a `uv run`-managed script that parses both files, normalises names, and asserts every shared package's env.yml range is a subset of its pyproject.toml range.
- Wired into `.github/workflows/main.yml` as the `env-consistency` job (runs alongside lint).
- Initial run flagged **five drifts** (all fixed in this commit):
  - `geopandas`: env `>=0.12.2` vs pyproject `>=1.0`
  - `pandas`: env `>=1.5.3` vs pyproject `>=2.1.1`
  - `pint`: env `~=0.20` vs pyproject `>=0.21.0`
  - `shapely`: env `~=2.0` vs pyproject `>=2.0.1`
  - `pyaedt`: env `~=0.21` (no ceiling) vs pyproject `>=0.21,<0.24`
- After fixes: `"OK: 17 shared packages, no drift."`

### 4. `docs`: silence Sphinx 'not in toctree' warnings via hidden apidocs glob
`docs/apidocs/` has ~107 auto-generated per-class stub `.rst` files. The API References toctree only references the *module-level* entries, so Sphinx flags every per-class stub with `WARNING: document isn't included in any toctree` (~100 warnings).

Added a hidden `:glob:` toctree at the bottom of `index.rst` matching `apidocs/*`. Satisfies Sphinx's reachability check without adding stubs to the visible nav.

## Test plan

- [ ] CI green (lint + matrix + new env-consistency job)
- [ ] `tox -e docs` warnings drop by ~100 (the per-class stub ones)
- [ ] `uvx ruff check src` reports 13 errors (down from 22), all in HFSS/`_gui/` zones

## What was deliberately not done

Tier-0 items that need your input or admin access:
- **Branch-protection bypass for `github-actions[bot]`** (Settings UI)
- **Dependabot triage** (3 alerts)
- **Coverage CI choice** (Codecov vs Coveralls vs PR comment)
- **`pyaedt 0.24/0.25` retest** (needs full env setup; HFSS-touching)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_