### PR TITLE
test + ci: tier-1 — coverage reporting, make() idempotency, pin sanity

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,5 +81,62 @@ jobs:
       - name: Check environment.yml against pyproject.toml
         run: uv run --quiet scripts/check_env_consistency.py
 
+  coverage:
+    name: coverage
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_COLOR: "1"
+      UV_MANAGED_PYTHON: "True"
+      UV_PYTHON: "3.12"
+      QISKIT_METAL_HEADLESS: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      - name: Install Gmsh + Qt OS dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libglu1-mesa libglu1-mesa-dev libegl1-mesa-dev
+      - name: Run tests with coverage
+        # Sync into the project venv so pytest can import the package by
+        # name; then run via uv to use the same Python the matrix uses.
+        run: |
+          uv sync --group test --quiet
+          uv run --quiet pytest tests/ \
+            --cov=src/qiskit_metal \
+            --cov-report=term \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov \
+            | tee coverage_output.txt
+      - name: Coverage summary
+        if: always()
+        run: |
+          {
+            echo "## Test coverage"
+            echo ""
+            echo '```'
+            # Emit the per-file table from pytest-cov's terminal report.
+            sed -n '/^Name.*Stmts.*Miss.*Cover/,/^TOTAL/p' coverage_output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+          retention-days: 14
+      - name: Upload coverage XML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          retention-days: 14
+
 
 

--- a/tests/test_qlibrary_idempotency.py
+++ b/tests/test_qlibrary_idempotency.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Idempotency tests for ``QComponent.make()``.
+
+``QComponent.rebuild()`` is expected to be deterministic and
+side-effect-free: calling it twice on the same component with the same
+options must produce the same set of geometry rows. Violations are
+silent bugs (component reads from internal state instead of
+``self.options``, uses an unseeded random call, depends on render
+order, etc.) that would silently break HFSS/Q3D analyses by perturbing
+geometry between runs.
+
+These tests parametrize via ``subTest`` over a small but representative
+subset of ``qlibrary``:
+
+* every transmon family
+* both terminations
+* one lumped coupler
+* one sample shape
+
+Routes are intentionally skipped — they require pre-existing pin
+connections; an idempotency test for them is a separate piece of
+plumbing.
+"""
+
+import unittest
+
+from qiskit_metal import designs
+from qiskit_metal.qlibrary.lumped.cap_n_interdigital import CapNInterdigital
+from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
+from qiskit_metal.qlibrary.qubits.transmon_cross_fl import TransmonCrossFL
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+from qiskit_metal.qlibrary.qubits.transmon_pocket_6 import TransmonPocket6
+from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
+from qiskit_metal.qlibrary.sample_shapes.rectangle import Rectangle
+from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+from qiskit_metal.qlibrary.terminations.short_to_ground import ShortToGround
+
+# Components to exercise. Each is instantiated with ``(design, name)``
+# and default options; ``make=True`` is the default so rebuild() runs
+# via __init__.
+COMPONENTS_UNDER_TEST = [
+    TransmonPocket,
+    TransmonPocketCL,
+    TransmonPocket6,
+    TransmonCross,
+    TransmonCrossFL,
+    OpenToGround,
+    ShortToGround,
+    Rectangle,
+    CapNInterdigital,
+]
+
+
+def _snapshot_geometry(design) -> dict:
+    """Return a deterministic, comparable representation of every
+    geometry row in every table.
+
+    The snapshot is a dict ``{table_name: [row_tuple, ...]}`` where
+    each row tuple is a sorted, stringified projection of the row's
+    contents. ``shapely`` geometries are converted to WKT so they're
+    stable across comparison ops; everything else is ``repr()``-ed
+    (stable for scalars and ``addict.Dict``).
+    """
+    out = {}
+    for table_name, table in design.qgeometry.tables.items():
+        rows = []
+        for _, row in table.iterrows():
+            row_tuple = tuple(
+                (col, (row[col].wkt if hasattr(row[col], "wkt") else
+                       repr(row[col])))
+                for col in sorted(table.columns))
+            rows.append(row_tuple)
+        # Sort: only the *set* of geometry rows produced by make()
+        # matters, not their insertion order.
+        out[table_name] = sorted(rows)
+    return out
+
+
+class TestQComponentIdempotency(unittest.TestCase):
+    """Each component's ``make()`` must produce identical geometry on
+    a second ``rebuild()`` call."""
+
+    def test_rebuild_is_idempotent(self):
+        """Calling ``component.rebuild()`` a second time must not
+        change the resulting geometry.
+
+        Catches:
+          * ``make()`` mutating ``self.options`` so the second call
+            sees different inputs
+          * ``make()`` accumulating state across calls instead of
+            clearing it
+          * Position drift from un-seeded randomness in ``make()``
+        """
+        for component_cls in COMPONENTS_UNDER_TEST:
+            with self.subTest(component=component_cls.__name__):
+                design = designs.DesignPlanar()
+                component = component_cls(design,
+                                          f"test_{component_cls.__name__}")
+                first = _snapshot_geometry(design)
+                component.rebuild()
+                second = _snapshot_geometry(design)
+                self.assertEqual(
+                    first, second,
+                    f"{component_cls.__name__}.make() is not idempotent: "
+                    f"the second rebuild() produced different geometry.")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_qlibrary_pin_sanity.py
+++ b/tests/test_qlibrary_pin_sanity.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Pin-data sanity checks for components in ``qlibrary``.
+
+Every pin emitted by ``QComponent.add_pin()`` populates a dict with
+geometric metadata used by the renderer dispatch (HFSS/Q3D port
+placement, GDS port markers). Bad pin metadata causes silent
+mis-renders that only surface during an Ansys solve:
+
+* zero or negative width -> Ansys can't place a port
+* non-unit ``normal`` -> port orientation is rotated by the magnitude
+* ``normal`` not perpendicular to ``tangent`` -> port plane is skewed
+* ``middle`` not at the midpoint of ``points`` -> port offset
+
+These tests catch all four by walking ``component.pins`` on a small
+set of representative components. The transmon family is the highest
+priority because that's where coupler pins live; routes are skipped
+because their pin layout depends on pin_inputs that aren't available
+in default options.
+"""
+
+import unittest
+
+import numpy as np
+
+from qiskit_metal import Dict, designs
+from qiskit_metal.qlibrary.lumped.cap_n_interdigital import CapNInterdigital
+from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+from qiskit_metal.qlibrary.qubits.transmon_pocket_6 import TransmonPocket6
+from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
+
+# (component_class, options) — options force at least one pin to be
+# emitted under what would otherwise be a pin-less default config.
+# Transmons add pins through their ``connection_pads`` dict; an empty
+# sub-dict falls back to ``_default_connection_pads`` for the per-pad
+# values.
+_PIN_KW = Dict(connection_pads=Dict(a=Dict()))
+COMPONENTS_WITH_PINS = [
+    (TransmonPocket, _PIN_KW),
+    (TransmonPocketCL, _PIN_KW),
+    (TransmonPocket6, _PIN_KW),
+    (TransmonCross, _PIN_KW),
+    (CapNInterdigital, Dict()),  # adds two pins by default
+]
+
+
+class TestQComponentPinSanity(unittest.TestCase):
+    """Each emitted pin must have well-formed geometric metadata."""
+
+    UNIT_TOLERANCE = 1e-6
+    PERPENDICULAR_TOLERANCE = 1e-6
+
+    def test_pin_geometry_invariants(self):
+        """For each pin: width > 0, ``normal`` and ``tangent`` are unit
+        vectors and mutually perpendicular, and ``middle`` is the
+        midpoint of ``points``."""
+        for component_cls, options in COMPONENTS_WITH_PINS:
+            with self.subTest(component=component_cls.__name__):
+                design = designs.DesignPlanar()
+                component = component_cls(design,
+                                          f"test_{component_cls.__name__}",
+                                          options=options)
+                if not component.pins:
+                    self.fail(
+                        f"{component_cls.__name__} produced no pins with "
+                        f"the test's configured options — update the "
+                        f"options dict if the component's pin trigger "
+                        f"changed.")
+                for pin_name, pin in component.pins.items():
+                    self._check_pin(component_cls.__name__, pin_name, pin)
+
+    def _check_pin(self, component_name: str, pin_name: str, pin: dict):
+        ref = f"{component_name}.{pin_name}"
+
+        # Width must be strictly positive — zero-width ports break HFSS.
+        self.assertGreater(
+            pin["width"], 0.0,
+            f"{ref}: pin width must be > 0, got {pin['width']}")
+
+        normal = np.asarray(pin["normal"], dtype=float)
+        tangent = np.asarray(pin["tangent"], dtype=float)
+
+        # Normal and tangent should both be unit vectors. ``add_pin``
+        # rounds them, so we tolerate a small numeric drift but reject
+        # anything that's drifted into "this clearly isn't normalised"
+        # territory.
+        self.assertAlmostEqual(
+            float(np.linalg.norm(normal)), 1.0, delta=self.UNIT_TOLERANCE,
+            msg=f"{ref}: ||normal|| != 1; got {normal}")
+        self.assertAlmostEqual(
+            float(np.linalg.norm(tangent)), 1.0, delta=self.UNIT_TOLERANCE,
+            msg=f"{ref}: ||tangent|| != 1; got {tangent}")
+
+        # Perpendicularity. A port plane that isn't square produces
+        # silent geometry errors at solve time.
+        self.assertLess(
+            abs(float(np.dot(normal, tangent))),
+            self.PERPENDICULAR_TOLERANCE,
+            f"{ref}: normal . tangent != 0; "
+            f"normal={normal}, tangent={tangent}")
+
+        # ``middle`` must equal the average of ``points``. If it
+        # doesn't, downstream renderers place the port off-center.
+        points = np.asarray(pin["points"], dtype=float)
+        self.assertEqual(
+            points.shape[0], 2,
+            f"{ref}: expected 2 points, got shape {points.shape}")
+        expected_middle = points.mean(axis=0)
+        actual_middle = np.asarray(pin["middle"], dtype=float)
+        # add_pin rounds to design.template_options.PRECISION; allow
+        # a generous tolerance here.
+        self.assertTrue(
+            np.allclose(actual_middle, expected_middle, atol=1e-6),
+            f"{ref}: middle {actual_middle} != mean(points) "
+            f"{expected_middle}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Three commits, all additive (no existing files modified except `main.yml`'s CI):

### 1. `ci`: coverage job with GitHub step-summary report

Adds a single ubuntu/py3.12 `coverage` job that runs the test suite with `pytest --cov` and emits the per-file coverage table to `GITHUB_STEP_SUMMARY` — visible inline on the Actions run page and in the PR's Checks tab. No external service, no tokens, no accounts. Also uploads the HTML report and `coverage.xml` as 14-day artifacts so anyone can drill into specific files or pipe the XML into Codecov/Coveralls later if you change your mind.

The 9-job test matrix is left alone (coverage instrumentation slows pytest measurably and we only need one snapshot per commit).

### 2. `test`: `make()` idempotency tests

`QComponent.rebuild()` is expected to be deterministic — calling it twice with unchanged options must produce identical geometry. Violations are silent bugs (`make()` mutating `self.options`, accumulating state, using un-seeded randomness) that would silently perturb HFSS/Q3D analyses between runs.

The test parametrizes via `subTest` over 9 representative components:
- All five transmon variants (Pocket, PocketCL, Pocket6, Cross, CrossFL)
- Both ground terminations (OpenToGround, ShortToGround)
- One lumped coupler (CapNInterdigital)
- One sample shape (Rectangle)

For each: snapshot `design.qgeometry.tables` (WKT-stringified, sorted), call `rebuild()` again, snapshot again, assert equal. Routes deliberately excluded — they need pre-existing pin connections.

**Local run: 9/9 subtests pass in ~35s on py3.11.**

### 3. `test`: pin-geometry sanity checks

Every pin emitted by `add_pin()` populates a dict with geometric metadata that downstream renderers depend on. Bad pin metadata is silently fatal — Ansys accepts it and produces wrong physics.

Five invariants checked on every pin:
1. `width > 0` — Ansys can't place a port on zero-width geometry
2. `||normal|| == 1` — non-unit normals rotate the port plane
3. `||tangent|| == 1` — same for the port's width axis
4. `normal · tangent == 0` — port plane must be square
5. `middle == mean(points)` — port sits at the midpoint of its segment

Tested across 4 transmons + 1 lumped coupler. Transmons are configured with `connection_pads={'a': {}}` because the default config emits no pins; the empty sub-dict falls back to `_default_connection_pads`.

**Local run: 5/5 subtests pass in ~3s on py3.11.**

## What this catches (real failure modes)

Both tests are designed around concrete bug classes I've seen in this codebase or its dependencies:

- **Idempotency**: would have caught any future regression where `make()` reads `self.geometry` instead of rebuilding from `self.options`, or where a `make()` helper mutates `self.options`.
- **Pin sanity**: would have caught the kind of "everything looks fine but Ansys S-parameters are off" failures that get diagnosed only after a several-hour solve.

## What I deliberately did *not* do

Other Tier-1 plan items I held off on:

- **`default_options` static AST audit** — needs more thought on dynamic key access (`connection_pads[name]` etc.) before it can be a CI gate without false positives. Worth a follow-up PR.
- **Renderer protocol audit** — read-only research task; better as a separate document/PR.
- **Notebook smoke test in CI** — needs the `[lite]` extras (Tier 2) to be viable on a clean CI runner without Qt/Ansys baggage.

## Test plan

- [ ] CI green: lint, env-consistency, coverage, full matrix
- [ ] Coverage step summary appears on the `coverage` job's run page
- [ ] Coverage artifacts (`coverage-html`, `coverage-xml`) downloadable
- [ ] `tests/test_qlibrary_idempotency.py` and `tests/test_qlibrary_pin_sanity.py` show in matrix runs

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_