### PR TITLE
test + docs: expand qlibrary test coverage, add renderer-protocol audit + Qt-optional callout

### DIFF
--- a/docs/architecture/renderer_protocol.md
+++ b/docs/architecture/renderer_protocol.md
@@ -1,0 +1,173 @@
+# Renderer protocol audit
+
+This is a read-only inventory of qiskit-metal's renderer class hierarchy
+as of v0.6.1. It exists so a contributor or HFSS-savvy reviewer can
+spot gaps without re-discovering the hierarchy each time.
+
+## TL;DR
+
+There are **two** abstract base classes in `renderers/renderer_base/`:
+
+| Base | Purpose | Abstract methods |
+|------|---------|------------------|
+| `QRenderer` | Top-level interface, suitable for **export-only** renderers (GDS, Gmsh). | 3 |
+| `QRendererAnalysis(QRenderer)` | Adds the per-element / per-chip render hooks that analysis renderers need. | 8 |
+
+There are **9 concrete renderer classes** (10 if you count `QMplRenderer` — see caveat).
+
+Every concrete renderer overrides its base's abstract methods (no
+silent NotImplementedError surface). The one stub-only method I found
+(`render_chip` at `ansys_renderer.py:1053`) is dead — the real
+implementation is at line 1529. That F811 is in the "needs HFSS
+review" bucket from the tier-0 ruff triage.
+
+## Inheritance map
+
+```
+QRenderer (renderer_base.py)
+├── _initiate_renderer()     [abstract]
+├── _close_renderer()        [abstract]
+└── render_design()          [abstract]
+
+QRendererAnalysis(QRenderer) (rndr_analysis.py)
+├── initialized              [abstract property]
+├── render_chips()           [abstract]
+├── render_chip(name)        [abstract]
+├── render_components(...)   [abstract]
+├── render_component(...)    [abstract]
+├── render_element(...)      [abstract]
+├── render_element_path(...)  [abstract]
+├── render_element_poly(...) [abstract]
+└── save_screenshot(...)     [abstract]
+```
+
+### Concrete renderers
+
+```
+QRenderer
+├── QGDSRenderer             (renderer_gds/gds_renderer.py)        export-only
+└── QGmshRenderer            (renderer_gmsh/gmsh_renderer.py)      export-only (FEM mesh)
+
+QRendererAnalysis (which is itself a QRenderer)
+├── QAnsysRenderer           (renderer_ansys/ansys_renderer.py)    legacy COM-based Ansys
+│   ├── QHFSSRenderer        (renderer_ansys/hfss_renderer.py)
+│   └── QQ3DRenderer         (renderer_ansys/q3d_renderer.py)
+├── QPyaedt                  (renderer_ansys_pyaedt/pyaedt_base.py)  new pyaedt-based
+│   ├── QHFSSPyaedt          (renderer_ansys_pyaedt/hfss_renderer_aedt.py)
+│   │                         + QHFSSPyaedtDrivenmodal, QHFSSPyaedtEigenmode
+│   └── QQ3DPyaedt           (renderer_ansys_pyaedt/q3d_renderer_aedt.py)
+└── QElmerRenderer           (renderer_elmer/elmer_renderer.py)    open-source FEM
+
+QMplRenderer  ⚠ NOT a QRenderer subclass — see caveat below.
+```
+
+## Two-track Ansys story (architectural observation)
+
+Both `renderer_ansys/` (`QAnsysRenderer`) and `renderer_ansys_pyaedt/`
+(`QPyaedt`) exist in parallel. They render the same designs to the
+same Ansys backends but use different bridges:
+
+* `renderer_ansys/` — original implementation, COM-based, Windows-only
+  for the live solve path. Goes via `pyEPR.ansys` for the lower-level
+  COM calls. Touched in the v0.6.0 work to handle the HFSS 2024.1+
+  solution-type rename.
+* `renderer_ansys_pyaedt/` — newer, uses the official `pyaedt` Python
+  package (Ansys-supplied). Should eventually replace the COM-based
+  path; the existence of both is the migration in progress.
+
+**No deprecation policy is currently documented for the `renderer_ansys/`
+track.** Worth deciding before adding new Ansys functionality.
+
+## The `QMplRenderer` caveat
+
+`renderers/renderer_mpl/mpl_renderer.py` defines `class QMplRenderer:`
+— **with no parent class**. It is *not* a `QRenderer`. Despite being
+in the `renderers/` directory, it's a Qt-canvas widget renderer, not
+a design-export renderer.
+
+Constructor signature:
+
+```python
+def __init__(self, canvas: "PlotCanvas", design: QDesign,
+             logger: logging.Logger):
+```
+
+`PlotCanvas` is the Qt-based `mpl_canvas.PlotCanvas` widget. The whole
+class is coupled to Qt via that constructor, so it can't be used
+standalone (e.g. in Jupyter or on a headless cloud runner).
+
+**Decoupling `QMplRenderer` from `PlotCanvas` is Tier 2 in the
+maintenance plan** — it's the single change that unlocks a no-Qt
+rendering path for Binder/Colab/JupyterLab tutorials.
+
+A natural follow-on would be to either:
+
+1. Make `QMplRenderer` accept an `ax: Optional[matplotlib.axes.Axes]`
+   instead of a `PlotCanvas`, and synthesise a canvas internally only
+   when needed (least disruptive — keeps existing call sites working).
+2. Promote `QMplRenderer` to a `QRenderer` subclass with proper
+   `_initiate_renderer` / `render_design` overrides, and make
+   `PlotCanvas` consume *it* rather than the other way round (deeper,
+   cleaner long-term).
+
+(1) is the unblock-now path; (2) is the right architectural endpoint.
+
+## Per-renderer override matrix
+
+A `✓` means the renderer overrides the abstract method. A `inherits`
+means it uses a non-abstract default. A `—` means N/A for this base.
+
+| Method                | GDS | Gmsh | Ansys | HFSS | Q3D | Pyaedt | HFSSPyaedt | Q3DPyaedt | Elmer |
+|-----------------------|:---:|:----:|:-----:|:----:|:---:|:------:|:----------:|:---------:|:-----:|
+| `_initiate_renderer`  | ✓   | ✓    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `_close_renderer`     | ✓   | ✓    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_design`       | ✓   | ✓    | ✓     | ✓    | ✓   | ✓      | ✓          | ✓         | ✓     |
+| `render_chips`        | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_chip`         | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_components`   | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_component`    | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_element`      | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_element_path` | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `render_element_poly` | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+| `save_screenshot`     | —   | —    | ✓     | inh. | inh.| ✓      | inh.       | inh.      | ✓     |
+
+Sources: greps of `class …(QRenderer|QAnsysRenderer|QPyaedt|…)` and
+`def render_*` / `def _initiate_renderer` / `def _close_renderer`
+across `src/qiskit_metal/renderers/`. The `inh.` cells were verified
+by walking each MRO.
+
+## Known issues
+
+1. **Dead `render_chip` stub** at
+   `renderer_ansys/ansys_renderer.py:1053`. Just `def render_chip(self): pass`;
+   the real implementation is 476 lines later at 1529. Ruff flags this
+   as `F811 Redefinition of unused`. Listed in the tier-0 ruff
+   skipped-because-HFSS bucket.
+2. **No documented deprecation path** for the COM-based
+   `renderer_ansys/` track despite the pyaedt-based replacement
+   existing in `renderer_ansys_pyaedt/`. Adding new Ansys
+   functionality has to land in both today, with no clear rule for
+   when to stop.
+3. **`QMplRenderer` is structurally outside the renderer protocol**
+   (no `QRenderer` base). This is the Tier 2 target.
+4. **No `QRenderer` subclass for SVG / PNG export.** A user who just
+   wants a static image of a design currently has no good path
+   without going through Qt. (Resolved as a side-effect of the Tier 2
+   `QMplRenderer` decoupling: once it produces standalone `Figure`s,
+   `fig.savefig(…)` is right there.)
+
+## How to extend this document
+
+If you add a new concrete renderer:
+
+1. Add it to the inheritance map.
+2. Add a column to the override matrix.
+3. If you intentionally don't override an `inh.` method, write a
+   sentence in "Known issues" explaining why your renderer can ignore
+   it.
+
+If you change `QRenderer` or `QRendererAnalysis` abstract surface:
+
+1. Update the TL;DR counts.
+2. Add the new method to the matrix and verify every existing
+   renderer implements it (or is intentionally exempt).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,18 @@ Quantum Device Design & Analysis (Q-EDA)
 Design and analyze superconducting quantum chips with a Python API + GUI that plugs into your favorite tools.
 Leverages existing EDA stacks, automates tedious workflows, and keeps best practices baked in.
 
+.. note::
+    **You don't need the Qt GUI to use Quantum Metal.** The full API
+    — designs, components, renderers, analyses — works headlessly in a
+    plain Python interpreter or a Jupyter notebook.  The ``MetalGUI``
+    desktop app is optional and exists for interactive design work; if
+    you're scripting designs, running parameter sweeps, or working in
+    a cloud notebook environment, you can ignore it entirely.
+
+    A no-Qt, in-notebook viewer is under active development as part of
+    the Jupyter / cloud workflow track. See the
+    :doc:`workflow <workflow>` roadmap for status.
+
 .. grid:: 1 2 2 2
    :gutter: 1
 

--- a/tests/test_qlibrary_idempotency.py
+++ b/tests/test_qlibrary_idempotency.py
@@ -21,45 +21,88 @@ silent bugs (component reads from internal state instead of
 order, etc.) that would silently break HFSS/Q3D analyses by perturbing
 geometry between runs.
 
-These tests parametrize via ``subTest`` over a small but representative
-subset of ``qlibrary``:
-
-* every transmon family
-* both terminations
-* one lumped coupler
-* one sample shape
-
-Routes are intentionally skipped — they require pre-existing pin
-connections; an idempotency test for them is a separate piece of
+These tests parametrize via ``subTest`` over every ``qlibrary``
+component that instantiates cleanly on ``DesignPlanar`` with default
+options. Routes are intentionally excluded — they require pre-existing
+pin connections; an idempotency test for them is a separate piece of
 plumbing.
 """
 
 import unittest
 
 from qiskit_metal import designs
+from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import (
+    CapNInterdigitalTee)
+from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
+from qiskit_metal.qlibrary.couplers.line_tee import LineTee
+from qiskit_metal.qlibrary.lumped.cap_3_interdigital import Cap3Interdigital
 from qiskit_metal.qlibrary.lumped.cap_n_interdigital import CapNInterdigital
+from qiskit_metal.qlibrary.lumped.resonator_coil_rect import ResonatorCoilRect
+from qiskit_metal.qlibrary.qubits.JJ_Dolan import jj_dolan
+from qiskit_metal.qlibrary.qubits.JJ_Manhattan import jj_manhattan
+from qiskit_metal.qlibrary.qubits.SQUID_loop import SQUID_LOOP
+from qiskit_metal.qlibrary.qubits.star_qubit import StarQubit
+from qiskit_metal.qlibrary.qubits.transmon_concentric import TransmonConcentric
 from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
 from qiskit_metal.qlibrary.qubits.transmon_cross_fl import TransmonCrossFL
 from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
 from qiskit_metal.qlibrary.qubits.transmon_pocket_6 import TransmonPocket6
 from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
+from qiskit_metal.qlibrary.qubits.transmon_pocket_teeth import (
+    TransmonPocketTeeth)
+from qiskit_metal.qlibrary.sample_shapes.circle_caterpillar import (
+    CircleCaterpillar)
+from qiskit_metal.qlibrary.sample_shapes.circle_raster import CircleRaster
+from qiskit_metal.qlibrary.sample_shapes.n_gon import NGon
+from qiskit_metal.qlibrary.sample_shapes.n_square_spiral import NSquareSpiral
 from qiskit_metal.qlibrary.sample_shapes.rectangle import Rectangle
+from qiskit_metal.qlibrary.sample_shapes.rectangle_hollow import (
+    RectangleHollow)
+from qiskit_metal.qlibrary.terminations.launchpad_wb import LaunchpadWirebond
+from qiskit_metal.qlibrary.terminations.launchpad_wb_coupled import (
+    LaunchpadWirebondCoupled)
+from qiskit_metal.qlibrary.terminations.launchpad_wb_driven import (
+    LaunchpadWirebondDriven)
 from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
 from qiskit_metal.qlibrary.terminations.short_to_ground import ShortToGround
 
-# Components to exercise. Each is instantiated with ``(design, name)``
-# and default options; ``make=True`` is the default so rebuild() runs
-# via __init__.
+# Every component that instantiates cleanly on DesignPlanar with
+# (design, name) and no extra options. Routes are excluded — they need
+# pin connections that aren't available in default options.
 COMPONENTS_UNDER_TEST = [
+    # Sample shapes
+    Rectangle,
+    RectangleHollow,
+    NGon,
+    NSquareSpiral,
+    CircleRaster,
+    CircleCaterpillar,
+    # Terminations
+    OpenToGround,
+    ShortToGround,
+    LaunchpadWirebond,
+    LaunchpadWirebondCoupled,
+    LaunchpadWirebondDriven,
+    # Qubit family
+    TransmonConcentric,
     TransmonPocket,
     TransmonPocketCL,
     TransmonPocket6,
+    TransmonPocketTeeth,
     TransmonCross,
     TransmonCrossFL,
-    OpenToGround,
-    ShortToGround,
-    Rectangle,
+    StarQubit,
+    SQUID_LOOP,
+    jj_dolan,
+    jj_manhattan,
+    # Lumped
     CapNInterdigital,
+    Cap3Interdigital,
+    ResonatorCoilRect,
+    # Couplers
+    LineTee,
+    CapNInterdigitalTee,
+    CoupledLineTee,
 ]
 
 

--- a/tests/test_qlibrary_pin_sanity.py
+++ b/tests/test_qlibrary_pin_sanity.py
@@ -23,9 +23,9 @@ mis-renders that only surface during an Ansys solve:
 * ``normal`` not perpendicular to ``tangent`` -> port plane is skewed
 * ``middle`` not at the midpoint of ``points`` -> port offset
 
-These tests catch all four by walking ``component.pins`` on a small
-set of representative components. The transmon family is the highest
-priority because that's where coupler pins live; routes are skipped
+These tests catch all four by walking ``component.pins`` on every
+``qlibrary`` component that emits at least one pin under either
+default options or a minimal pin-trigger config. Routes are skipped
 because their pin layout depends on pin_inputs that aren't available
 in default options.
 """
@@ -35,11 +35,28 @@ import unittest
 import numpy as np
 
 from qiskit_metal import Dict, designs
+from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import (
+    CapNInterdigitalTee)
+from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
+from qiskit_metal.qlibrary.couplers.line_tee import LineTee
+from qiskit_metal.qlibrary.lumped.cap_3_interdigital import Cap3Interdigital
 from qiskit_metal.qlibrary.lumped.cap_n_interdigital import CapNInterdigital
+from qiskit_metal.qlibrary.lumped.resonator_coil_rect import ResonatorCoilRect
+from qiskit_metal.qlibrary.qubits.star_qubit import StarQubit
+from qiskit_metal.qlibrary.qubits.transmon_concentric import TransmonConcentric
 from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
+from qiskit_metal.qlibrary.qubits.transmon_cross_fl import TransmonCrossFL
 from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
 from qiskit_metal.qlibrary.qubits.transmon_pocket_6 import TransmonPocket6
 from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
+from qiskit_metal.qlibrary.sample_shapes.n_square_spiral import NSquareSpiral
+from qiskit_metal.qlibrary.terminations.launchpad_wb import LaunchpadWirebond
+from qiskit_metal.qlibrary.terminations.launchpad_wb_coupled import (
+    LaunchpadWirebondCoupled)
+from qiskit_metal.qlibrary.terminations.launchpad_wb_driven import (
+    LaunchpadWirebondDriven)
+from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+from qiskit_metal.qlibrary.terminations.short_to_ground import ShortToGround
 
 # (component_class, options) — options force at least one pin to be
 # emitted under what would otherwise be a pin-less default config.
@@ -47,12 +64,30 @@ from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
 # sub-dict falls back to ``_default_connection_pads`` for the per-pad
 # values.
 _PIN_KW = Dict(connection_pads=Dict(a=Dict()))
+_NONE = Dict()
+
 COMPONENTS_WITH_PINS = [
+    # Trigger transmon connection pads explicitly.
     (TransmonPocket, _PIN_KW),
     (TransmonPocketCL, _PIN_KW),
     (TransmonPocket6, _PIN_KW),
     (TransmonCross, _PIN_KW),
-    (CapNInterdigital, Dict()),  # adds two pins by default
+    # The following components emit at least one pin under default options.
+    (TransmonConcentric, _NONE),
+    (TransmonCrossFL, _NONE),
+    (StarQubit, _NONE),
+    (NSquareSpiral, _NONE),
+    (OpenToGround, _NONE),
+    (ShortToGround, _NONE),
+    (LaunchpadWirebond, _NONE),
+    (LaunchpadWirebondCoupled, _NONE),
+    (LaunchpadWirebondDriven, _NONE),
+    (CapNInterdigital, _NONE),
+    (Cap3Interdigital, _NONE),
+    (ResonatorCoilRect, _NONE),
+    (LineTee, _NONE),
+    (CapNInterdigitalTee, _NONE),
+    (CoupledLineTee, _NONE),
 ]
 
 


### PR DESCRIPTION
## Summary

Two commits, both extending what landed in #1058. No new behavior, only new tests and docs.

### 1. `test`: expand idempotency + pin coverage to all clean-instantiating components

Discovery sweep found **28 of 35** non-Route qlibrary classes instantiate cleanly on `DesignPlanar` with default options. Previously only 9 were under idempotency test and 5 under pin sanity.

- **Idempotency: 9 → 28 components.** Added every sample shape (Rectangle, RectangleHollow, NGon, NSquareSpiral, CircleRaster, CircleCaterpillar), all 3 launchpads, the remaining transmons (Concentric, PocketTeeth), StarQubit, SQUID_LOOP, JJ_Dolan, JJ_Manhattan, the remaining lumped (Cap3Interdigital, ResonatorCoilRect), and all 3 couplers (LineTee, CapNInterdigitalTee, CoupledLineTee).
- **Pin sanity: 5 → 19 components.** Added every component that emits a pin under default options.

Routes still excluded — they require pre-existing pin connections.

**Local run: 28/28 + 19/19 subtests pass in ~5s.**

### 2. `docs`: renderer-protocol audit + 'Qt GUI is optional' callout

- **`docs/architecture/renderer_protocol.md`** — full inventory of the renderer hierarchy. `QRenderer` (3 abstract methods) and `QRendererAnalysis` (8 more) bases, the 9 concrete renderers, per-renderer override matrix, and three architectural observations:
  - Two parallel Ansys tracks (`renderer_ansys/` COM-based vs `renderer_ansys_pyaedt/` pyaedt-based) with **no documented deprecation path**
  - The dead `render_chip` stub at `ansys_renderer.py:1053` (F811 we skipped in tier-0)
  - **`QMplRenderer` is structurally outside the renderer protocol** — has no `QRenderer` base, coupled to Qt's `PlotCanvas` via its constructor. Names this as the **tier-2 unlock** for no-Qt rendering.

- **`docs/index.rst`** — a callout setting the correct expectation that `MetalGUI` is optional, the full API works headlessly in notebook/script environments, and an in-notebook viewer is on the roadmap. Aimed at users who would otherwise abandon the project on first install because they can't get PySide6 to build on a cloud notebook.

## What this PR is *not*

- Doesn't decouple `QMplRenderer` from Qt — that's tier-2, separate PR.
- Doesn't fix HFSS/`_gui/` ruff findings — needs HFSS validation.
- Doesn't add notebook execution to CI — needs tier-2 first.

## Test plan

- [ ] CI green (full matrix + lint + env-consistency + coverage + new tests)
- [ ] All 47 new subtests (28 idempotency + 19 pin sanity) pass on all 9 matrix jobs

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_