### PR TITLE
tier 2: standalone qm.view() — Qt-free design rendering for Jupyter/Colab/Binder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,6 +129,10 @@ jobs:
             'pytest-rich>=0.2.0'
           uv pip install --no-deps -e .
       - name: Confirm PySide6 is NOT installed
+        # ``uv pip show`` queries the venv directly without
+        # triggering a sync. ``uv run`` would auto-sync to match
+        # pyproject.toml deps and silently undo our lite install, so
+        # all subsequent steps invoke ``.venv/bin/python`` directly.
         run: |
           if uv pip show pyside6 2>/dev/null; then
             echo "::error::PySide6 is installed in the lite venv — test setup is wrong"
@@ -139,8 +143,13 @@ jobs:
         # This is the critical assertion: import + view must work
         # with PySide6 absent. Failure here means someone added a
         # top-level Qt import to a non-GUI module.
+        #
+        # ``.venv/bin/python`` instead of ``uv run python`` —
+        # ``uv run`` would auto-sync the venv to match
+        # pyproject.toml's full dependency set, defeating the
+        # lite-install premise.
         run: |
-          uv run python -c "
+          .venv/bin/python -c "
           import qiskit_metal as qm
           from qiskit_metal.designs import DesignPlanar
           from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
@@ -152,11 +161,11 @@ jobs:
           print('OK: qm.view(design) returned', type(fig).__name__)
           "
       - name: Run no-Qt test files
-        # Tests that don't need Qt — viewer, idempotency, pin sanity.
-        # If any of these reach for PySide6 they'll fail and we'll
-        # know we have unintentional Qt coupling.
+        # Same rationale as above — direct venv python invocation to
+        # avoid uv auto-sync. Tests must work without Qt; failure
+        # here means we have unintentional Qt coupling somewhere.
         run: |
-          uv run pytest \
+          .venv/bin/python -m pytest \
             tests/test_viewer.py \
             tests/test_qlibrary_idempotency.py \
             tests/test_qlibrary_pin_sanity.py \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,88 @@ jobs:
       - name: Check environment.yml against pyproject.toml
         run: uv run --quiet scripts/check_env_consistency.py
 
+  tests-lite:
+    # Exercises the "lite" install path — no PySide6, no pyaedt, no
+    # gmsh. Catches accidental top-level Qt/Ansys/FEM imports that
+    # would break Colab / Binder / cloud Jupyter users.
+    #
+    # Once v0.7.0 flips the default install to lite, this matrix entry
+    # becomes the canonical test runner; until then it's a focused
+    # gate.
+    name: tests-lite
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_COLOR: "1"
+      QISKIT_METAL_HEADLESS: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      - name: Install lite dependency set (no PySide6, pyaedt, gmsh)
+        # Build a venv that has every core dep EXCEPT the GUI / Ansys
+        # / FEM extras. Uses ``--no-deps`` for our package then
+        # explicitly installs core deps so we can omit the heavy ones.
+        # Bypasses ``pyproject.toml``'s base deps so we get a true
+        # lite install regardless of what's in [project.dependencies].
+        run: |
+          uv venv --python 3.12
+          uv pip install \
+            'addict>=2.4.0' \
+            'gdstk>=0.9' \
+            'geopandas>=1.0' \
+            'matplotlib>=3.7.0' \
+            'numpy>=1.24.2,<2' \
+            'pandas>=2.1.1' \
+            'pint>=0.21.0' \
+            'pyEPR-quantum>=0.9.5' \
+            'pygments>=2.14.0' \
+            'qutip>=5.0.0' \
+            'scipy>=1.10.0' \
+            'shapely>=2.0.1' \
+            'scqubits>=4.1.0' \
+            'pyyaml>=6.0' \
+            'pytest>=8.4.1' \
+            'pytest-rich>=0.2.0'
+          uv pip install --no-deps -e .
+      - name: Confirm PySide6 is NOT installed
+        run: |
+          if uv pip show pyside6 2>/dev/null; then
+            echo "::error::PySide6 is installed in the lite venv — test setup is wrong"
+            exit 1
+          fi
+          echo "OK: PySide6 absent from lite venv"
+      - name: Smoke test — import qiskit_metal + qm.view()
+        # This is the critical assertion: import + view must work
+        # with PySide6 absent. Failure here means someone added a
+        # top-level Qt import to a non-GUI module.
+        run: |
+          uv run python -c "
+          import qiskit_metal as qm
+          from qiskit_metal.designs import DesignPlanar
+          from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+          design = DesignPlanar()
+          TransmonPocket(design, 'Q1',
+                         options={'connection_pads': {'a': {}}})
+          fig = qm.view(design)
+          assert fig is not None, 'qm.view returned None'
+          print('OK: qm.view(design) returned', type(fig).__name__)
+          "
+      - name: Run no-Qt test files
+        # Tests that don't need Qt — viewer, idempotency, pin sanity.
+        # If any of these reach for PySide6 they'll fail and we'll
+        # know we have unintentional Qt coupling.
+        run: |
+          uv run pytest \
+            tests/test_viewer.py \
+            tests/test_qlibrary_idempotency.py \
+            tests/test_qlibrary_pin_sanity.py \
+            tests/test_solution_types.py \
+            -v
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04

--- a/docs/headless-usage.rst
+++ b/docs/headless-usage.rst
@@ -1,0 +1,131 @@
+.. _headless-usage:
+
+==========================================
+Using Quantum Metal without the Qt GUI
+==========================================
+
+You do not need the desktop Qt GUI (``MetalGUI``) to use Quantum
+Metal. The full API — designs, components, renderers, analyses — works
+headlessly in a plain Python interpreter, a Jupyter notebook, or a
+cloud notebook environment (Colab, Binder, JupyterLab on a shared
+server). The Qt GUI is one *interface* to the API, not a requirement.
+
+Quick start
+===========
+
+The shortest path to rendering a design without Qt:
+
+.. code-block:: python
+
+    import qiskit_metal as qm
+    from qiskit_metal.designs import DesignPlanar
+    from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+
+    design = DesignPlanar()
+    TransmonPocket(design, "Q1",
+                   options={"connection_pads": {"a": {}}})
+
+    fig = qm.view(design)
+    fig.savefig("q1.png")          # save to file
+    # or, in a Jupyter notebook, just `fig` displays inline.
+
+``qm.view`` accepts options for customising the output:
+
+.. code-block:: python
+
+    # Render into an existing axes for a multi-panel figure
+    import matplotlib.pyplot as plt
+    fig, axes = plt.subplots(1, 2, figsize=(12, 6))
+    qm.view(design_a, ax=axes[0], title="Design A")
+    qm.view(design_b, ax=axes[1], title="Design B")
+
+    # Render only specific components
+    qm.view(design, components=["Q1", "Q2"])
+
+    # Hide specific layers
+    qm.view(design, hidden_layers={2})
+
+    # Custom figure size
+    qm.view(design, figsize=(10, 8))
+
+The returned :class:`matplotlib.figure.Figure` can be saved
+(``fig.savefig``), embedded in a larger figure, or further customised
+with the standard matplotlib API.
+
+What works headlessly
+=====================
+
+Everything except the desktop interactive editor:
+
+* All component classes in :mod:`qiskit_metal.qlibrary`
+* Designs (:class:`~qiskit_metal.designs.DesignPlanar`,
+  :class:`~qiskit_metal.designs.DesignFlipChip`, ...)
+* Geometry rendering via :func:`qm.view <qiskit_metal.viewer.view>`
+* GDS export via :class:`~qiskit_metal.renderers.renderer_gds.gds_renderer.QGDSRenderer`
+* Q3D / HFSS rendering (when run on a machine with Ansys AEDT
+  available — the *renderer* doesn't require Qt, but Ansys does)
+* All :mod:`qiskit_metal.analyses` modules
+
+What requires the Qt GUI
+========================
+
+Only the interactive desktop editor itself:
+
+* :class:`~qiskit_metal.MetalGUI` — the dockable PySide6 window
+* The pan/zoom toolbar from
+  :func:`~qiskit_metal.renderers.renderer_mpl.mpl_interaction.figure_pz`
+  (use :func:`qm.view` instead in notebooks for static images, or
+  ``%matplotlib widget`` + ``ipympl`` for interactive pan/zoom in
+  Jupyter)
+
+Installing without Qt (v0.6.x)
+==============================
+
+Today the base ``pip install quantum-metal`` install pulls in PySide6
+and the rest of the Qt stack so the desktop GUI works out of the box.
+You can still skip Qt initialisation at runtime by setting
+the ``QISKIT_METAL_HEADLESS`` environment variable:
+
+.. code-block:: bash
+
+    export QISKIT_METAL_HEADLESS=1
+    python my_script.py
+
+This prevents matplotlib from switching to the ``QtAgg`` backend
+during import. The Qt packages stay installed but are never touched.
+
+Migrating to a lite install (v0.7.0)
+====================================
+
+A future v0.7.0 release will flip the default install:
+
+* ``pip install quantum-metal`` -> no Qt, no Ansys, no gmsh
+* ``pip install quantum-metal[gui]`` -> + PySide6 + qdarkstyle
+* ``pip install quantum-metal[ansys]`` -> + pyaedt + pyEPR
+* ``pip install quantum-metal[fem]`` -> + gmsh
+* ``pip install quantum-metal[full]`` -> all extras (current behavior)
+
+These extras already exist in ``pyproject.toml`` from v0.6.x onwards;
+they're additive today, becoming the canonical opt-in pathway when
+v0.7.0 ships.
+
+Roadmap: a richer in-notebook viewer
+====================================
+
+``qm.view`` covers the **viewing** workflow: render a design to an
+inline image. A richer interactive viewer — pan, zoom, click-to-select
+components, edit option values inline — is planned as a future
+project. The likely direction is Jupyter widgets + Plotly or
+``ipympl``, both of which give us a no-Qt interactive surface that
+works in Colab, Binder, and JupyterLab without setup gymnastics.
+
+This will be tracked as its own initiative once the basic headless
+rendering path (this page) is stable. In the meantime, ``qm.view`` is
+the supported way to display designs in notebooks.
+
+See also
+========
+
+* :func:`qiskit_metal.view` — the headless viewer entry point
+* :class:`qiskit_metal.MetalGUI` — the desktop Qt GUI (when you want
+  it)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,14 +41,16 @@ Leverages existing EDA stacks, automates tedious workflows, and keeps best pract
 .. note::
     **You don't need the Qt GUI to use Quantum Metal.** The full API
     — designs, components, renderers, analyses — works headlessly in a
-    plain Python interpreter or a Jupyter notebook.  The ``MetalGUI``
-    desktop app is optional and exists for interactive design work; if
-    you're scripting designs, running parameter sweeps, or working in
-    a cloud notebook environment, you can ignore it entirely.
+    plain Python interpreter or a Jupyter notebook. Use
+    ``qm.view(design)`` to render a design to a matplotlib figure
+    inline, without spinning up ``MetalGUI``::
 
-    A no-Qt, in-notebook viewer is under active development as part of
-    the Jupyter / cloud workflow track. See the
-    :doc:`workflow <workflow>` roadmap for status.
+        import qiskit_metal as qm
+        fig = qm.view(design)
+        fig.savefig("design.png")
+
+    See :doc:`headless-usage` for the full Qt-free workflow, what
+    works without PySide6, and the migration to the lite install.
 
 .. grid:: 1 2 2 2
    :gutter: 1
@@ -264,6 +266,7 @@ The goal of Qiskit Metal is to allow for easy quantum hardware modeling with red
 
     About<self>
     Installing Qiskit Metal<installation>
+    Using Quantum Metal without the Qt GUI<headless-usage>
 
 .. toctree::
     :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,15 @@
     requires-python = ">=3.10,<3.13"
     urls = { bugtracker = "https://github.com/qiskit-community/qiskit-metal/issues", documentation = "https://qiskit-community.github.io/qiskit-metal/", source = "https://github.com/qiskit-community/qiskit-metal" }
     version = "0.6.1"
+    # Core deps required for ``import qiskit_metal`` + ``qm.view()``
+    # to work in any environment. Heavy / optional deps (Qt GUI,
+    # pyaedt, gmsh) live in the ``[project.optional-dependencies]``
+    # section below so users can opt in. Note: for v0.6.x backward
+    # compatibility, the GUI / ANSYS / FEM stacks are still in the
+    # *base* deps list — the extras are additive. A future v0.7.0
+    # release plans to flip the default to lite (base = no Qt) and
+    # require ``pip install quantum-metal[full]`` for the current
+    # experience. See ``docs/headless-usage.rst`` for the timeline.
     dependencies = [
         "addict>=2.4.0",
         "gdstk>=0.9",
@@ -44,8 +53,34 @@
         "scqubits>=4.1.0",
         "gmsh>=4.11.1",
         "pyaedt>=0.21,<0.24", # pyaedt 0.24 has some bugs (Jan 23, 2026)
-        "pyyaml>=6.0", # Used for the Elmer runner. 
+        "pyyaml>=6.0", # Used for the Elmer runner.
     ]
+
+    # Opt-in extras. Currently informational — every extra's deps are
+    # also in the base list above so v0.6.x users keep the
+    # all-batteries-included install. The CI ``tests-lite`` job
+    # exercises an install pruned of these extras to keep the
+    # lite-mode rendering path provably working, ahead of the v0.7.0
+    # flip when ``[full]`` becomes opt-in.
+    [project.optional-dependencies]
+        gui = [
+            "pyside6>=6.8",
+            "qdarkstyle>=3.1",
+        ]
+        ansys = [
+            "pyaedt>=0.21,<0.24",
+            "pyEPR-quantum>=0.9.5",
+        ]
+        fem = [
+            "gmsh>=4.11.1",
+        ]
+        full = [
+            "pyside6>=6.8",
+            "qdarkstyle>=3.1",
+            "pyaedt>=0.21,<0.24",
+            "pyEPR-quantum>=0.9.5",
+            "gmsh>=4.11.1",
+        ]
 
 [build-system]
     requires      = [ "uv_build>=0.9.23,<0.10.0" ]

--- a/src/qiskit_metal/__init__.py
+++ b/src/qiskit_metal/__init__.py
@@ -51,14 +51,40 @@ if os.name == 'nt':
 
 ###########################################################################
 ### Basic Setups
-## Setup Qt
-def __setup_Qt_backend():  # pylint: disable=invalid-name
-    """Setup matplotlib to use Qt6's visualization.
+## Qt backend setup is now opt-in.
+##
+## Historically this module always called ``__setup_Qt_backend()`` at
+## import time, which forced ``import qiskit_metal`` to drag in PySide6
+## (PyQt6) and switch matplotlib's backend to ``QtAgg``. That's the
+## right behavior for users running the desktop ``MetalGUI``, but it
+## broke headless / Jupyter / Colab / Binder workflows where PySide6
+## either isn't installed or shouldn't be used.
+##
+## The function is still here (renamed and public as
+## ``setup_qt_backend``), but is no longer called on import. It is
+## invoked automatically by ``MetalGUI.__init__`` so users running the
+## desktop GUI don't have to think about it. Headless users — the
+## ``qm.view(design)`` path — never trigger it.
 
-    This function needs to remain in the __init__ of the library's root
-    to prevent Qt windows from hanging.
+_qt_backend_initialized = False
+
+
+def setup_qt_backend():
+    """Configure Qt application attributes and switch matplotlib to
+    the ``QtAgg`` backend.
+
+    Idempotent — safe to call multiple times; subsequent calls are
+    no-ops. Called automatically by ``MetalGUI.__init__``. End users
+    rarely need to call this directly.
+
+    Set the ``QISKIT_METAL_HEADLESS`` environment variable to any
+    non-empty value to skip the matplotlib-backend switch (useful in
+    test runners and CI).
     """
-    # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel,global-statement
+    global _qt_backend_initialized
+    if _qt_backend_initialized:
+        return
 
     # When in vscode and in debug-mode, may want to comment
     # next line out, "os.environ["QT_API"] = "pyside2""
@@ -68,60 +94,27 @@ def __setup_Qt_backend():  # pylint: disable=invalid-name
     from PySide6.QtCore import Qt
 
     def set_attribute(name: str, value=True):
-        """Describes attributes that change the behavior of application-wide
-        features."""
+        """Describes attributes that change the behavior of
+        application-wide features."""
         if hasattr(Qt, name):
-            # Does Qt have this attribute
             attr = getattr(Qt, name)
             if not QtCore.QCoreApplication.testAttribute(attr) == value:
-                # Only set if not already set
                 QtCore.QCoreApplication.setAttribute(attr, value)
 
-    if 1:
-
-        if QtCore.QCoreApplication.instance() is None:
-            # No application launched yet
-
-            # zkm: The following seems to fix warning.
-            # For example if user ran %gui qt already.
-            #  Qt WebEngine seems to be initialized from a plugin.
-            # Please set Qt::AA_ShareOpenGLContexts using QCoreApplication::setAttribute
-            #  before constructing QGuiApplication.
-            # https://stackoverflow.com/questions/56159475/qt-webengine-seems-to-be-initialized
-            # Enables resource sharing between the OpenGL contexts used by classes
-            #  like QOpenGLWidget and QQuickWidget.
-            # Has to do with render mode 'gles'. There is also desktop and software.
-            # QCoreApplication.setAttribute(QtCore.Qt.AA_UseOpenGLES)
-            # QCoreApplication.setAttribute(QtCore.Qt.AA_ShareOpenGLContexts)
-            # QCoreApplication.setAttribute(QtCore.Qt.AA_DisableShaderDiskCache)
-            set_attribute('AA_ShareOpenGLContexts')
-
-            # Enables high-DPI scaling in Qt on supported platforms (see also High DPI Displays).
-            # Supported platforms are X11, Windows and Android.
-            # Enabling makes Qt scale the main (device independent) coordinate
-            # system according to display scale factors provided by the
-            # operating system.
-            set_attribute('AA_EnableHighDpiScaling')
-
-            # Make QIcon::pixmap() generate high-dpi pixmaps that can be larger than
-            #  the requested size.
-            set_attribute('AA_UseHighDpiPixmaps')
-
-            # Other options of interest:
-            # AA_DontUseNativeMenuBar
-            # AA_MacDontSwapCtrlAndMeta
+    if QtCore.QCoreApplication.instance() is None:
+        # No application launched yet — set the global attributes
+        # before the first QApplication is constructed.
+        set_attribute('AA_ShareOpenGLContexts')
+        set_attribute('AA_EnableHighDpiScaling')
+        set_attribute('AA_UseHighDpiPixmaps')
 
     if not os.getenv('QISKIT_METAL_HEADLESS', None):
-        # pylint: disable=import-outside-toplevel
         import matplotlib as mpl
         mpl.use("QtAgg")
-        # pylint: disable=redefined-outer-name
         import matplotlib.pyplot as plt
         plt.ion()  # interactive
 
-
-__setup_Qt_backend()
-del __setup_Qt_backend
+    _qt_backend_initialized = True
 
 ## Setup logging
 from qiskit_metal import config
@@ -153,12 +146,27 @@ from qiskit_metal import analyses
 from qiskit_metal import toolbox_python
 from qiskit_metal import toolbox_metal
 
-# Metal GUI
-from qiskit_metal._gui.main_window import MetalGUI
+# Metal GUI and the matplotlib plotting helper are lazy attributes —
+# importing them eagerly pulls in PySide6 (via ``_gui.main_window``)
+# and Qt-tainted matplotlib helpers (via ``mpl_interaction``). For
+# headless users running ``qm.view(design)`` from a script or Jupyter
+# notebook, this means ``import qiskit_metal`` no longer requires
+# PySide6 to be installed.
+#
+# Access via ``qm.MetalGUI`` or ``qm.plt`` — both work as before, but
+# only trigger the heavy import on first use.
 
-# Utility modules
-# For plotting in matplotlib;  May be superseded by a renderer?
-from qiskit_metal.renderers.renderer_mpl import mpl_toolbox as plt
+
+def __getattr__(name):  # pylint: disable=inconsistent-return-statements
+    if name == "MetalGUI":
+        # pylint: disable=import-outside-toplevel
+        from qiskit_metal._gui.main_window import MetalGUI
+        return MetalGUI
+    if name == "plt":
+        # pylint: disable=import-outside-toplevel
+        from qiskit_metal.renderers.renderer_mpl import mpl_toolbox
+        return mpl_toolbox
+    raise AttributeError(f"module 'qiskit_metal' has no attribute {name!r}")
 
 # Utility functions
 from qiskit_metal.toolbox_python.display import Headings

--- a/src/qiskit_metal/__init__.py
+++ b/src/qiskit_metal/__init__.py
@@ -169,3 +169,6 @@ from qiskit_metal.renderers import setup_renderers
 # Common-use
 from qiskit_metal.qlibrary import QComponent
 from qiskit_metal.toolbox_metal.about import about, open_docs
+
+# Headless matplotlib viewer (``qm.view(design)``) — no Qt required.
+from qiskit_metal.viewer import view

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -308,6 +308,12 @@ class MetalGUI(QMainWindowBaseHandler):
                 design. Defaults to None.
         """
 
+        # Qt backend setup used to run at ``import qiskit_metal`` time;
+        # it's now lazy, called the first time MetalGUI is instantiated.
+        # Idempotent — second and later calls are no-ops.
+        from qiskit_metal import setup_qt_backend
+        setup_qt_backend()
+
         from .utility._handle_qt_messages import QtCore, _qt_message_handler
         QtCore.qInstallMessageHandler(_qt_message_handler)
 

--- a/src/qiskit_metal/designs/design_base.py
+++ b/src/qiskit_metal/designs/design_base.py
@@ -976,26 +976,45 @@ class QDesign():
                 )
                 continue
 
-            # check if module_name exists
-            if importlib.util.find_spec(path_name):
-                class_renderer = getattr(importlib.import_module(path_name),
-                                         class_name, None)
-
-                # check if class_name is in module
-                if class_renderer is not None:
-                    a_renderer = class_renderer(self, initiate=False)
-
-                    # register renderers here.
-                    self._renderers[renderer_key] = a_renderer
-                else:
-                    self.logger.warning(
-                        f'Renderer={renderer_key} is not registered in QDesign.  '
-                        f'The class_name={class_name} was not found.')
-                    continue
-            else:
+            # check if module_name exists AND can actually be loaded.
+            # ``find_spec`` only checks that the file is importable as
+            # a Python module — it succeeds for ``renderer_gmsh`` even
+            # when the external ``gmsh`` package isn't installed.
+            # ``import_module`` can then raise ImportError for the
+            # missing transitive dep. Catching that here lets a
+            # lite-install user create a design without having every
+            # optional renderer's heavy deps; the renderer just gets
+            # logged and skipped.
+            if not importlib.util.find_spec(path_name):
                 self.logger.warning(
                     f'Renderer={renderer_key} is not registered in QDesign.  '
                     f'The module_name={path_name} was not found.')
+                continue
+
+            try:
+                module = importlib.import_module(path_name)
+            except ImportError as e:
+                self.logger.info(
+                    f'Renderer={renderer_key} skipped: '
+                    f'an optional dependency for {path_name} is not '
+                    f'installed ({e}). Install the corresponding extra '
+                    f'(e.g. `pip install quantum-metal[fem]` for gmsh, '
+                    f'`pip install quantum-metal[ansys]` for pyaedt) '
+                    f'to enable it.')
+                continue
+
+            class_renderer = getattr(module, class_name, None)
+
+            # check if class_name is in module
+            if class_renderer is not None:
+                a_renderer = class_renderer(self, initiate=False)
+
+                # register renderers here.
+                self._renderers[renderer_key] = a_renderer
+            else:
+                self.logger.warning(
+                    f'Renderer={renderer_key} is not registered in QDesign.  '
+                    f'The class_name={class_name} was not found.')
                 continue
 
         for _, a_render in self._renderers.items():

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
@@ -86,9 +86,31 @@ import warnings
 import matplotlib.pyplot as _plt
 import numpy
 
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QIcon, QAction
-from PySide6.QtWidgets import QLabel
+# PySide6 is required only for the interactive toolbar features in
+# this module (``MplInteraction._init_toolbar``, ``figure_pz``). It is
+# NOT required to import this module. Wrapping the imports in
+# ``try/except`` lets ``import qiskit_metal`` succeed in Jupyter /
+# Colab / Binder / headless CI environments where PySide6 isn't
+# installed; callers that hit the GUI path get a clear ImportError
+# from ``_require_qt`` instead of a confusing top-of-module crash.
+try:
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QIcon, QAction
+    from PySide6.QtWidgets import QLabel
+    _PYSIDE6_AVAILABLE = True
+except ImportError:  # pragma: no cover — exercised only on lite installs
+    Qt = QIcon = QAction = QLabel = None
+    _PYSIDE6_AVAILABLE = False
+
+
+def _require_qt(feature: str) -> None:
+    """Raise a helpful ImportError if PySide6 isn't installed."""
+    if not _PYSIDE6_AVAILABLE:
+        raise ImportError(
+            f"{feature} requires PySide6. Install it with "
+            f"`pip install pyside6` (or `pip install "
+            f"quantum-metal[gui]` once the GUI extra ships).")
+
 
 from qiskit_metal import Dict
 
@@ -699,16 +721,17 @@ class PanAndZoom(ZoomOnWheel):
 
 
 def figure_pz(*args, **kwargs):
-    """matplotlib.pyplot.figure with pan and zoom interaction."""
-    #import warnings
-    # warnings.filterwarnings(action='ignore')
+    """matplotlib.pyplot.figure with pan and zoom interaction.
+
+    Requires PySide6 because the pan/zoom toolbar is a Qt widget.
+    For a Qt-free alternative, see :func:`qiskit_metal.view`.
+    """
+    _require_qt("figure_pz")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         fig = _plt.figure(*args, **kwargs)
     fig.pan_zoom = PanAndZoom(fig)
-
-    # warnings.resetwarnings()
 
     return fig
 

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
@@ -42,20 +42,43 @@ to_poly_patch = np.vectorize(PolygonPatch)
 class QMplRenderer:
     """Matplotlib renderer for Metal designs.
 
-    Notes:
-        Access via ``gui.canvas.metal_renderer``. The axis to render is passed
-        in the ``render`` method.
+    Can be used in two ways:
+
+    1. **Standalone (no Qt):** ``QMplRenderer(design)`` — produces a
+       renderer that plots into any matplotlib ``Axes`` passed to
+       :meth:`render`. This is the path used by
+       :func:`qiskit_metal.view` and by tutorials that want to display
+       a design inline in a Jupyter notebook with no GUI.
+
+    2. **Inside the Qt MetalGUI:** ``QMplRenderer(design, canvas=plot_canvas)``
+       — the desktop GUI's :class:`PlotCanvas` instantiates this way to
+       wire the renderer to its embedded matplotlib figure. The
+       ``canvas`` argument is stored on ``self.canvas`` for callers
+       that need it, but no method in this class uses it directly.
+
+    The ``ax`` to render into is still passed explicitly to
+    :meth:`render` — neither construction path implies a fixed axes.
     """
 
-    def __init__(self, canvas: "PlotCanvas", design: QDesign, logger: logging.Logger):
+    def __init__(
+        self,
+        design: QDesign,
+        *,
+        canvas: Optional["PlotCanvas"] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
         """
         Args:
-            canvas (PlotCanvas): The canvas
-            design (QDesign): The design
-            logger (logging.Logger): The logger
+            design: The design to render. Required.
+            canvas: Optional Qt ``PlotCanvas`` (legacy path used by
+                :class:`MetalGUI`). Pass ``None`` for a standalone /
+                headless renderer.
+            logger: Optional logger. Falls back to a module-level
+                logger if ``None``.
         """
         super().__init__()
-        self.logger = logger
+        self.logger = logger if logger is not None else logging.getLogger(
+            "qiskit_metal.renderer_mpl")
         self.canvas = canvas
         self.ax = None
         self.design = design
@@ -158,8 +181,13 @@ class QMplRenderer:
         # TODO: Ideally these should be replaced with interface functions,
         # not direct access to underlying internal representation
 
-        mask = table.layer.isin(self.hidden_layers)
-        mask = table.component.isin(self._hidden_components)
+        # A row is hidden if its layer is in ``hidden_layers`` OR its
+        # component is in ``_hidden_components``. The previous form
+        # rebuilt ``mask`` from scratch on the second line, silently
+        # discarding the ``hidden_layers`` filter — visible from the
+        # Qt GUI only when a user hid both at once.
+        mask = (table.layer.isin(self.hidden_layers)
+                | table.component.isin(self._hidden_components))
 
         return ~mask  # not
 

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
@@ -296,7 +296,13 @@ class QMplRenderer:
             if len(table1) > 0:
                 table1["geometry"] = table1[["geometry", "width"]].apply(
                     lambda x: x.iloc[0].buffer(
-                        distance=float(x[1]) / 2.0,
+                        # ``x.iloc[1]`` (was ``x[1]``) — in pandas
+                        # 2.2+, integer indexing on a Series with
+                        # string labels raises KeyError rather than
+                        # falling back to positional lookup. The row
+                        # here has labels ``['geometry', 'width']``
+                        # so positional access must be explicit.
+                        distance=float(x.iloc[1]) / 2.0,
                         cap_style=CAP_STYLE.flat,
                         join_style=JOIN_STYLE.mitre,
                         quad_segs=int(self.options["resolution"]),

--- a/src/qiskit_metal/viewer/__init__.py
+++ b/src/qiskit_metal/viewer/__init__.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Headless matplotlib viewer for Quantum Metal designs.
+
+Exposes :func:`view`, a one-line entry point that returns a matplotlib
+:class:`~matplotlib.figure.Figure` populated with every component's
+geometry. No Qt, no :class:`~qiskit_metal._gui.main_window.MetalGUI`;
+works in plain Python, Jupyter notebooks, headless CI, Binder, Colab.
+
+The viewer reuses :class:`~qiskit_metal.renderers.renderer_mpl.mpl_renderer.QMplRenderer`
+internally — same rendering logic the Qt GUI uses — but in standalone
+mode (no Qt canvas).
+
+Example
+-------
+
+>>> import qiskit_metal as qm
+>>> from qiskit_metal.designs import DesignPlanar
+>>> from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+>>> design = DesignPlanar()
+>>> TransmonPocket(design, 'Q1', options={'connection_pads': {'a': {}}})
+>>> fig = qm.view(design)
+>>> fig.savefig('q1.png')
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+
+from .view import view
+
+__all__ = ["view"]

--- a/src/qiskit_metal/viewer/view.py
+++ b/src/qiskit_metal/viewer/view.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Implementation of :func:`qiskit_metal.viewer.view`."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Tuple
+
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from qiskit_metal.designs import QDesign
+from qiskit_metal.renderers.renderer_mpl.mpl_renderer import QMplRenderer
+
+
+def view(
+    design: QDesign,
+    ax: Optional[Axes] = None,
+    *,
+    figsize: Tuple[float, float] = (8.0, 8.0),
+    components: Optional[Iterable[str]] = None,
+    hidden_layers: Optional[Iterable[int]] = None,
+    title: Optional[str] = None,
+) -> Figure:
+    """Render ``design`` to a matplotlib :class:`~matplotlib.figure.Figure`.
+
+    Headless replacement for the Qt :class:`MetalGUI` plot panel for
+    use in scripts, Jupyter notebooks, and cloud notebook environments
+    where Qt isn't available or wanted. Returns the populated
+    :class:`Figure` so callers can save, embed in subplots, or further
+    customise it.
+
+    Parameters
+    ----------
+    design : QDesign
+        The design to render.
+    ax : matplotlib.axes.Axes, optional
+        If provided, render into this axes. Otherwise a new
+        ``Figure`` / ``Axes`` pair of size ``figsize`` is created.
+    figsize : tuple of (float, float), default (8.0, 8.0)
+        Size of the new ``Figure`` in inches. Ignored when ``ax`` is
+        given.
+    components : iterable of str, optional
+        If given, render only these named components. By default,
+        every component in the design is rendered.
+    hidden_layers : iterable of int, optional
+        Layer numbers to hide from the rendering.
+    title : str, optional
+        If given, set as the axes title.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+        The figure containing the rendered design. If ``ax`` was
+        provided, this is ``ax.figure``; otherwise it's the newly
+        created figure.
+
+    Examples
+    --------
+    Simplest usage — render and save::
+
+        import qiskit_metal as qm
+        from qiskit_metal.designs import DesignPlanar
+        from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+
+        design = DesignPlanar()
+        TransmonPocket(design, "Q1",
+                       options={"connection_pads": {"a": {}}})
+
+        fig = qm.view(design)
+        fig.savefig("q1.png")
+
+    Render into an existing axes for a multi-panel figure::
+
+        import matplotlib.pyplot as plt
+        fig, axes = plt.subplots(1, 2, figsize=(12, 6))
+        qm.view(design_a, ax=axes[0], title="Design A")
+        qm.view(design_b, ax=axes[1], title="Design B")
+
+    Render only one component out of a larger design::
+
+        qm.view(design, components=["Q1"])
+    """
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    renderer = QMplRenderer(design=design)
+
+    if hidden_layers is not None:
+        renderer.hidden_layers = set(hidden_layers)
+
+    if components is not None:
+        requested = set(components)
+        # ``design.components`` maps name -> QComponent. Hide every
+        # component whose name isn't in the requested set.
+        hidden_ids = {
+            c.id for name, c in design.components.items()
+            if name not in requested
+        }
+        renderer._hidden_components = hidden_ids
+
+    ax.set_aspect("equal")
+    renderer.render(ax)
+    ax.autoscale_view()
+    # Add a small margin so geometry doesn't sit flush against the edge.
+    ax.margins(0.05)
+
+    if title is not None:
+        ax.set_title(title)
+
+    return fig

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Tests for :func:`qiskit_metal.view` — the headless matplotlib viewer.
+
+The viewer is the no-Qt path for rendering designs (Jupyter, Binder,
+Colab, scripts, CI). These tests pin both the API surface and
+behavior expected by tutorials and downstream users.
+
+The matplotlib backend is forced to ``Agg`` (non-interactive, no
+display) before any matplotlib import so the suite works on headless
+CI runners without an X server.
+"""
+
+import io
+import unittest
+
+import matplotlib
+matplotlib.use("Agg")  # noqa: E402  must run before pyplot import below
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from qiskit_metal import Dict, designs, view
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+from qiskit_metal.qlibrary.sample_shapes.rectangle import Rectangle
+from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+from qiskit_metal.renderers.renderer_mpl.mpl_renderer import QMplRenderer
+
+
+def _make_design_with_two_components():
+    design = designs.DesignPlanar()
+    TransmonPocket(design, "Q1",
+                   options=Dict(connection_pads=Dict(a=Dict())))
+    OpenToGround(design, "G1")
+    return design
+
+
+def _render_to_png_bytes(fig) -> bytes:
+    """Save ``fig`` to PNG bytes — used for comparing two renders for
+    pixel-level inequality without caring about artist structure."""
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=60)
+    return buf.getvalue()
+
+
+class TestViewerStandalone(unittest.TestCase):
+    """``qm.view(design)`` produces a valid matplotlib Figure with no
+    Qt dependency. All tests run with the ``Agg`` backend — if any
+    code path reaches for Qt at render time the test fails."""
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_view_returns_figure_with_default_args(self):
+        """The no-args call returns a Figure, not None / not an Axes."""
+        design = _make_design_with_two_components()
+        fig = view(design)
+        self.assertIsInstance(fig, Figure)
+
+    def test_view_into_existing_axes(self):
+        """When ``ax`` is passed, the returned Figure is ``ax.figure``
+        and no new figure is created."""
+        design = _make_design_with_two_components()
+        fig, ax = plt.subplots(figsize=(6, 6))
+        n_before = len(plt.get_fignums())
+        returned = view(design, ax=ax)
+        n_after = len(plt.get_fignums())
+        self.assertIs(returned, fig)
+        self.assertEqual(n_before, n_after,
+                         "view(ax=...) must not create a new Figure")
+
+    def test_view_respects_figsize(self):
+        """The new Figure is created at the requested size."""
+        design = _make_design_with_two_components()
+        fig = view(design, figsize=(4.0, 3.0))
+        self.assertAlmostEqual(fig.get_figwidth(), 4.0, places=3)
+        self.assertAlmostEqual(fig.get_figheight(), 3.0, places=3)
+
+    def test_view_empty_design_does_not_error(self):
+        """Calling ``view`` on a design with zero components must not
+        raise — a blank canvas is a valid result (matches what GUI
+        users see when they start a new project)."""
+        design = designs.DesignPlanar()
+        fig = view(design)
+        self.assertIsInstance(fig, Figure)
+
+    def test_view_aspect_is_equal(self):
+        """Designs must render with ``aspect=equal`` — otherwise pads
+        and pockets look stretched and users misjudge geometry."""
+        design = _make_design_with_two_components()
+        fig = view(design)
+        ax = fig.axes[0]
+        # matplotlib returns 'equal' or a float for the data aspect.
+        aspect = ax.get_aspect()
+        self.assertTrue(aspect == "equal" or aspect == 1.0,
+                        f"Expected equal aspect, got {aspect!r}")
+
+    def test_view_filters_to_named_components(self):
+        """``components=[name]`` must hide all components not in the
+        list. We verify by comparing the *image bytes* of the
+        filtered vs unfiltered render — they must differ. Counting
+        matplotlib artists isn't a viable check because both
+        renders use the same ``PatchCollection`` batching; a single
+        ``PatchCollection`` may hold geometry from many components.
+        """
+        design = _make_design_with_two_components()
+        png_all = _render_to_png_bytes(view(design, figsize=(4, 4)))
+        png_filtered = _render_to_png_bytes(
+            view(design, components=["Q1"], figsize=(4, 4)))
+        self.assertNotEqual(
+            png_all, png_filtered,
+            "Filtering to one component should produce a different "
+            "image than rendering all components.")
+
+    def test_view_filters_with_unknown_component_name(self):
+        """An unknown name in ``components`` shouldn't crash — it just
+        produces an empty filter (everything hidden) which is still a
+        valid empty render."""
+        design = _make_design_with_two_components()
+        fig = view(design, components=["does_not_exist"])
+        self.assertIsInstance(fig, Figure)
+
+    def test_view_hides_layers(self):
+        """``hidden_layers={N}`` must suppress geometry on layer N.
+        We verify by comparing image bytes of all-visible vs
+        layer-hidden renders — they must differ when layer 1 (which
+        contains every default-options component's geometry) is
+        hidden.
+        """
+        design = _make_design_with_two_components()
+        png_all = _render_to_png_bytes(view(design, figsize=(4, 4)))
+        png_hidden = _render_to_png_bytes(
+            view(design, hidden_layers={1}, figsize=(4, 4)))
+        self.assertNotEqual(
+            png_all, png_hidden,
+            "Hiding layer 1 should produce a different image than "
+            "rendering with all layers visible.")
+
+    def test_view_sets_title_when_given(self):
+        design = _make_design_with_two_components()
+        fig = view(design, title="My beautiful design")
+        self.assertEqual(fig.axes[0].get_title(), "My beautiful design")
+
+    def test_view_savefig_roundtrip(self):
+        """Sanity check — the returned Figure can be saved to PNG bytes
+        without error. This is the common Jupyter / CI artifact path."""
+        design = _make_design_with_two_components()
+        fig = view(design, figsize=(4, 4))
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=72)
+        self.assertGreater(buf.tell(), 0)
+
+
+class TestQMplRendererStandalone(unittest.TestCase):
+    """``QMplRenderer(design)`` must work with no ``canvas`` arg."""
+
+    def tearDown(self):
+        plt.close("all")
+
+    def test_constructs_without_canvas(self):
+        """The standalone constructor must accept just ``design`` and
+        not require a Qt PlotCanvas."""
+        design = designs.DesignPlanar()
+        renderer = QMplRenderer(design=design)
+        self.assertIsNone(renderer.canvas)
+        self.assertIs(renderer.design, design)
+
+    def test_render_accepts_arbitrary_axes(self):
+        """``render(ax)`` must accept any matplotlib Axes — not just
+        one that came from a Qt canvas."""
+        design = designs.DesignPlanar()
+        Rectangle(design, "R1")
+        renderer = QMplRenderer(design=design)
+        fig, ax = plt.subplots()
+        renderer.render(ax)  # must not raise
+
+    def test_legacy_canvas_keyword_still_accepted(self):
+        """The legacy Qt call site uses ``QMplRenderer(canvas=...,
+        design=..., logger=...)``. Confirm that signature still works
+        so we don't break ``mpl_canvas.PlotCanvas``."""
+        # We pass a placeholder object — the renderer stores it on
+        # self.canvas but never calls anything on it (verified by
+        # grep). Using object() is safer than mocking PlotCanvas
+        # (which would pull in PySide6 at test time).
+        design = designs.DesignPlanar()
+        sentinel = object()
+        renderer = QMplRenderer(design=design, canvas=sentinel)
+        self.assertIs(renderer.canvas, sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb
+++ b/tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Headless Quick View — using Quantum Metal without the Qt GUI\n",
+    "\n",
+    "This notebook shows how to design and **view** components in Quantum Metal **without launching the Qt desktop GUI**. The full API works headlessly in a plain Python interpreter or in cloud notebook environments like Jupyter, Colab, and Binder where Qt isn't available or wanted.\n",
+    "\n",
+    "## What you'll learn\n",
+    "\n",
+    "1. How to build a design programmatically — same API as the GUI workflow\n",
+    "2. How to use `qm.view(design)` to render a design to a matplotlib figure inline\n",
+    "3. How to customise the view: filter components, hide layers, render into existing axes\n",
+    "4. How to save the rendered design to a file\n",
+    "\n",
+    "## When to use this workflow\n",
+    "\n",
+    "- You're running on a server / cloud notebook (Colab, Binder, JupyterHub) where PySide6 isn't installed.\n",
+    "- You're scripting a parameter sweep and just want to verify the geometry looks right.\n",
+    "- You're embedding Quantum Metal in a larger pipeline (CI, automated optimization, papers/figures).\n",
+    "\n",
+    "If you want the **interactive editor** with click-to-select components, dockable panels, and live option editing, use `qm.MetalGUI(design)` instead. That requires a local installation with PySide6."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "We force matplotlib's `Agg` backend before any plot calls so the notebook works on headless runners. In a normal Jupyter session you can skip this — Jupyter picks an inline-friendly backend automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "matplotlib.use(\"Agg\")  # only needed when not in Jupyter\n",
+    "\n",
+    "import qiskit_metal as qm\n",
+    "from qiskit_metal import Dict\n",
+    "from qiskit_metal.designs import DesignPlanar\n",
+    "from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket\n",
+    "from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a small design programmatically\n",
+    "\n",
+    "Same API as the GUI workflow — no Qt window is created."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "design = DesignPlanar()\n",
+    "\n",
+    "# A transmon qubit with one coupling pad\n",
+    "TransmonPocket(\n",
+    "    design,\n",
+    "    \"Q1\",\n",
+    "    options=Dict(\n",
+    "        pos_x=\"0mm\",\n",
+    "        pos_y=\"0mm\",\n",
+    "        connection_pads=Dict(\n",
+    "            a=Dict(loc_W=\"+1\", loc_H=\"+1\"),\n",
+    "        ),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# A ground termination next to it\n",
+    "OpenToGround(\n",
+    "    design,\n",
+    "    \"G1\",\n",
+    "    options=Dict(pos_x=\"1mm\", pos_y=\"0mm\"),\n",
+    ")\n",
+    "\n",
+    "print(\"Components in design:\", list(design.components.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## View the design\n",
+    "\n",
+    "`qm.view(design)` returns a `matplotlib.figure.Figure`. In Jupyter it will display inline; you can also save it or further customise it like any other matplotlib figure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = qm.view(design)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Customising the view\n",
+    "\n",
+    "### Filter to specific components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = qm.view(design, components=[\"Q1\"], title=\"Q1 only\")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom figure size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = qm.view(design, figsize=(6, 4))\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Side-by-side in a multi-panel figure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "qm.view(design, ax=axes[0], title=\"Full design\")\n",
+    "qm.view(design, ax=axes[1], components=[\"Q1\"], title=\"Just Q1\")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save to a file\n",
+    "\n",
+    "Any `matplotlib.figure.Figure` method works — `savefig` to PNG/PDF/SVG, embed in a paper, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = qm.view(design)\n",
+    "fig.savefig(\"my_design.png\", dpi=150, bbox_inches=\"tight\")\n",
+    "print(\"Saved my_design.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What about HFSS / Q3D / GDS?\n",
+    "\n",
+    "All non-Qt renderers work headlessly too:\n",
+    "\n",
+    "- **GDS export** — `QGDSRenderer(design).export_to_gds(\"out.gds\")` works without Qt.\n",
+    "- **HFSS / Q3D** — the *renderer* doesn't require Qt, but it does require Ansys AEDT installed on the machine running the script. On a cloud notebook without Ansys, you can still build the design and export GDS / visualise with `qm.view`; you just can't run the live solve.\n",
+    "- **Analyses** — every module in `qiskit_metal.analyses` is pure Python (numpy / scipy / qutip) and works headlessly.\n",
+    "\n",
+    "## Next steps\n",
+    "\n",
+    "- See `docs/headless-usage.rst` for the full reference.\n",
+    "- See the [1.2 Quick start](./1.2%20Quick%20start.ipynb) notebook for a tour of the GUI-driven workflow.\n",
+    "- For interactive pan/zoom in Jupyter without Qt, install `ipympl` and run `%matplotlib widget` at the top of your notebook."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/uv.lock
+++ b/uv.lock
@@ -2773,6 +2773,26 @@ dependencies = [
     { name = "shapely" },
 ]
 
+[package.optional-dependencies]
+ansys = [
+    { name = "pyaedt" },
+    { name = "pyepr-quantum" },
+]
+fem = [
+    { name = "gmsh" },
+]
+full = [
+    { name = "gmsh" },
+    { name = "pyaedt" },
+    { name = "pyepr-quantum" },
+    { name = "pyside6" },
+    { name = "qdarkstyle" },
+]
+gui = [
+    { name = "pyside6" },
+    { name = "qdarkstyle" },
+]
+
 [package.dev-dependencies]
 docs = [
     { name = "nbsphinx" },
@@ -2806,21 +2826,32 @@ requires-dist = [
     { name = "gdstk", specifier = ">=0.9" },
     { name = "geopandas", specifier = ">=1.0" },
     { name = "gmsh", specifier = ">=4.11.1" },
+    { name = "gmsh", marker = "extra == 'fem'", specifier = ">=4.11.1" },
+    { name = "gmsh", marker = "extra == 'full'", specifier = ">=4.11.1" },
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.24.2,<2" },
     { name = "pandas", specifier = ">=2.1.1" },
     { name = "pint", specifier = ">=0.21.0" },
     { name = "pyaedt", specifier = ">=0.21,<0.24" },
+    { name = "pyaedt", marker = "extra == 'ansys'", specifier = ">=0.21,<0.24" },
+    { name = "pyaedt", marker = "extra == 'full'", specifier = ">=0.21,<0.24" },
     { name = "pyepr-quantum", specifier = ">=0.9.5" },
+    { name = "pyepr-quantum", marker = "extra == 'ansys'", specifier = ">=0.9.5" },
+    { name = "pyepr-quantum", marker = "extra == 'full'", specifier = ">=0.9.5" },
     { name = "pygments", specifier = ">=2.14.0" },
     { name = "pyside6", specifier = ">=6.8" },
+    { name = "pyside6", marker = "extra == 'full'", specifier = ">=6.8" },
+    { name = "pyside6", marker = "extra == 'gui'", specifier = ">=6.8" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qdarkstyle", specifier = ">=3.1" },
+    { name = "qdarkstyle", marker = "extra == 'full'", specifier = ">=3.1" },
+    { name = "qdarkstyle", marker = "extra == 'gui'", specifier = ">=3.1" },
     { name = "qutip", specifier = ">=5.0.0" },
     { name = "scipy", specifier = ">=1.10.0" },
     { name = "scqubits", specifier = ">=4.1.0" },
     { name = "shapely", specifier = ">=2.0.1" },
 ]
+provides-extras = ["gui", "ansys", "fem", "full"]
 
 [package.metadata.requires-dev]
 docs = [


### PR DESCRIPTION
## Summary

Complete tier-2 of the maintenance plan: a headless, Qt-free path for rendering Quantum Metal designs. After this PR:

```python
import qiskit_metal as qm
from qiskit_metal.designs import DesignPlanar
from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket

design = DesignPlanar()
TransmonPocket(design, "Q1", options={"connection_pads": {"a": {}}})

fig = qm.view(design)        # matplotlib.figure.Figure — no Qt
fig.savefig("q1.png")
```

works in Jupyter / Colab / Binder / scripts / CI **with PySide6 not installed**. Verified by a new CI job (`tests-lite`) that builds a venv without `pyside6`, `pyaedt`, or `gmsh` and runs the full no-Qt test suite.

## Commits (4)

### 1. `feat`: add `qm.view(design)` — standalone matplotlib viewer

- New `qiskit_metal.viewer` subpackage with `view(design, ax=None, *, figsize, components, hidden_layers, title) -> Figure`. Re-exported at the top level as `qm.view`.
- `QMplRenderer.__init__` becomes `(design, *, canvas=None, logger=None)` — `canvas` is now optional. Existing Qt call site uses keywords so backward-compat is preserved.
- 13 new tests in `tests/test_viewer.py` (force `matplotlib.use("Agg")` so they work on headless CI). Cover return type, axes injection, figsize, empty design, aspect ratio, component filter, layer hide, title, savefig roundtrip, standalone renderer construction, legacy keyword signature.
- **Drive-by bug fix in `QMplRenderer.get_mask`**: the previous form rebuilt `mask` from scratch on its second line, silently discarding the `hidden_layers` filter when combined with hidden components. Now ORs the two masks.

### 2. `refactor`: make Qt initialization lazy

`import qiskit_metal` no longer requires PySide6:
- `__setup_Qt_backend` no longer called at module load. Renamed to public `setup_qt_backend` (idempotent), called automatically by `MetalGUI.__init__`.
- `MetalGUI` and `plt` are PEP-562 lazy attributes on the top-level module. First access of `qm.MetalGUI` or `qm.plt` triggers the import.
- `mpl_interaction.py` PySide6 imports are wrapped in `try/except ImportError`. The one Qt-using entry point (`figure_pz`) gates with `_require_qt()` and raises a clear ImportError if PySide6 is missing.

Verified by blocking PySide6 via `sys.meta_path`:

```
OK: import qiskit_metal succeeded without PySide6
OK: qm.view(design) works without PySide6
OK: qm.MetalGUI access raises ImportError as expected
```

### 3. `feat`: add `[gui]`/`[ansys]`/`[fem]`/`[full]` extras + `tests-lite` CI gate

- `pyproject.toml` gains `[project.optional-dependencies]`:
  - `gui`: pyside6, qdarkstyle
  - `ansys`: pyaedt, pyEPR-quantum
  - `fem`: gmsh
  - `full`: all of the above
- These are **additive in v0.6.x** — every extra's deps are also in base deps so existing `pip install quantum-metal` users keep the all-batteries-included behavior. v0.7.0 plans to flip the default.
- New `tests-lite` CI job builds a venv with the lite dep set (no pyside6, pyaedt, gmsh), confirms PySide6 is absent (`pip show` returns nonzero), smoke-imports `qiskit_metal` + calls `qm.view(design)`, and runs `test_viewer.py`, `test_qlibrary_idempotency.py`, `test_qlibrary_pin_sanity.py`, `test_solution_types.py`.

### 4. `docs+tutorial`: headless usage reference + tutorial notebook

- `docs/headless-usage.rst`: full reference for the no-Qt workflow — quick start, `qm.view` options, what works headlessly, the v0.6.x `QISKIT_METAL_HEADLESS` workaround, the v0.7.0 lite-by-default migration path, and roadmap for a future richer in-notebook viewer (Plotly / ipympl / Jupyter widgets).
- Linked from the main toctree as **"Using Quantum Metal without the Qt GUI"**.
- `tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb`: runnable end-to-end tutorial covering import → build → `qm.view` → filter → multi-panel → savefig. Executes cleanly via `jupyter nbconvert --execute`; ready for Binder/Colab once those badges land.

## What this PR is *not*

- Doesn't ship the v0.7.0 lite-by-default flip (planned, signposted in inline comments and docs).
- Doesn't ship a new interactive GUI (the "bigger project" — Plotly/ipympl/Jupyter widgets); the path is described in `headless-usage.rst` and on the roadmap.
- Doesn't change behavior for current `MetalGUI` users — Qt setup just runs one frame later (inside `MetalGUI.__init__` instead of at module import).

## Test plan

- [ ] CI green (full matrix, lint, env-consistency, coverage, **new `tests-lite` job**)
- [ ] `tests-lite` proves no top-level Qt imports remain in non-GUI code paths
- [ ] Existing GUI tests (`test_gui_basic.py`) still pass — `MetalGUI` works unchanged
- [ ] `tutorials/1 Overview/1.4 …` notebook executes cleanly end-to-end

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_