### PR TITLE
tutorials: discoverability + CI gate for the headless rendering path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -171,6 +171,28 @@ jobs:
             tests/test_qlibrary_pin_sanity.py \
             tests/test_solution_types.py \
             -v
+      - name: Execute headless tutorial notebook
+        # Gate the canonical no-Qt tutorial (1.4 Headless quick view).
+        # If a future change breaks the headless path, this step
+        # catches it before users hit it.
+        #
+        # ``uv pip install`` is used (not ``python -m pip``) because
+        # the lite venv was created by ``uv venv``, which does not
+        # ship pip inside. The kernel must be registered explicitly —
+        # nbconvert defaults to a kernel named ``python3`` that isn't
+        # tied to our venv.
+        run: |
+          uv pip install --quiet \
+            'jupyter>=1.0' 'nbconvert>=7.0' 'ipykernel>=6.0'
+          .venv/bin/python -m ipykernel install --user --name qm_lite
+          .venv/bin/jupyter nbconvert \
+            --to notebook \
+            --execute \
+            --ExecutePreprocessor.kernel_name=qm_lite \
+            --ExecutePreprocessor.timeout=180 \
+            --output-dir /tmp/exec_check \
+            'tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb'
+          echo "OK: 1.4 Headless quick view executed cleanly"
 
   coverage:
     name: coverage

--- a/tutorials/1 Overview/1.1 Bird's eye view of Qiskit Metal.ipynb
+++ b/tutorials/1 Overview/1.1 Bird's eye view of Qiskit Metal.ipynb
@@ -11,6 +11,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI` and includes screenshots of what it looks like. **The Qt GUI is optional** — the full Quantum Metal API works without it.\n",
+    "> \n",
+    "> To follow along on Colab, Binder, JupyterHub, or any headless environment, replace any `gui.rebuild()` or `gui.screenshot()` call with `qm.view(design)` to render the design inline as a matplotlib figure.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](./1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### 🌟 The Qiskit Metal Design Flow — Your 4-Step Adventure 🌟\n",
     "\n",
     "Welcome! In this short tutorial, you’ll take your very first steps in Qiskit Metal.  \n",
@@ -790,6 +803,41 @@
    "outputs": [],
    "source": [
     "# gui.main_window.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Following along without the Qt GUI\n",
+    "\n",
+    "Everything we just did works **without** `MetalGUI` — the design, components, and analyses are all Qt-free. Use `qm.view(design)` to display the design inline in any matplotlib-aware environment (Jupyter, Colab, Binder, or a plain Python script).\n",
+    "\n",
+    "Here's the headless equivalent of the workflow above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qiskit_metal as qm\n",
+    "from qiskit_metal import Dict, designs\n",
+    "from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket\n",
+    "\n",
+    "# Same design as above — no Qt needed\n",
+    "design = designs.DesignPlanar()\n",
+    "TransmonPocket(\n",
+    "    design,\n",
+    "    \"Q1\",\n",
+    "    options=Dict(connection_pads=Dict(a=Dict())),\n",
+    ")\n",
+    "\n",
+    "fig = qm.view(design)\n",
+    "fig  # inline-display in Jupyter; fig.savefig(\"...\") to write to file"
    ]
   }
  ],

--- a/tutorials/1 Overview/1.2 Quick start.ipynb
+++ b/tutorials/1 Overview/1.2 Quick start.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Following along without the Qt GUI**\n",
+    "> \n",
+    "> This Quick Start uses the desktop `MetalGUI`. If you're on Colab, Binder, JupyterHub, or running a script — anywhere the Qt GUI isn't available or wanted — substitute every `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`. The returned `matplotlib.figure.Figure` displays inline in Jupyter and can be saved with `fig.savefig(...)`.\n",
+    "> \n",
+    "> A runnable end-to-end headless version of this workflow lives in [1.4 Headless quick view](./1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For convenience, let's begin by enabling [automatic reloading of modules](https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html?highlight=autoreload) when they change."
    ]
   },
@@ -3187,6 +3198,48 @@
     "\n",
     "![image.png](attachment:image.png)\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Following along without the Qt GUI\n",
+    "\n",
+    "Every step of this Quick Start works **without** `MetalGUI`. To run on Colab, Binder, JupyterHub, or headlessly in a script, replace `gui.rebuild()` / `gui.screenshot()` with `qm.view(design)`. The Qt-free rendering path is provided by [`qiskit_metal.viewer.view`](../../docs/headless-usage.rst).\n",
+    "\n",
+    "Below is the **headless equivalent** of building the simple transmon design from the start of this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import qiskit_metal as qm\n",
+    "from qiskit_metal import Dict, designs\n",
+    "from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket\n",
+    "\n",
+    "# 1. Create a planar design\n",
+    "design = designs.DesignPlanar()\n",
+    "\n",
+    "# 2. Add a transmon with one coupling pad\n",
+    "TransmonPocket(\n",
+    "    design,\n",
+    "    \"Q1\",\n",
+    "    options=Dict(\n",
+    "        pos_x=\"0mm\",\n",
+    "        pos_y=\"0mm\",\n",
+    "        connection_pads=Dict(a=Dict(loc_W=\"+1\", loc_H=\"+1\")),\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "# 3. View — no Qt window opens; you get a matplotlib Figure\n",
+    "fig = qm.view(design)\n",
+    "fig"
    ]
   }
  ],

--- a/tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb
+++ b/tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb
@@ -112,6 +112,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Iterating on the design\n",
+    "\n",
+    "Changing a component's options is the same workflow as in the GUI — but you get a new `Figure` instead of an updated Qt canvas. Component objects are accessible by name via `design.components`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change Q1's pocket dimensions and re-render — no Qt window\n",
+    "design.components[\"Q1\"].options.pocket_width = \"800um\"\n",
+    "design.components[\"Q1\"].options.pocket_height = \"500um\"\n",
+    "design.rebuild()\n",
+    "\n",
+    "fig = qm.view(design, title=\"After resizing Q1\")\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Customising the view\n",
     "\n",
     "### Filter to specific components"
@@ -202,6 +226,25 @@
     "- See `docs/headless-usage.rst` for the full reference.\n",
     "- See the [1.2 Quick start](./1.2%20Quick%20start.ipynb) notebook for a tour of the GUI-driven workflow.\n",
     "- For interactive pan/zoom in Jupyter without Qt, install `ipympl` and run `%matplotlib widget` at the top of your notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next\n",
+    "\n",
+    "* Browse [1.1 Bird's eye view](./1.1%20Bird%27s%20eye%20view%20of%20Qiskit%20Metal.ipynb) and [1.2 Quick start](./1.2%20Quick%20start.ipynb) — they use `MetalGUI` for visualisation but every concept transfers; just replace `gui.rebuild()` with `qm.view(design)`. The GUI-screenshots in those tutorials give you a sense of what the desktop experience looks like.\n",
+    "* See the **2 From components to chip** folder for multi-qubit designs and CPW routing. The same `qm.view(design)` call works for any of them — pass `figsize=(12, 12)` for chip-scale views.\n",
+    "* For programmatic GDS export (no Qt or Ansys required), use the `QGDSRenderer`:\n",
+    "\n",
+    "  ```python\n",
+    "  from qiskit_metal.renderers.renderer_gds.gds_renderer import QGDSRenderer\n",
+    "  gds = QGDSRenderer(design)\n",
+    "  gds.export_to_gds(\"my_chip.gds\")\n",
+    "  ```\n",
+    "\n",
+    "* Read the full reference in [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for all of `qm.view`'s options, the `[gui]`/`[ansys]`/`[fem]` install extras, and the roadmap for a future richer interactive viewer."
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Tutorial refresh: makes the no-Qt rendering path discoverable from the canonical onboarding tutorials and gates it in CI. **Purely additive** — no existing notebook content is removed, no screenshots discarded, no notebooks re-executed.

## The design tension and how it was resolved

The existing tutorials (`1.1 Bird's eye view`, `1.2 Quick start`) have valuable GUI screenshots showing what the desktop `MetalGUI` looks like. Removing them weakens the GUI documentation. But new users on Colab/Binder/cloud Jupyter hit a wall when those notebooks invoke `MetalGUI`.

**Resolution: side-by-side additive callouts.** Two markdown cells per tutorial:
1. A top-of-notebook tip box ("Use `qm.view(design)` to follow along without the Qt GUI")
2. A final "Following along without the Qt GUI" section with a runnable headless equivalent of the design built earlier

Both screenshots and GUI cells stay exactly as-is. Diff is pure insertion: **101 lines added, 0 removed** across 1.1 and 1.2.

## Changes

### `1.1 Bird's eye view`
- New header callout (cell 1) with pointer to 1.4
- New "Following along without the Qt GUI" section at the end with runnable transmon-builds-and-views snippet

### `1.2 Quick start`
- Same pattern: header callout + final headless section
- Section points to `docs/headless-usage.rst` for the full reference

### `1.4 Headless quick view` — light expansion
Two cell pairs added to the existing headless tutorial:
- **"Iterating on the design"** — shows the `modify-options → rebuild → re-view` loop, the headless equivalent of editing options live in `MetalGUI`
- **"What's next"** — pointers to 1.1, 1.2, the components folder, GDS export via `QGDSRenderer`, and `docs/headless-usage.rst`

### CI gate (in `tests-lite`)
New `Execute headless tutorial notebook` step that runs `jupyter nbconvert --execute` against `1.4`. Future regressions in the headless rendering path — accidental top-level Qt imports, `qm.view` signature changes without tutorial updates — fail the build.

Implementation notes (debug points worth preserving):
- `uv pip install` (not `python -m pip`) — `uv venv` doesn't ship pip inside the venv.
- Lite venv registered as a Jupyter kernel via `python -m ipykernel install --user --name qm_lite` — without this, nbconvert defaults to a kernel named `python3` that points at whatever system Python is on the runner.
- `--ExecutePreprocessor.timeout=180` — notebook runs in ~30s locally; 180s leaves CI headroom.

## Out of scope (intentional)

- **1.3 Saving Your Chip Design** — empty (4 placeholder cells); skipped.
- **Bulk rewrite of all 40 tutorial notebooks** — high effort, low marginal value beyond the canonical 1.1 + 1.2 + dedicated 1.4.
- **Other folder tutorials (2-Components, 4-Analysis, etc.)** — those are deeper and many genuinely need HFSS. Will get the same callout treatment in a follow-up PR if needed; for now the entry-point tutorials cover the discoverability problem.

## Test plan

- [ ] CI green (full matrix, lint, env-consistency, coverage, tests-lite **including new notebook-execute step**)
- [ ] Local `jupyter nbconvert --execute` of 1.4 succeeds in a lite venv (verified pre-push)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_