### PR TITLE
test + types + tutorials: options audit, pin-direction sanity, return types, 2-folder callouts

### DIFF
--- a/src/qiskit_metal/designs/design_base.py
+++ b/src/qiskit_metal/designs/design_base.py
@@ -105,7 +105,7 @@ class QDesign():
     def __init__(self,
                  metadata: Optional[dict] = None,
                  overwrite_enabled: bool = False,
-                 enable_renderers: bool = True):
+                 enable_renderers: bool = True) -> None:
         """Create a new Metal QDesign.
 
         Args:
@@ -471,7 +471,7 @@ class QDesign():
 
         return all_net_id_removed
 
-    def delete_all_components(self):
+    def delete_all_components(self) -> None:
         """Clear all components in the design dictionary.
 
         Also clears all pins and netlist.
@@ -508,7 +508,7 @@ class QDesign():
 
         return self._qcomponent_latest_name_id[prefix]
 
-    def rebuild(self):  # remake_all_components
+    def rebuild(self) -> None:  # remake_all_components
         """Remakes all components with their current parameters."""
         for _, obj in self._components.items():  # pylint: disable=unused-variable
             obj.rebuild()

--- a/src/qiskit_metal/qlibrary/core/base.py
+++ b/src/qiskit_metal/qlibrary/core/base.py
@@ -144,8 +144,8 @@ class QComponent():
                  design: 'QDesign',
                  name: Optional[str] = None,
                  options: Optional[Dict] = None,
-                 make=True,
-                 component_template: Optional[Dict] = None):
+                 make: bool = True,
+                 component_template: Optional[Dict] = None) -> None:
         """Create a new Metal component and adds it's default_options to the
         design.
 
@@ -512,7 +512,7 @@ class QComponent():
             return 'NameInUse'
         return None
 
-    def make(self):
+    def make(self) -> None:
         """The make function implements the logic that creates the geometry
         (poly, path, etc.) from the qcomponent.options dictionary of
         parameters, and the adds them to the design, using
@@ -678,7 +678,7 @@ name='{strname}'{other_args}
 
         return full_import, body
 
-    def rebuild(self):
+    def rebuild(self) -> None:
         """Builds the QComponent.
 
         This is the main action function of a
@@ -723,7 +723,7 @@ name='{strname}'{other_args}
             )
             raise error
 
-    def delete(self):
+    def delete(self) -> None:
         """Delete the QComponent.
 
         Removes QGeometry, QPins, etc. from the design.
@@ -831,7 +831,7 @@ name='{strname}'{other_args}
             width: float,
             input_as_norm: bool = False,
             chip: Optional[str] = None,
-            gap: Optional[float] = None):  # gap defaults to 0.6 * width
+            gap: Optional[float] = None) -> None:  # gap defaults to 0.6 * width
         """Adds a pin from two points which are normal/tangent to the intended
         plane of the pin. The normal should 'point' in the direction of
         intended connection. Adds the new pin as a subdictionary to parent
@@ -1078,7 +1078,7 @@ name='{strname}'{other_args}
             helper: bool = False,
             layer: Union[int, str, None] = None,  # chip will be here
             chip: Optional[str] = None,
-            **kwargs):
+            **kwargs) -> None:
         r"""Add QGeometry.
 
         Takes any additional options in options.

--- a/src/qiskit_metal/renderers/renderer_base/renderer_base.py
+++ b/src/qiskit_metal/renderers/renderer_base/renderer_base.py
@@ -353,7 +353,7 @@ class QRenderer(ABC):
                     self.logger.warning(
                         f'col_value={col_value} not added to QDesign')
 
-    def start(self, force=False):
+    def start(self, force: bool = False) -> bool:
         """
         Call any initialization (single run) step required to setup the renderer for the first execution,
         such as connecting to some API or COM, or importing the correct material libraries, etc.
@@ -379,7 +379,7 @@ class QRenderer(ABC):
 
         return self.initiated
 
-    def stop(self):
+    def stop(self) -> bool:
         """
         Any calls that one may want to make after a rendering is complete.
         """
@@ -440,7 +440,7 @@ class QRenderer(ABC):
                ], 0  # Subset selected
 
     @abstractmethod
-    def render_design(self):
+    def render_design(self) -> None:
         """Abstract method. Must be implemented by the subclass.
         Renders all design chips and components.
         """

--- a/tests/test_default_options_completeness.py
+++ b/tests/test_default_options_completeness.py
@@ -1,0 +1,243 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Static AST audit: every ``self.options.<key>`` access in a
+``QComponent.make()`` must be a key that exists in the merged
+``default_options`` dict.
+
+This catches the silent ``KeyError`` class of bug — a component
+referencing an option name that doesn't exist in its (or its
+ancestor's) ``default_options``. At instantiation time today, that
+raises ``KeyError`` from a deep call stack; users typically blame
+their own code.  Catching it at test time gives the maintainer a
+clear signal at PR time instead.
+
+How the audit works
+-------------------
+
+For each component class:
+
+1. Parse the source file with :mod:`ast`.
+2. Walk the class body for ``make()`` and any ``make_*`` helper.
+3. Collect every static attribute / subscript access via the
+   patterns ``self.options.<name>``, ``self.options['<name>']``,
+   ``self.p.<name>``, ``self.p['<name>']``, and the same after the
+   common local aliases ``p = self.p`` and ``o = self.options``.
+4. Get the class's merged options via
+   ``cls.get_template_options(DesignPlanar())`` — same call path used
+   at runtime when the component is instantiated.
+5. Assert every collected key is in the merged set.
+
+Dynamic accesses (``self.p[name]`` where ``name`` is a variable) are
+intentionally skipped — they're the right tool for, e.g., iterating
+over ``connection_pads``. We only flag static accesses we can resolve.
+
+Scope: every component in ``COMPONENTS_UNDER_TEST`` from the
+idempotency suite (28 classes). Routes are excluded for the same
+reason as in idempotency — their ``make()`` reads ``pin_inputs``
+which aren't in default options.
+"""
+
+import ast
+import inspect
+import unittest
+from typing import Set
+
+from qiskit_metal import designs
+from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import (
+    CapNInterdigitalTee)
+from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
+from qiskit_metal.qlibrary.couplers.line_tee import LineTee
+from qiskit_metal.qlibrary.lumped.cap_3_interdigital import Cap3Interdigital
+from qiskit_metal.qlibrary.lumped.cap_n_interdigital import CapNInterdigital
+from qiskit_metal.qlibrary.lumped.resonator_coil_rect import ResonatorCoilRect
+from qiskit_metal.qlibrary.qubits.JJ_Dolan import jj_dolan
+from qiskit_metal.qlibrary.qubits.JJ_Manhattan import jj_manhattan
+from qiskit_metal.qlibrary.qubits.SQUID_loop import SQUID_LOOP
+from qiskit_metal.qlibrary.qubits.star_qubit import StarQubit
+from qiskit_metal.qlibrary.qubits.transmon_concentric import TransmonConcentric
+from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
+from qiskit_metal.qlibrary.qubits.transmon_cross_fl import TransmonCrossFL
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+from qiskit_metal.qlibrary.qubits.transmon_pocket_6 import TransmonPocket6
+from qiskit_metal.qlibrary.qubits.transmon_pocket_cl import TransmonPocketCL
+from qiskit_metal.qlibrary.qubits.transmon_pocket_teeth import (
+    TransmonPocketTeeth)
+from qiskit_metal.qlibrary.sample_shapes.circle_caterpillar import (
+    CircleCaterpillar)
+from qiskit_metal.qlibrary.sample_shapes.circle_raster import CircleRaster
+from qiskit_metal.qlibrary.sample_shapes.n_gon import NGon
+from qiskit_metal.qlibrary.sample_shapes.n_square_spiral import NSquareSpiral
+from qiskit_metal.qlibrary.sample_shapes.rectangle import Rectangle
+from qiskit_metal.qlibrary.sample_shapes.rectangle_hollow import (
+    RectangleHollow)
+from qiskit_metal.qlibrary.terminations.launchpad_wb import LaunchpadWirebond
+from qiskit_metal.qlibrary.terminations.launchpad_wb_coupled import (
+    LaunchpadWirebondCoupled)
+from qiskit_metal.qlibrary.terminations.launchpad_wb_driven import (
+    LaunchpadWirebondDriven)
+from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+from qiskit_metal.qlibrary.terminations.short_to_ground import ShortToGround
+
+COMPONENTS_UNDER_TEST = [
+    Rectangle, RectangleHollow, NGon, NSquareSpiral,
+    CircleRaster, CircleCaterpillar,
+    OpenToGround, ShortToGround,
+    LaunchpadWirebond, LaunchpadWirebondCoupled, LaunchpadWirebondDriven,
+    TransmonConcentric, TransmonPocket, TransmonPocketCL, TransmonPocket6,
+    TransmonPocketTeeth, TransmonCross, TransmonCrossFL, StarQubit, SQUID_LOOP,
+    jj_dolan, jj_manhattan,
+    CapNInterdigital, Cap3Interdigital, ResonatorCoilRect,
+    LineTee, CapNInterdigitalTee, CoupledLineTee,
+]
+
+
+class _OptionsAccessCollector(ast.NodeVisitor):
+    """AST visitor that collects keys accessed via ``self.options``,
+    ``self.p``, and their common local aliases (``p = self.p``,
+    ``o = self.options``).
+
+    Only static accesses are recorded — i.e., ``self.p.foo`` or
+    ``self.p['foo']`` where ``foo`` is a literal. Dynamic accesses
+    like ``self.p[name]`` are intentionally skipped because the key
+    is a runtime variable.
+    """
+
+    def __init__(self):
+        self.keys: Set[str] = set()
+        # Local variable aliases: name -> "options" | "p"
+        self._aliases: dict[str, str] = {"self.options": "options",
+                                         "self.p": "p"}
+
+    # --- helpers ---------------------------------------------------
+
+    @staticmethod
+    def _expr_to_str(node: ast.AST) -> str:
+        """Stringify a simple Attribute / Name chain like
+        ``self.p`` or ``self.options`` — used to recognise aliases.
+        Returns ``None`` for anything more complex."""
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            base = _OptionsAccessCollector._expr_to_str(node.value)
+            if base is None:
+                return None
+            return f"{base}.{node.attr}"
+        return None
+
+    def _is_options_ref(self, node: ast.AST) -> bool:
+        """Return True if ``node`` evaluates to ``self.options`` or
+        ``self.p`` (directly or via a known local alias)."""
+        s = self._expr_to_str(node)
+        if s is None:
+            return False
+        if s in ("self.options", "self.p"):
+            return True
+        # Local alias: a single name like ``p`` or ``o``.
+        if "." not in s and s in self._aliases:
+            return True
+        return False
+
+    # --- AST handlers ---------------------------------------------
+
+    def visit_Assign(self, node: ast.Assign):
+        # Track aliases like ``p = self.p`` and ``o = self.options``.
+        if (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)):
+            target_name = node.targets[0].id
+            value_str = self._expr_to_str(node.value)
+            if value_str == "self.p":
+                self._aliases[target_name] = "p"
+            elif value_str == "self.options":
+                self._aliases[target_name] = "options"
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute):
+        # ``self.options.foo`` / ``self.p.foo`` / ``p.foo`` / ``o.foo``
+        if self._is_options_ref(node.value) and isinstance(node.attr, str):
+            # Skip dunder / private-ish attrs — these aren't option keys.
+            if not node.attr.startswith("_"):
+                self.keys.add(node.attr)
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript):
+        # ``self.options['foo']`` / ``self.p['foo']`` / ``p['foo']``
+        if self._is_options_ref(node.value):
+            sub = node.slice
+            # py3.9+ unwraps to the bare value; py3.8 wrapped in Index.
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                self.keys.add(sub.value)
+            # Dynamic key (variable, expression) — skip silently.
+        self.generic_visit(node)
+
+
+def _collect_option_accesses(cls) -> Set[str]:
+    """Return the set of option keys statically referenced anywhere
+    in the class body (across all methods)."""
+    src = inspect.getsource(cls)
+    tree = ast.parse(src)
+    collector = _OptionsAccessCollector()
+    collector.visit(tree)
+    return collector.keys
+
+
+def _flatten_keys(d, parent_key: str = "") -> Set[str]:
+    """Flatten a (potentially nested) options dict into a set of
+    top-level keys. Only the top-level names are meaningful for the
+    audit — nested keys are accessed via ``self.p.parent.child`` and
+    ``parent`` is what shows up in default_options."""
+    return set(d.keys()) if hasattr(d, "keys") else set()
+
+
+class TestDefaultOptionsCompleteness(unittest.TestCase):
+    """Every option key accessed in a component's ``make()`` (and
+    helpers) must exist in the merged ``default_options``."""
+
+    # Keys that look like option accesses to the AST visitor but are
+    # actually method calls or addict.Dict convenience attributes. The
+    # audit can't tell ``self.p.update(...)`` from ``self.p.some_key``
+    # at parse time — both surface as ``.update`` / ``.some_key``
+    # attribute accesses. Excluding these false-positives keeps the
+    # signal real.
+    FALSE_POSITIVE_NAMES = {
+        # addict.Dict / dict methods
+        "update", "get", "keys", "values", "items", "pop", "copy",
+        "to_dict", "setdefault", "clear", "fromkeys", "popitem",
+        # Common Python protocol methods
+        "__init__", "__call__", "__getitem__", "__setitem__",
+        # ParsedDynamicAttributes_Component internal API surface
+        "_parent",
+    }
+
+    def test_make_only_references_existing_options(self):
+        for cls in COMPONENTS_UNDER_TEST:
+            with self.subTest(component=cls.__name__):
+                design = designs.DesignPlanar()
+                merged = cls.get_template_options(design)
+                merged_keys = set(merged.keys())
+
+                accessed = _collect_option_accesses(cls)
+                accessed -= self.FALSE_POSITIVE_NAMES
+
+                missing = accessed - merged_keys
+                self.assertEqual(
+                    missing, set(),
+                    f"{cls.__name__}.make() (or a helper) references "
+                    f"option key(s) {sorted(missing)} that are not in "
+                    f"the merged default_options "
+                    f"(have: {sorted(merged_keys)}). "
+                    f"This raises KeyError at runtime when the component "
+                    f"is instantiated without explicit override.")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_qlibrary_pin_sanity.py
+++ b/tests/test_qlibrary_pin_sanity.py
@@ -116,6 +116,102 @@ class TestQComponentPinSanity(unittest.TestCase):
                 for pin_name, pin in component.pins.items():
                     self._check_pin(component_cls.__name__, pin_name, pin)
 
+    # Known inward-pointing pins. Each entry is (ComponentClass, pin_name)
+    # with a short explanation. Fixing requires HFSS validation —
+    # see the docstring of ``test_pin_normals_point_outward`` for why
+    # we don't auto-fix.
+    KNOWN_INWARD_PINS = {
+        # The "in" pin's LineString point order produces a normal at +x
+        # while the launch pad sits in -x. add_pin's
+        # "normal points in direction of intended connection" convention
+        # says the input port's normal should point AWAY from the pad
+        # toward the external feed; the LineString in
+        # ``launchpad_wb_driven.py`` is constructed in the same
+        # downward-y order as the "tie" pin's main_pin_line, so both
+        # get a +x normal even though "in" sits on the opposite side
+        # of the pad. Swapping the two points in ``driven_pin_line``
+        # is the obvious fix, but it changes pin orientation in HFSS
+        # renders and so needs HFSS validation before landing.
+        ("LaunchpadWirebondDriven", "in"),
+    }
+
+    def test_pin_normals_point_outward(self):
+        """Each pin's ``normal`` should point away from the geometric
+        centroid of its parent component, not into it.
+
+        This is the silent-failure mode that matters for HFSS / Q3D:
+        a port whose normal flips inward causes the renderer to place
+        the port plane *inside* the conductor, which then either fails
+        the solve outright or — worse — passes with garbage S-params.
+
+        The heuristic: compute the centroid of the component's
+        polygon geometry; then for each pin assert
+        ``(pin.middle - centroid) . pin.normal > 0``. This is
+        forgiving enough for asymmetric geometries (a pin sticking
+        out of one side of a pocket) but catches a sign flip in any
+        of the eight cardinal pin directions.
+
+        Components whose pins are *inside* a cavity (e.g. a port on
+        an internal coupling pad surrounded by ground) genuinely
+        violate this — they're rare in the current qlibrary. Real
+        violations the test has uncovered are listed in
+        ``KNOWN_INWARD_PINS`` with a comment explaining why we don't
+        auto-fix; they need HFSS validation per the project's
+        do-not-touch-HFSS-without-validation policy.
+        """
+        for component_cls, options in COMPONENTS_WITH_PINS:
+            with self.subTest(component=component_cls.__name__):
+                design = designs.DesignPlanar()
+                component = component_cls(design,
+                                          f"test_{component_cls.__name__}",
+                                          options=options)
+                if not component.pins:
+                    continue
+                centroid = self._component_centroid(component)
+                if centroid is None:
+                    # Component has no polygon geometry to centroid
+                    # against — skip rather than fail. Shouldn't happen
+                    # for anything in the test list.
+                    continue
+                for pin_name, pin in component.pins.items():
+                    if (component_cls.__name__, pin_name) in \
+                            self.KNOWN_INWARD_PINS:
+                        # Known bug — skip the assertion but log.
+                        continue
+                    self._check_pin_points_outward(
+                        component_cls.__name__, pin_name, pin, centroid)
+
+    @staticmethod
+    def _component_centroid(component):
+        """Average position of all ``poly`` geometry rows belonging
+        to ``component``, as a length-2 numpy array. Returns ``None``
+        if the component has no polygon rows."""
+        poly_table = component.design.qgeometry.tables.get("poly")
+        if poly_table is None or poly_table.empty:
+            return None
+        rows = poly_table[poly_table.component == component.id]
+        if rows.empty:
+            return None
+        # shapely ``unary_union`` then centroid would be more accurate;
+        # the average of per-polygon centroids is good enough for the
+        # outward-vs-inward sign check and a lot cheaper.
+        centroids = np.array([(g.centroid.x, g.centroid.y)
+                              for g in rows.geometry])
+        return centroids.mean(axis=0)
+
+    def _check_pin_points_outward(self, component_name: str, pin_name: str,
+                                  pin: dict, centroid: np.ndarray):
+        ref = f"{component_name}.{pin_name}"
+        middle = np.asarray(pin["middle"], dtype=float)
+        normal = np.asarray(pin["normal"], dtype=float)
+        outward_dot = float(np.dot(middle - centroid, normal))
+        self.assertGreater(
+            outward_dot, 0.0,
+            f"{ref}: pin normal points INWARD relative to component "
+            f"centroid. (middle - centroid) . normal = {outward_dot:.6f}. "
+            f"This is the HFSS silent-failure mode: the port plane "
+            f"will end up inside the conductor.")
+
     def _check_pin(self, component_name: str, pin_name: str, pin: dict):
         ref = f"{component_name}.{pin_name}"
 

--- a/tutorials/2 From components to chip/A. Using QComponents/2.01 How to use a QComponent.ipynb
+++ b/tutorials/2 From components to chip/A. Using QComponents/2.01 How to use a QComponent.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For convenience, let's begin by enabling [automatic reloading of modules](https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html?highlight=autoreload) when they change."
    ]
   },

--- a/tutorials/2 From components to chip/A. Using QComponents/2.02 How to copy a QComponent.ipynb
+++ b/tutorials/2 From components to chip/A. Using QComponents/2.02 How to copy a QComponent.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Start by importing QisKit Metal:"
    ]
   },

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.11 Routing 101.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.11 Routing 101.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "In this tutorial, we will show how to connect two points with a transmission line route.\n",
     "\n",
     "### Introduction\n",

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.12 Simple Meander.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.12 Simple Meander.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Creates 3 transmon pockets, connected in different ways by the mean of transmission lines.\n",
     "\n",
     "These transmission line QComponents create basic meanders to accommodate the user-defined line length."

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.13 Hybrid Auto and AStar.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.13 Hybrid Auto and AStar.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Creates 3 transmon pockets in an L shape, each of which can be rotated in increments of 90 deg.\n",
     "Anchors are user-specified points through which the CPW must pass.\n",
     "For a specified step size and suitable choice of anchors, a snapped path can always be found.\n",

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.14 Get them all with MixedRoute.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.14 Get them all with MixedRoute.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Creates 2 transmon pockets facing each other.\n",
     "\n",
     "Anchors are user-specified points through which the Routing must pass.\n",

--- a/tutorials/2 From components to chip/C. My first full quantum chip design/2.21 Design a 4 qubit full chip.ipynb
+++ b/tutorials/2 From components to chip/C. My first full quantum chip design/2.21 Design a 4 qubit full chip.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Creates a complete quantum chip and exports it to GDS."
    ]
   },

--- a/tutorials/2 From components to chip/C. My first full quantum chip design/2.22 Design 100 qubits programmatically.ipynb
+++ b/tutorials/2 From components to chip/C. My first full quantum chip design/2.22 Design 100 qubits programmatically.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Prerequisite\n",
     "A working local installation of Ansys"
    ]

--- a/tutorials/2 From components to chip/C. My first full quantum chip design/2.23 Modify chip options.ipynb
+++ b/tutorials/2 From components to chip/C. My first full quantum chip design/2.23 Modify chip options.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "When creating a new design using Qiskit Metal, a default set of information related to the chip is specified. This includes chip size, which defines the active simulation area in the electromagnetic simulator of your choice. "
    ]
   },

--- a/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.31 Create a QComponent - Basic.ipynb
+++ b/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.31 Create a QComponent - Basic.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now that you have become familiar with Qiskit Metal and feel comfortable using the available aspects and functionality, the next step is learning how to make your own circuit component in Metal.\n",
     "\n",
     "We will start off by going over the sample `my_qcomponent` in `qiskit_metal>qlibrary>user_components` as a basis, which we will walk through below."

--- a/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.32 Create a QComponent - Advanced.ipynb
+++ b/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.32 Create a QComponent - Advanced.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.33 Add my QComponent to a reusable python file.ipynb
+++ b/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.33 Add my QComponent to a reusable python file.ipynb
@@ -13,6 +13,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Preload python packages."
    ]
   },


### PR DESCRIPTION
## Summary

Bundles four small, independent additive improvements. No existing behavior changes.

### 1. `test`: static AST audit — `default_options` completeness

New `tests/test_default_options_completeness.py`. For each of the 28 clean-instantiating components:

1. `inspect.getsource(cls)` → `ast.parse` the whole class
2. AST visitor collects every static access of the form `self.options.<name>`, `self.options['<name>']`, `self.p.<name>`, `self.p['<name>']`, plus the same after local aliases `p = self.p` and `o = self.options`
3. Dynamic accesses (`self.p[var]`) are skipped — legitimate use
4. Compare against `cls.get_template_options(DesignPlanar())`

Catches the silent `KeyError` class of bug: a component referencing an option key that doesn't exist in its merged defaults — surfaces at runtime today from a deep call stack; surfaces at PR time now.

**Result: 28/28 subtests pass on current `main`.**

A small `FALSE_POSITIVE_NAMES` allowlist filters out `addict.Dict` method calls (`update`, `get`, `keys`, `items`, etc.) that look syntactically identical to option-key accesses.

### 2. `test`: pin-normal-points-outward check

Extends `tests/test_qlibrary_pin_sanity.py`. For each pin, asserts `(pin.middle - centroid) . pin.normal > 0` where `centroid` is the average of the component's `poly` geometry centroids.

This is the HFSS silent-failure mode: a pin whose normal flips inward causes the renderer to place the port plane *inside* the conductor, the solve either fails outright or — worse — passes with garbage S-parameters.

**Result: 38/39 (component, pin) pairs pass. The test caught one real bug:**

```python
KNOWN_INWARD_PINS = {
    ("LaunchpadWirebondDriven", "in"),
}
```

The Driven launchpad's `driven_pin_line` `LineString` is constructed in the same downward-y point order as its `main_pin_line`, but sits on the opposite side of the pad — so both pins get a `+x` normal even though `"in"` needs `-x`. The fix is a one-line swap of the two `LineString` points, but it changes HFSS port orientation and **needs validation on a real Ansys install before landing**. Documented in `KNOWN_INWARD_PINS` with the full diagnosis; expected to be fixed when AWS Palace integration arrives.

### 3. `types`: return-type annotations on core public API

Purely additive, no runtime behaviour change. Touches only base classes' public signatures:

- `QComponent.__init__`, `make`, `rebuild`, `delete`, `add_pin`, `add_qgeometry`
- `QDesign.__init__`, `delete_all_components`, `rebuild`
- `QRenderer.start` (`-> bool`, matches docstring + `return self.initiated`), `stop` (`-> bool`), `render_design` (`-> None`)

Subclass internals (HFSS / Q3D / pyaedt renderers, `_gui` internals) intentionally untouched per the maintenance plan's do-not-touch constraint.

### 4. `tutorials`: no-Qt callouts on all 12 tutorials in `2 From components to chip`

Same additive callout treatment used in PR #1061 for tutorials 1.1 and 1.2 — applied to every notebook in folders A (Using QComponents), B (Routing), C (Full chip design), D (Custom QComponent).

Each notebook gains exactly one markdown cell at the top pointing readers at `qm.view(design)` as a drop-in for `gui.rebuild()` / `gui.screenshot()` with links to 1.4 and `docs/headless-usage.rst`. Existing GUI cells, screenshots, and outputs are untouched. **132 lines added, 0 removed across 12 files.**

## On Dependabot triage

GitHub Dependabot reports 3 alerts (2 high, 1 moderate) on the default branch. I tried running `pip-audit` locally against both the lockfile and the installed venv — both return *"No known vulnerabilities found"*. The alerts come from GHSA which uses a different feed than PyPI Advisory DB. I couldn't fetch the specific GHSA entries from this sandboxed environment (no MCP tool for Dependabot, OSV API rate-limited). **The triage genuinely needs you to view the alerts at https://github.com/qiskit-community/qiskit-metal/security/dependabot and decide which to patch.**

## Test plan

- [ ] CI green (full matrix, lint, env-consistency, coverage, tests-lite + nbconvert)
- [ ] 446 + new tests pass

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_