### PR TITLE
docs(agents): add CLAUDE.md + .claude/ repo know-how for future agents

### DIFF
--- a/.claude/commands/headless-check.md
+++ b/.claude/commands/headless-check.md
@@ -1,0 +1,184 @@
+# /headless-check — verify the Qt-free path locally
+
+This command reproduces the `tests-lite` CI job locally so you can
+catch a broken headless path before pushing. Use it when:
+
+- You're about to push a change that touches `__init__.py`,
+  `_gui/`, `renderer_mpl/`, or `viewer/`.
+- The `tests-lite` CI job failed and you need to debug.
+- A user reports `pip install quantum-metal[lite]` doesn't work.
+
+## What "the headless path" means
+
+After v0.6.1, this works without PySide6 / pyaedt / gmsh
+installed:
+
+```python
+import qiskit_metal as qm
+from qiskit_metal.designs import DesignPlanar
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+
+design = DesignPlanar()
+TransmonPocket(design, "Q1", options={"connection_pads": {"a": {}}})
+fig = qm.view(design)
+```
+
+If this breaks on any of the listed installs being absent,
+someone added a top-level Qt / Ansys / gmsh import somewhere
+they shouldn't have.
+
+## Procedure
+
+### 1. Build a lite venv
+
+```bash
+cd /tmp
+rm -rf qm_lite_check && mkdir qm_lite_check && cd qm_lite_check
+uv venv --python 3.12 --quiet
+
+# Install exactly the lite dep set. NO pyside6, pyaedt, or gmsh.
+uv pip install --quiet \
+    'addict>=2.4.0' \
+    'gdstk>=0.9' \
+    'geopandas>=1.0' \
+    'matplotlib>=3.7.0' \
+    'numpy>=1.24.2,<2' \
+    'pandas>=2.1.1' \
+    'pint>=0.21.0' \
+    'pyEPR-quantum>=0.9.5' \
+    'pygments>=2.14.0' \
+    'qutip>=5.0.0' \
+    'scipy>=1.10.0' \
+    'shapely>=2.0.1' \
+    'scqubits>=4.1.0' \
+    'pyyaml>=6.0' \
+    'pytest>=8.4.1' \
+    'pytest-rich>=0.2.0'
+
+# Install quantum-metal in editable mode, NO deps (we just hand-listed them)
+uv pip install --no-deps -e /path/to/qiskit-metal
+```
+
+### 2. Confirm PySide6 isn't installed
+
+```bash
+uv pip show pyside6 2>&1 | head -2
+# Expected: "warning: Package(s) not found for: pyside6"
+```
+
+If pyside6 IS installed, the test is invalid — start over from
+step 1.
+
+### 3. Smoke test
+
+**Use `.venv/bin/python` directly, NOT `uv run python`** —
+`uv run` auto-syncs the venv to pyproject.toml's full deps,
+silently reinstalling pyside6 / pyaedt / gmsh and defeating the
+test.
+
+```bash
+QISKIT_METAL_HEADLESS=1 .venv/bin/python -c "
+import qiskit_metal as qm
+from qiskit_metal.designs import DesignPlanar
+from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket
+
+design = DesignPlanar()
+TransmonPocket(design, 'Q1', options={'connection_pads': {'a': {}}})
+fig = qm.view(design)
+print('OK:', type(fig).__name__)
+"
+```
+
+Expected output (4 `Renderer=... skipped` lines, then OK):
+
+```
+Renderer=gmsh skipped: an optional dependency ... 'gmsh' ... is not installed
+Renderer=elmer skipped: ...
+Renderer=aedt_q3d skipped: ...
+Renderer=aedt_hfss skipped: ...
+OK: Figure
+```
+
+If you get `ModuleNotFoundError`, find the culprit:
+
+```bash
+QISKIT_METAL_HEADLESS=1 .venv/bin/python -c "
+import sys
+class Block:
+    def find_spec(self, name, path, target=None):
+        if name.startswith('PySide6'):
+            import traceback
+            print(f'\\n*** Qt import attempted: {name}')
+            traceback.print_stack(limit=15)
+            sys.exit(0)
+        return None
+sys.meta_path.insert(0, Block())
+import qiskit_metal
+"
+```
+
+The traceback shows which module pulled in Qt.
+
+### 4. Run the no-Qt test suite
+
+```bash
+.venv/bin/python -m pytest \
+    /path/to/qiskit-metal/tests/test_viewer.py \
+    /path/to/qiskit-metal/tests/test_qlibrary_idempotency.py \
+    /path/to/qiskit-metal/tests/test_qlibrary_pin_sanity.py \
+    /path/to/qiskit-metal/tests/test_default_options_completeness.py \
+    /path/to/qiskit-metal/tests/test_solution_types.py \
+    -v
+```
+
+All four files must pass on the lite venv.
+
+### 5. Execute the canonical headless tutorial
+
+```bash
+uv pip install --quiet 'jupyter>=1.0' 'nbconvert>=7.0' 'ipykernel>=6.0'
+.venv/bin/python -m ipykernel install --user --name qm_lite_check
+QISKIT_METAL_HEADLESS=1 .venv/bin/jupyter nbconvert \
+    --to notebook \
+    --execute \
+    --ExecutePreprocessor.kernel_name=qm_lite_check \
+    --ExecutePreprocessor.timeout=180 \
+    --output-dir /tmp/qm_lite_check/out \
+    '/path/to/qiskit-metal/tutorials/1 Overview/1.4 Headless quick view (no Qt GUI).ipynb'
+```
+
+The notebook should execute cleanly (~30s).
+
+### 6. Cleanup
+
+```bash
+rm -rf /tmp/qm_lite_check
+rm -rf ~/.local/share/jupyter/kernels/qm_lite_check  # the ipykernel registration
+```
+
+## Common failure modes
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `ModuleNotFoundError: No module named 'PySide6'` | Some non-`_gui/` module added a top-level `from PySide6 import …`. Use the traceback hook (step 3) to find it. |
+| `ModuleNotFoundError: No module named 'gmsh'` | A renderer auto-import in `_start_renderers` isn't wrapped in `try/except ImportError`. Check `designs/design_base.py:_start_renderers`. |
+| `KeyError: 1` in `render_junction` | pandas 2.2 positional-indexing issue. Replace `x[1]` with `x.iloc[1]`. See `lessons-learned.md`. |
+| Tests pass but `nbconvert --execute` fails with import error | Kernel issue — verify you registered the venv as `qm_lite_check` and passed `--ExecutePreprocessor.kernel_name=qm_lite_check`. |
+| `uv run` re-installs PySide6 | You used `uv run` instead of `.venv/bin/python`. See `lessons-learned.md`. |
+
+## What to report
+
+After running, produce a short status:
+
+```markdown
+## Headless check — <date>
+
+- Lite venv built: <yes/no>
+- PySide6 absent: <confirmed/installed>
+- Smoke test (qm.view): <OK / error>
+- No-Qt test suite: <X/X passed>
+- 1.4 notebook execute: <OK / error>
+
+### Issues found
+- ...
+```

--- a/.claude/commands/health-check.md
+++ b/.claude/commands/health-check.md
@@ -1,0 +1,149 @@
+# /health-check — repo health audit
+
+Use this command to do a broad sanity check on the repo. It's
+deliberately read-only — no changes get committed by default.
+
+## What you're looking for
+
+1. CI status of the most recent commits on `main`
+2. Open PRs that look stale
+3. Test count + recent flakiness
+4. Lint findings — are they all in the known-deferred zones?
+5. Dependency drift (`environment.yml` ↔ `pyproject.toml`)
+6. Coverage on critical paths
+7. Recent code changes that warrant attention
+8. Dependabot alerts (if accessible)
+
+## Procedure
+
+Run these in parallel where possible.
+
+### 1. CI status
+
+```bash
+# Most recent main commits + their statuses
+mcp__github__list_commits --owner qiskit-community --repo qiskit-metal --sha main --perPage 5
+# Or via gh if available
+gh run list --branch main --limit 10
+```
+
+Look for: red runs, flaky retries, jobs that took unusually long.
+
+### 2. Open PRs
+
+```bash
+mcp__github__list_pull_requests --owner qiskit-community --repo qiskit-metal --state open
+```
+
+Flag: PRs > 14 days old without recent activity. Don't auto-merge
+or close — just report.
+
+### 3. Local test count
+
+```bash
+QISKIT_METAL_HEADLESS=1 uv run pytest tests/ --collect-only -q | tail -5
+QISKIT_METAL_HEADLESS=1 uv run pytest tests/ 2>&1 | tail -3
+```
+
+Compare against the baseline in `CLAUDE.md` status snapshot.
+Investigate any drop in test count.
+
+### 4. Lint
+
+```bash
+uvx ruff check src 2>&1 | tail -10
+```
+
+Expected output as of v0.6.1:
+
+```
+8  E721  type-comparison
+6  E711  none-comparison
+5  F811  redefined-while-unused
+2  F405  undefined-local-with-import-star-usage
+1  F822  undefined-export
+Found 22 errors.
+```
+
+**13 of these are deferred** (HFSS / `_gui/` zones, see
+`lessons-learned.md`). If the count changes:
+
+- ↑ Someone added new lint debt. Look at the new findings;
+  triage.
+- ↓ Someone fixed deferred findings. Verify they had HFSS / Qt
+  validation. If not, raise a flag.
+
+### 5. Environment-drift gate
+
+```bash
+uv run scripts/check_env_consistency.py
+```
+
+Expect: `OK: 17 shared packages, no drift.` Any drift is a real
+issue — see `lessons-learned.md` for context.
+
+### 6. Coverage
+
+The `coverage` CI job emits per-file coverage to the run's step
+summary. Check it for the most recent main commit's run page.
+
+Investigate:
+
+- Files dropping below 30% coverage (something heavy was added
+  without tests)
+- New files at 0% (untested code shipped)
+
+### 7. Recent activity heuristic
+
+```bash
+git log --oneline main -20
+git log --since='2 weeks ago' --pretty=format:'%h %s' main
+```
+
+Skim for:
+
+- Multiple "fix CI" commits in a row → flaky test or fragile
+  infrastructure worth fixing
+- Long stretches with no merges → release candidate window or
+  branch protection issue
+- Commit subjects that mention HFSS / Qt — verify they had
+  appropriate validation
+
+### 8. Dependabot
+
+If you have repo access via the GitHub UI:
+
+- https://github.com/qiskit-community/qiskit-metal/security/dependabot
+- Note count, severity, oldest unhandled alert.
+
+In a sandboxed agent context this often isn't accessible — note
+the limitation in the report rather than guessing.
+
+## Output format
+
+Produce a short markdown report (under 300 words):
+
+```markdown
+## Repo health — <date>
+
+**CI**: <green/red/flaky>, <last main commit sha + status>
+**Tests**: <count> passing, <count> failing
+**Lint**: <total findings>; <delta from baseline if any>
+**Env drift**: <OK / list of drifts>
+**Open PRs**: <count>, <oldest age>
+**Dependabot**: <count if accessible, else "needs manual check">
+
+### Things worth attention
+- ...
+- ...
+
+### Things ready to do next
+- ...
+```
+
+## What this command is NOT
+
+- Not a fix-everything pass. Report and let the user decide.
+- Not a release readiness check. For that use `.claude/commands/release.md`.
+- Not a security audit. Dependabot covers that; this just surfaces
+  the count.

--- a/.claude/commands/refresh-tutorial.md
+++ b/.claude/commands/refresh-tutorial.md
@@ -1,0 +1,186 @@
+# /refresh-tutorial — apply the standard no-Qt callout to a tutorial
+
+The callout makes the headless rendering path discoverable from
+every GUI-using tutorial. This is the same pattern applied to 1.1,
+1.2, and all of `2 From components to chip/` in PRs #1061 and
+#1062. Use this command when:
+
+- Adding the callout to a folder we haven't covered yet (3-Renderers,
+  4-Analysis, Appendix A/B/C, quick-topics)
+- A new tutorial lands and needs the callout
+
+## What the callout looks like
+
+A single markdown cell inserted as the second cell of the notebook
+(after the title):
+
+```markdown
+> 💡 **Using this tutorial without the Qt GUI**
+> 
+> This tutorial uses the desktop `MetalGUI`. To follow along on
+> Colab, Binder, JupyterHub, or any environment where Qt isn't
+> available, **replace any `gui.rebuild()` / `gui.screenshot()`
+> call with `qm.view(design)`** — it renders the design to a
+> matplotlib `Figure` you can display inline or save with
+> `fig.savefig(...)`.
+> 
+> See [1.4 Headless quick view](...) for a complete runnable
+> walkthrough and `docs/headless-usage.rst` for the full reference.
+```
+
+The relative link path to `1.4` depends on which folder the
+tutorial lives in. For `2 From components to chip/A/.../*.ipynb`
+the path is:
+
+```
+../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb
+```
+
+For a tutorial directly under `tutorials/3 Renderers/*.ipynb`:
+
+```
+../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb
+```
+
+## Procedure
+
+### 1. Decide scope
+
+Either a single notebook or a whole folder. Don't try to do all
+remaining tutorials in one PR — the diff gets too noisy to review.
+One folder per PR is the sweet spot.
+
+Current state of callouts (as of v0.6.1):
+
+| Folder | Callout applied? |
+|--------|------------------|
+| `1 Overview/` | ✅ 1.1, 1.2 (1.3 skipped — empty; 1.4 is the canonical headless) |
+| `2 From components to chip/` (all of A, B, C, D) | ✅ |
+| `3 Renderers/` | ❌ |
+| `4 Analysis/` | ❌ |
+| `Appendix A Full design flow examples/` | ❌ |
+| `Appendix B Quick topics/` | ❌ |
+| `Appendix C Circuit examples/` | ❌ |
+
+### 2. Write the injection script
+
+```python
+import json
+from pathlib import Path
+
+# Adjust the relative path based on folder depth!
+RELATIVE_LINK = ("../../1%20Overview/"
+                 "1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb")
+
+CALLOUT = {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+        "> 💡 **Using this tutorial without the Qt GUI**\n",
+        "> \n",
+        "> This tutorial uses the desktop `MetalGUI`. To follow "
+        "along on Colab, Binder, JupyterHub, or any environment "
+        "where Qt isn't available, **replace any `gui.rebuild()` / "
+        "`gui.screenshot()` call with `qm.view(design)`** — it "
+        "renders the design to a matplotlib `Figure` you can "
+        "display inline or save with `fig.savefig(...)`.\n",
+        "> \n",
+        f"> See [1.4 Headless quick view]({RELATIVE_LINK}) for a "
+        "complete runnable walkthrough and "
+        "[`docs/headless-usage.rst`](../../../docs/headless-usage.rst) "
+        "for the full reference."
+    ]
+}
+
+# Adjust target folder
+TARGET = Path("tutorials/3 Renderers")
+notebooks = sorted(TARGET.rglob("*.ipynb"))
+
+for nb_path in notebooks:
+    with open(nb_path) as f:
+        nb = json.load(f)
+    # Idempotent: skip if callout already present
+    first_md = next((c for c in nb["cells"] if c["cell_type"] == "markdown"), None)
+    if first_md and "Using this tutorial without the Qt GUI" in "".join(first_md["source"]):
+        print(f"  SKIP (has callout): {nb_path.name}")
+        continue
+    nb["cells"].insert(1, CALLOUT)
+    with open(nb_path, "w", encoding="utf-8") as f:
+        # CRITICAL: ensure_ascii=False preserves unicode (χ, ε, etc.)
+        # — without it the diff balloons with \uXXXX escapes.
+        # See .claude/context/lessons-learned.md "json.dump".
+        json.dump(nb, f, indent=1, ensure_ascii=False)
+        f.write("\n")
+    print(f"  added: {nb_path}")
+```
+
+### 3. Run and verify
+
+```bash
+python3 your_injection_script.py
+git diff --stat tutorials/
+```
+
+Expect: N files, ~11 insertions each (the callout is 11 lines),
+**0 deletions**. If you see deletions, you broke an existing cell.
+
+### 4. Validate JSON + cell count
+
+```bash
+python3 -c "
+import json, glob
+for p in sorted(glob.glob('tutorials/3 Renderers/**/*.ipynb', recursive=True)):
+    with open(p) as f:
+        nb = json.load(f)
+    has = any('Using this tutorial without the Qt GUI' in ''.join(c['source'])
+              for c in nb['cells'] if c['cell_type'] == 'markdown')
+    print(f'{\"OK\" if has else \"MISSING\"}: {p}')
+"
+```
+
+### 5. Commit, push, open PR
+
+```bash
+git add tutorials/
+git commit -m "tutorials: add no-Qt callouts to <folder> (N notebooks)"
+git push -u origin claude/tutorial-refresh-<folder>
+```
+
+Then open a PR with body matching the pattern from PRs #1061 and
+#1062 (purely-additive, no notebooks re-executed, etc.).
+
+## Critical pitfalls
+
+### `ensure_ascii=False`
+
+If you forget this and save a notebook containing `χ` or `ε`, the
+JSON serialiser escapes them to `χ` and the diff balloons with
+hundreds of bogus lines. See `lessons-learned.md`.
+
+### Don't re-execute the notebook
+
+The original GUI screenshots are part of the documentation value.
+Re-executing would discard them. Inject the callout in place; leave
+all outputs alone.
+
+### Relative link depth
+
+`../../` for tutorials inside `2 From components to chip/X/...`
+(two levels deep), but `../` for tutorials directly under
+`tutorials/3 Renderers/`. Get the depth wrong and the link
+404s.
+
+### Idempotency
+
+Always check whether the callout is already present before
+inserting — otherwise re-running on the same folder duplicates the
+callout. The script template above handles this.
+
+## What this command is NOT
+
+- Not a full notebook rewrite. The GUI-driven path stays as-is;
+  only the callout points users at the headless alternative.
+- Not a re-execution. Outputs and screenshots are preserved
+  exactly.
+- Not a way to fix individual notebook bugs. If the tutorial has a
+  real issue, file it separately.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,203 @@
+# /release — ship a new quantum-metal version to PyPI
+
+This procedure ships a new release tag, GitHub Release page, and
+PyPI artifact. **Read the v0.6.0 post-mortem (below) before
+starting** — there's a real failure mode you need to avoid.
+
+## The v0.6.0 post-mortem (cautionary tale)
+
+v0.6.0 was supposed to ship via the `bump-version` workflow. It
+failed silently:
+
+1. The workflow tried to update `pyproject.toml` directly on `main`
+   via the GitHub Contents API.
+2. Branch protection on `main` rejected the write with `HTTP 409:
+   Changes must be made through a pull request`.
+3. The tag `v0.6.0` was created anyway (likely manually after the
+   failure). It points at the v1054 merge commit where
+   `pyproject.toml` still says `0.5.4`.
+4. When `release.yml` fired from the tag push, `uv build` produced
+   `quantum-metal-0.5.4.whl` and `uv publish` failed with
+   "version already exists" — PyPI was never updated.
+
+Result: GitHub Release page existed, tag existed, but `pip install
+quantum-metal` still got 0.5.4.
+
+**Fix applied for v0.6.1**: bump version via a regular PR. **Until
+`github-actions[bot]` is added to the branch-protection bypass
+list, the `bump-version` workflow doesn't work — use the manual
+procedure below.**
+
+## Procedure (when bump-version workflow is broken)
+
+### 1. Pre-flight check
+
+```bash
+# Confirm main is green
+mcp__github__list_commits --owner qiskit-community --repo qiskit-metal --sha main --perPage 1
+# Run full test suite locally
+QISKIT_METAL_HEADLESS=1 uv run pytest tests/
+# Run the drift gate
+uv run scripts/check_env_consistency.py
+# Run lint
+uvx ruff check src
+```
+
+All four must be clean. If any is red, fix before tagging.
+
+### 2. Decide the version
+
+- Patch bump (0.6.1 → 0.6.2): bug-fix-only release
+- Minor bump (0.6.x → 0.7.0): new features, possibly breaking
+- Major bump (0.x → 1.0): commit to API stability
+
+Check `CLAUDE.md`'s status snapshot for what's queued.
+
+### 3. Open the version-bump PR
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b claude/bump-X.Y.Z
+
+# Bump pyproject.toml
+# (line 28-ish: version = "X.Y.Z")
+# Bump uv.lock — find the quantum-metal entry (~line 2749) and
+# update its version field
+```
+
+Both files MUST match exactly. The lockfile bump is the easy thing
+to forget.
+
+Commit and push:
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "chore: bump version to X.Y.Z"
+git push -u origin claude/bump-X.Y.Z
+```
+
+Open a PR via `mcp__github__create_pull_request` with title
+`chore: bump version to X.Y.Z` and base `main`.
+
+### 4. Wait for the user to merge
+
+The CLA bot will block; only the human can satisfy it. **Don't
+push the tag yet.**
+
+### 5. Tag and push
+
+After merge, on the user's go:
+
+```bash
+git checkout main
+git pull origin main
+# Confirm pyproject.toml says X.Y.Z at HEAD
+grep '^    version' pyproject.toml
+
+git tag vX.Y.Z origin/main
+git push origin vX.Y.Z
+```
+
+This fires `release.yml` which:
+
+- `uv build` → produces `quantum-metal-X.Y.Z-py3-none-any.whl`
+  and `.tar.gz`
+- `twine check` validates them
+- Imports the wheel + sdist in isolation as a smoke test
+- `uv publish` to PyPI via OIDC
+
+### 6. Create the GitHub Release
+
+Either:
+
+- Via the GitHub UI: Releases → Draft a new release → tag
+  `vX.Y.Z`, target `main`, title `vX.Y.Z`, body = release notes
+  (curated, not auto-generated)
+- Via `mcp__github__create_release` (if available)
+
+Use the release-notes template from the v0.6.1 release as a
+starting point — categorise by Compatibility / Bug fixes / Tests /
+Docs / Hygiene / Compatibility matrix.
+
+### 7. Post-release sanity check
+
+```bash
+# Wait ~2 min for PyPI to update
+pip index versions quantum-metal   # should list the new version
+# Or via WebFetch
+WebFetch "https://pypi.org/pypi/quantum-metal/json" "what is the latest version?"
+```
+
+If PyPI still shows the old version, check the `release.yml` run on
+GitHub Actions for errors.
+
+### 8. Announce
+
+The QDC Discord and the `#metal` Slack channel are the two places
+the user typically announces. Generate a 3-sentence summary they
+can post.
+
+## Procedure (when bump-version workflow is fixed)
+
+Once `github-actions[bot]` is added to the branch-protection
+bypass list:
+
+1. Go to https://github.com/qiskit-community/qiskit-metal/actions/workflows/bump-version.yml
+2. Run workflow → version: `X.Y.Z`
+3. Workflow bumps `pyproject.toml`, creates a commit on `main`,
+   tags it, creates a draft GitHub Release, fires `release.yml`,
+   publishes to PyPI.
+4. Edit the draft release notes (auto-generated is too noisy).
+5. Publish.
+
+Then steps 7 + 8 above.
+
+## Common pitfalls
+
+### `uv.lock` not bumped
+
+PyPI release goes out as the lockfile-declared version, not the
+pyproject.toml version. Always update both.
+
+### Tag name format
+
+It's `vX.Y.Z` (lowercase v, no leading `release/` or `tag/`).
+`release.yml` only fires on tags matching `v*`.
+
+### Pre-release versions
+
+For RCs use `vX.Y.Z-rc1` etc. — PyPI accepts these. Make sure they
+parse as PEP 440 pre-releases or `twine check` rejects.
+
+### Release notes vs auto-generated
+
+GitHub's `--generate-notes` produces "what changed since last tag"
+which is too granular. Always write curated notes that group by
+theme.
+
+### The CLA bot
+
+Every PR Claude opens gets a CLA-bot comment. It blocks merge
+until the human satisfies it. Mention this when handing the PR
+off.
+
+## Output format
+
+When invoked, produce a short status report:
+
+```markdown
+## Release readiness — vX.Y.Z
+
+- [ ] main is green
+- [ ] tests pass locally (count: ...)
+- [ ] env-consistency clean
+- [ ] lint: 13 (deferred) / no new
+- [ ] pyproject.toml + uv.lock bumped
+- [ ] PR opened: #...
+- [ ] PR merged → tag pushed
+- [ ] PyPI shows X.Y.Z
+- [ ] Release notes published
+```
+
+Mark items off as the user gates through. Don't skip steps.

--- a/.claude/context/architecture.md
+++ b/.claude/context/architecture.md
@@ -1,0 +1,227 @@
+# Architecture — how Quantum Metal's pieces fit together
+
+Read this when you need to make structural changes. For tactical
+"don't trip on this" knowledge, see `lessons-learned.md`.
+
+## The three load-bearing abstractions
+
+### `QComponent` — `qlibrary/core/base.py`
+
+A `QComponent` is a piece of geometry parameterised by an options
+dict. Subclasses live in `qlibrary/` (transmons, terminations,
+routes, etc.). Every component has:
+
+- **`default_options`**: class-level `addict.Dict` of default
+  parameter values
+- **`make()`**: builds the geometry from `self.options` / `self.p`,
+  calls `self.add_qgeometry(...)` and `self.add_pin(...)`
+- **`rebuild()`**: clears prior geometry and calls `make()` —
+  idempotent by design (see `tests/test_qlibrary_idempotency.py`)
+
+Lifecycle: `__init__` → registers component on `design` → calls
+`rebuild()` (which calls `make()`) → component sits in
+`design.components` until deleted or re-built.
+
+The `self.p` proxy is `ParsedDynamicAttributes_Component(self)` — a
+view of `self.options` that parses string units (`"30um"` → numeric)
+on attribute access. `make()` should generally read via `self.p`,
+not `self.options` directly. Both are static-analysable —
+`tests/test_default_options_completeness.py` AST-walks each `make()`
+to assert every accessed key exists in the merged
+`default_options`.
+
+### `QDesign` — `designs/design_base.py`
+
+The container for components, qgeometry, variables, and chip
+metadata. Subclasses (`DesignPlanar`, `DesignFlipChip`, etc.) define
+the chip stack.
+
+Lifecycle: `__init__` → creates qgeometry tables → calls
+`_start_renderers()` which loads every registered renderer
+(gracefully skipping ones whose deps aren't installed, post-v0.6.1).
+
+Components attach automatically when constructed with a design
+argument: `TransmonPocket(design, "Q1")` registers itself on
+`design.components["Q1"]`.
+
+### `QRenderer` (and `QRendererAnalysis`) — `renderers/renderer_base/`
+
+The output side. `QRenderer` has 3 abstract methods
+(`_initiate_renderer`, `_close_renderer`, `render_design`);
+`QRendererAnalysis(QRenderer)` adds 8 more for analysis-renderer
+needs (per-component, per-element, per-chip dispatch).
+
+Concrete renderers split into two camps:
+
+- **Lightweight / export-only**: `QGDSRenderer`, `QGmshRenderer` —
+  direct `QRenderer` subclasses
+- **Analysis**: `QAnsysRenderer` (legacy COM), `QPyaedt` (new
+  pyaedt-based), `QElmerRenderer` — `QRendererAnalysis` subclasses
+
+`QMplRenderer` is a special case — it lives in `renderer_mpl/` but
+**does not inherit from `QRenderer`**. It's structurally an
+in-memory viewer that operates on the same `design.qgeometry.tables`
+the proper renderers consume. As of v0.6.1 it's usable standalone
+(no `PlotCanvas` required).
+
+See `docs/architecture/renderer_protocol.md` for the full
+inheritance map and override matrix.
+
+## The two parallel Ansys tracks
+
+Both `renderer_ansys/` (`QAnsysRenderer`) and
+`renderer_ansys_pyaedt/` (`QPyaedt`) exist in the repo. They render
+the same designs to the same backends via different bridges:
+
+- `renderer_ansys/` — original, COM-based, goes through
+  `pyEPR.ansys`. Windows-only at solve time. Handles the HFSS
+  2024.1+ solution-type rename via `solution_types.py`.
+- `renderer_ansys_pyaedt/` — newer, uses Ansys's official
+  `pyaedt` package. Migration target but not yet feature-parity.
+
+**No deprecation policy is currently documented for the older
+track.** Any new Ansys feature lands in both. AWS Palace
+integration on the roadmap may render this question moot (open
+FEM path replaces Ansys for most users).
+
+## Option flow
+
+```
+class TransmonPocket(BaseQubit):
+    default_options = Dict(pad_width='455um', pad_height='90um', ...)
+    #                       ↑
+    #                       └─ class-level static
+    
+    def make(self):
+        p = self.p                 # parsed proxy
+        pad_width = p.pad_width    # "455um" → 0.000455 (meters)
+        ...
+```
+
+At instantiation:
+
+```
+options = QComponent.get_template_options(design, ...)
+        = merge(
+            ancestor default_options chain,    # walked via MRO
+            user options dict,                  # passed to __init__
+            renderer-injected option columns,   # via setup_renderers
+          )
+```
+
+The merged result becomes `self.options` (an `addict.Dict`). `self.p`
+is a lazy parsing view over that.
+
+**Static guarantee** (PR #1062): `tests/test_default_options_completeness.py`
+AST-walks each component, collects every static `self.options.X` /
+`self.p.X` access, asserts every key is present in the merged
+defaults. Catches the silent `KeyError` class of bug at PR time
+instead of at user runtime.
+
+## QGeometry tables
+
+`design.qgeometry.tables` is a dict of `{table_name: GeoDataFrame}`.
+The three canonical tables:
+
+- `poly` — filled shapes (qubit pads, pockets)
+- `path` — line segments (CPWs, traces)
+- `junction` — Josephson junction placeholders (rendered as zero-width)
+
+Each row has columns: `component` (id), `name` (string per
+component-name pair), `geometry` (shapely object), `chip`, `layer`,
+`subtract`, `helper`, plus renderer-injected extras
+(`fillet_radius`, `material`, etc.).
+
+`QComponent.make()` populates these via `add_qgeometry('poly',
+dict(name=shape, ...), layer=N, subtract=False)`.
+
+## Lazy-Qt architecture (post v0.6.1)
+
+Pre-v0.6.1, `import qiskit_metal` unconditionally imported PySide6.
+Post-v0.6.1:
+
+```
+import qiskit_metal as qm        # no PySide6 import
+fig = qm.view(design)            # no PySide6 import
+qm.MetalGUI(design)              # NOW PySide6 imports (via __getattr__)
+qm.plt.draw_design(...)          # NOW PySide6 imports (via __getattr__)
+```
+
+Mechanism:
+
+1. `qiskit_metal/__init__.py` no longer calls `__setup_Qt_backend`
+   at module load. Renamed to public `setup_qt_backend()` and called
+   from `MetalGUI.__init__`.
+2. `MetalGUI` and `plt` (alias for `renderer_mpl.mpl_toolbox`) are
+   exposed via PEP-562 `__getattr__` on the top-level module — only
+   imported on first attribute access.
+3. `mpl_interaction.py` PySide6 imports are wrapped in `try/except
+   ImportError`, with `_require_qt()` gates on the Qt-using
+   functions (`figure_pz`).
+4. `_start_renderers` in `design_base.py` catches `ImportError`
+   from optional renderer modules (gmsh, pyaedt), skipping them
+   gracefully on lite installs.
+
+Net result: `pip install quantum-metal[lite]` (no PySide6, pyaedt,
+gmsh) supports the full headless API. The `tests-lite` CI job
+enforces this.
+
+## v0.7.0 planned lite-by-default flip
+
+Currently the `[gui]`, `[ansys]`, `[fem]`, `[full]` extras are
+*additive* — the base install still pulls in everything. v0.7.0
+plans to flip this:
+
+- `pip install quantum-metal` → no Qt, no Ansys, no gmsh (lite by
+  default)
+- `pip install quantum-metal[full]` → current all-in install
+- `pip install quantum-metal[gui]` → adds PySide6 + qdarkstyle
+- `pip install quantum-metal[ansys]` → adds pyaedt + pyEPR
+- `pip install quantum-metal[fem]` → adds gmsh
+
+The infrastructure (lazy imports, graceful renderer skip, CI gate,
+viewer module) is shipped in v0.6.1; the flip itself is a one-line
+`pyproject.toml` change planned for v0.7.0.
+
+## Test architecture
+
+Five canonical test families in `tests/`:
+
+| File | Scope |
+|------|-------|
+| `test_qlibrary_1_instantiate.py` | Every qlibrary class instantiates cleanly with default options |
+| `test_qlibrary_idempotency.py` | `make()` is deterministic — rebuild twice, geometry matches |
+| `test_qlibrary_pin_sanity.py` | Every pin has valid metadata: positive width, unit-norm normal, normal points outward |
+| `test_default_options_completeness.py` | Every `self.options.X` access in `make()` exists in merged defaults |
+| `test_viewer.py` | `qm.view(design)` returns a valid Figure on the lite venv |
+
+Plus targeted unit tests for analyses, solution types, pyEPR
+integration, etc. ~475 tests total as of v0.6.1.
+
+## CI architecture
+
+`.github/workflows/main.yml` defines:
+
+| Job | Run on | Time |
+|-----|--------|------|
+| `tests-pythonX.Y-OS` (9 jobs) | py3.10/3.11/3.12 × ubuntu/macos/windows | ~2-3 min each |
+| `lint` | ubuntu-py3.12, ruff | <1 min |
+| `env-consistency` | ubuntu, runs `scripts/check_env_consistency.py` | <30s |
+| `coverage` | ubuntu-py3.12, pytest --cov | ~3 min |
+| `tests-lite` | ubuntu-py3.12, lite venv (no Qt/Ansys/gmsh) | ~30s |
+
+`tests-lite` runs the headless test suite + executes the canonical
+no-Qt tutorial (`1.4 Headless quick view`) via nbconvert. Failing
+this job means a Qt import sneaked into a non-GUI module.
+
+## Where new code goes
+
+| You're adding... | It goes in... |
+|------------------|---------------|
+| A new `QComponent` | `src/qiskit_metal/qlibrary/<category>/<name>.py` + tests in `tests/test_qlibrary_*` |
+| A new analysis | `src/qiskit_metal/analyses/<topic>/<name>.py` |
+| A new renderer | `src/qiskit_metal/renderers/renderer_<name>/<name>_renderer.py`, inherit from `QRenderer` or `QRendererAnalysis` |
+| A user-facing helper | `src/qiskit_metal/<topic>/__init__.py` (e.g. `viewer/`) |
+| A CI gate | `.github/workflows/main.yml` step + `scripts/<gate>.py` if non-trivial |
+| Docs page | `docs/<topic>.rst`, add to `docs/index.rst` toctree |
+| Tutorial notebook | `tutorials/<folder>/X.Y Name.ipynb` with the standard "no-Qt callout" at top |

--- a/.claude/context/ecosystem.md
+++ b/.claude/context/ecosystem.md
@@ -1,0 +1,197 @@
+# Ecosystem — who uses Quantum Metal and why decisions are made
+
+Read this when making roadmap, API, or version decisions. For the
+"how things are structured" view, see `architecture.md`.
+
+## The three user groups
+
+Decisions on this project should weigh impact on each:
+
+### 1. Academic researchers (the growth lever)
+
+Graduate students and postdocs designing superconducting circuits
+for their group's experiments. Typically:
+
+- Run on shared cloud notebooks (Colab, Binder, JupyterHub, IBM
+  Quantum Lab) — **PySide6 doesn't install cleanly on most of
+  these**.
+- Want to iterate on a design fast, visualise, run a parameter
+  sweep, commit results to a paper figure.
+- Don't have Ansys licenses; do their own analysis in Python
+  (qutip, scqubits, custom code).
+- Will abandon a tool on the first installation failure.
+
+**This is why the v0.6.1 headless work matters.** Pre-v0.6.1, this
+group hit a wall on `pip install` or on the first `MetalGUI(design)`
+call.
+
+### 2. Industrial fab engineers (the existing base)
+
+Engineers at IBM, Quantinuum, Rigetti, and university-spinout
+labs. Typically:
+
+- Run on a workstation with Ansys AEDT installed locally.
+- Use the desktop `MetalGUI` for interactive design.
+- Care deeply about HFSS / Q3D solver correctness — silent
+  S-parameter errors cost weeks of fab time.
+- Tolerate version pins and complex installs because the tooling
+  is mature.
+
+**This is why HFSS-touching code is a hard-touch zone.** Any
+behavioural change without a validated solve is a regression that
+this group eats.
+
+### 3. Educators and outreach (the long tail)
+
+Quantum Workshop instructors, Quantum Device Workspace (QDW), Quantum
+Device Consortium (QDC), online courses, hackathons.
+
+- Need a clean "first 30 lines" story that works on Day 1 of a
+  workshop.
+- Care about tutorial quality and discoverability more than
+  feature depth.
+- Drive adoption among new students who eventually become group 1
+  or 2.
+
+**This is why tutorial 1.4 (Headless quick view) ships, why the
+"no-Qt callout" goes on every notebook, and why
+`docs/headless-usage.rst` exists.**
+
+## Repo relationships
+
+### pyEPR (sibling)
+
+[`zlatko-minev/pyEPR`](https://github.com/zlatko-minev/pyEPR) — the
+EPR analysis library. PyPI: `pyEPR-quantum`.
+
+Quantum Metal depends on pyEPR for:
+
+- Ansys COM bridge (`pyEPR.ansys.parse_units`, etc.) — used by
+  the legacy `renderer_ansys/` track.
+- Hamiltonian / EPR analysis utilities.
+
+**Cross-repo coordination protocol**: when a change in pyEPR's
+public API affects metal, both repos get coordinated PRs. The
+HFSS 2024.1+ rename was the canonical example (pyEPR PRs #172,
+#176 + metal PR #1051 + the test suite in
+`tests/test_pyepr_integration.py` and
+`tests/test_solution_types.py` that pin the API).
+
+The new (v0.9.5+) `pyEPR.solution_types` module is intentionally
+identical in structure to metal's own
+`qiskit_metal.renderers.renderer_ansys.solution_types`. They're
+kept as parallel implementations rather than one importing the
+other so an old pyEPR install doesn't break new metal and vice
+versa.
+
+### pyaedt (upstream)
+
+Ansys's official Python interface to AEDT. New track at
+`renderer_ansys_pyaedt/` uses it. Currently pinned `<0.24` due to
+bugs in 0.24 (noted Jan 2026).
+
+### Ansys AEDT (the proprietary backend)
+
+HFSS and Q3D Extractor are the gold standard for superconducting
+chip EM analysis. Not open source. Required for the analysis
+workflow that user group 2 depends on.
+
+### AWS Palace (the future open-source FEM path)
+
+[`awslabs/palace`](https://github.com/awslabs/palace) — AWS's
+open-source FEM solver, comparable to HFSS for many quantum-chip
+use cases. **Planned integration is a major roadmap item.**
+Unlocks:
+
+- Open-source validation of HFSS-touching changes (currently a
+  hard blocker on every drive-by HFSS fix — see
+  `lessons-learned.md`)
+- A no-Ansys solve path for user group 1 (academic researchers
+  who don't have Ansys licenses)
+- An on-cloud solve path (Palace runs in AWS, no local install)
+
+Until Palace ships, HFSS-touching code stays in the hard-touch
+zone.
+
+### Quantum Device Consortium (QDC) — community
+
+[`qdc-qcsa.vercel.app`](https://qdc-qcsa.vercel.app) — the
+community organisation that now maintains Quantum Metal (post-IBM
+graduation). Decision-making body for breaking changes and
+roadmap.
+
+### Quantum Device Workspace (QDW)
+
+[`qdw-ucla.squarespace.com`](https://qdw-ucla.squarespace.com) —
+annual workshop hosted at UCLA/USC. Largest single audience for
+new-user adoption each year.
+
+## Documentation philosophy
+
+- **Sphinx**: the canonical reference site at
+  https://qiskit-community.github.io/qiskit-metal/
+- **Tutorials**: 40+ Jupyter notebooks in `tutorials/`,
+  hand-authored, organised by topic. Each gets a "no-Qt callout"
+  at the top pointing at `qm.view(design)` for users without Qt.
+- **API reference**: auto-generated from docstrings via Sphinx
+  autodoc.
+- **Architecture docs**: under `docs/architecture/` — currently
+  one file (`renderer_protocol.md`); add more here as needed.
+- **Agent docs**: this directory (`.claude/`).
+
+When writing user-facing docs, target user group 1 first (they
+don't have Ansys, they're on cloud notebooks, they need it to
+*just work*). User group 2 has accumulated knowledge; they don't
+need hand-holding for the basics.
+
+## Release philosophy
+
+- **SemVer** target post-v1.0; pre-1.0 we use minor versions for
+  meaningful changes and patches for bug fixes only.
+- **v0.6.x line**: stabilisation of qutip 5 + pyEPR 0.9.5 + HFSS
+  2024.1+ support + the new headless rendering path. Additive
+  extras for `[gui]`/`[ansys]`/`[fem]`/`[full]`.
+- **v0.7.0 planned**: flip the default install to lite (no Qt,
+  Ansys, gmsh by default; opt-in via extras). Breaking for users
+  who install via `pip install quantum-metal` and expect the
+  desktop GUI to "just work" — needs migration messaging.
+- **Release procedure**: see `.claude/commands/release.md`.
+
+## Adoption strategy
+
+Roughly:
+
+1. **Lower the install friction** — done in v0.6.1 via the
+   headless path. `pip install quantum-metal[lite]; qm.view(design)`
+   works on any matplotlib-aware environment.
+2. **Make the first 30 lines work** — tutorial 1.4 + the
+   callouts on existing tutorials. Reader can copy-paste from any
+   tutorial onto Colab and follow along.
+3. **Ship a modern interactive viewer** — the "bigger project"
+   (Plotly/ipympl/Jupyter widgets), planned post-v0.6.x.
+   Replaces the Qt GUI for users who want pan/zoom + click-select
+   without a desktop install.
+4. **Unblock Ansys-free validation** — AWS Palace integration.
+   Then every contributor can test HFSS-adjacent changes without
+   a Windows + AEDT setup.
+
+## What this means for your changes
+
+When deciding whether to take on a task, weigh:
+
+- **Does it benefit group 1?** Lower install friction, headless
+  paths, tutorial coverage, lite extras — high-leverage.
+- **Does it risk breaking group 2?** Anything HFSS / Q3D / `_gui/`
+  touching — needs validation. Document the bug; don't fix it
+  silently.
+- **Does it help group 3 explain the tool?** Tutorial polish,
+  docs clarity, error messages — modest leverage but compounds.
+- **Does it move us toward Palace / lite-by-default / modern
+  viewer?** Tier-2 / tier-3 roadmap work — coordinate with
+  maintainers (you're not making the strategic call solo).
+
+## Cross-references
+
+- For the technical "what's where" view: `architecture.md`
+- For "stuff that bit us": `lessons-learned.md`
+- For specific recurring tasks: `.claude/commands/*.md`

--- a/.claude/context/lessons-learned.md
+++ b/.claude/context/lessons-learned.md
@@ -1,0 +1,411 @@
+# Lessons learned — quantum-metal hard-won fixes
+
+Every entry here is a real bug I (or a previous agent) shipped a fix
+for. Reading this first saves you hours of re-discovering the same
+walls from scratch.
+
+Each entry: **symptom → cause → fix → reference commit / PR / test
+where applicable**.
+
+## Python / packaging
+
+### `uv run` auto-syncs the venv
+
+**Symptom**: You install a custom set of deps with `uv pip install
+foo bar` then later run `uv run python -c "..."` — and uv silently
+installs 80+ packages from `pyproject.toml`, overwriting your custom
+set.
+
+**Cause**: Inside a `uv`-managed project, `uv run` calls `uv sync`
+first. The flag `--no-sync` warns *"has no effect when used outside
+of a project"* if you're outside a project dir, but the side-effect
+applies regardless.
+
+**Fix**: For custom-installed venvs, invoke `.venv/bin/python`
+directly. Never use `uv run` if you've manually set up the venv
+contents.
+
+**Reference**: `.github/workflows/main.yml` `tests-lite` job uses
+`.venv/bin/python -m pytest …`, NOT `uv run pytest`. PR #1060 commit
+that fixed this is the cautionary tale.
+
+### `uv venv` doesn't ship `pip`
+
+**Symptom**: `.venv/bin/python -m pip install foo` fails with
+`No module named pip`.
+
+**Cause**: `uv venv` builds a minimal venv without pip — uv is the
+package manager.
+
+**Fix**: Use `uv pip install foo` (uv-mode pip). Or
+`uv pip install --python /path/to/venv/bin/python foo` if you need
+to target a specific venv.
+
+### `nbconvert --execute` uses kernel `python3` by default
+
+**Symptom**: `jupyter nbconvert --execute notebook.ipynb` fails with
+`No module named matplotlib` even though the venv has matplotlib.
+
+**Cause**: nbconvert spawns the kernel named in the notebook
+metadata. The default `python3` kernel points at the *system*
+Python, not the venv.
+
+**Fix**: Register the venv as a kernel and pass it explicitly:
+
+```bash
+.venv/bin/python -m ipykernel install --user --name my_kernel
+.venv/bin/jupyter nbconvert --execute \
+    --ExecutePreprocessor.kernel_name=my_kernel \
+    notebook.ipynb
+```
+
+**Reference**: `tests-lite` CI job's `Execute headless tutorial
+notebook` step (PR #1061).
+
+### `json.dump(..., ensure_ascii=True)` (default) escapes unicode
+
+**Symptom**: Re-saving a `.ipynb` you only made small edits to
+produces a 1000-line diff full of `χ` instead of `χ` etc.
+
+**Cause**: Python's `json.dump` defaults to ASCII-escaping all
+non-ASCII characters. Jupyter writes notebooks with
+`ensure_ascii=False` so they're readable; round-tripping with the
+default flips them.
+
+**Fix**: Always use `json.dump(..., ensure_ascii=False, indent=1)`
+when round-tripping `.ipynb` files. Match Jupyter's format
+exactly:
+
+```python
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(nb, f, indent=1, ensure_ascii=False)
+    f.write("\n")  # trailing newline
+```
+
+**Reference**: PR #1055 fixed an earlier notebook-fix script that
+had this bug.
+
+## Dependency-version traps
+
+### pandas 2.2: integer indexing on string-labeled Series
+
+**Symptom**: Code like `series[1]` works in dev but raises
+`KeyError: 1` on a clean install.
+
+**Cause**: pandas 2.2 removed the positional-fallback behavior for
+integer indexing when the Series has non-integer labels. Was a
+FutureWarning in 2.0/2.1.
+
+**Fix**: Use `series.iloc[1]` for positional, `series[label]` for
+label-based.
+
+**Reference**: `src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py:299`
+(`render_junction`). Surfaced when the lite venv pulled a newer
+pandas than the dev env.
+
+### qutip 5: `np.array([Qobj, ...])` no longer stacks
+
+**Symptom**: Code that worked under qutip 4 returns an object-dtype
+ndarray under qutip 5, and downstream math operations fail.
+
+**Cause**: qutip 5 changed `__array__` so a list of `Qobj` becomes
+a 1-D array of Python objects rather than a stacked numeric matrix.
+
+**Fix**: Convert each `Qobj` to numpy explicitly before stacking:
+
+```python
+mat = np.array([q.full() for q in qobj_list])  # OK
+```
+
+**Reference**: `src/qiskit_metal/analyses/hamiltonian/states_energies.py`
+(fixed in PR #1050).
+
+### qutip 5: `np.absolute(Qobj)` no longer works
+
+**Symptom**: Used to return a numpy array of magnitudes; now
+raises.
+
+**Fix**: Call `.full()` first: `np.absolute(qobj.full())`.
+
+### HFSS 2024.1+: solution-type rename
+
+**Symptom**: `o_design.GetSolutionType()` returns
+`"HFSS Modal Network"` or `"HFSS Hybrid Modal Network"` instead of
+`"DrivenModal"` on AEDT 2024.1+; downstream `== "DrivenModal"`
+checks silently fall through.
+
+**Cause**: Ansys renamed the strings. Same for Driven Terminal.
+
+**Fix**: pyEPR ≥ 0.9.5 normalises `design.solution_type` at read
+time, so most call sites are insulated. The exception is metal's
+own `set_mode` in `hfss_renderer.py` which calls
+`o_design.GetSolutionType()` directly — that needs the predicate
+helpers in `solution_types.py` (`is_drivenmodal`, `canonical_kind`,
+etc.).
+
+**Reference**:
+- `src/qiskit_metal/renderers/renderer_ansys/solution_types.py`
+- `tests/test_solution_types.py`
+- pyEPR PRs #172, #176
+
+### `numpy<2` pin is real
+
+**Symptom**: `pip install quantum-metal` followed by `pip install
+numpy>=2` downgrades or breaks something.
+
+**Cause**: Some transitive dep (suspected: pyaedt or qutip 5
+intermediate) requires `numpy<2`. Hasn't been root-caused.
+
+**Fix**: Until identified and upstream-resolved, the pin stays.
+Don't relax it casually.
+
+### `pyaedt<0.24` is a temporary pin
+
+**Symptom**: pyaedt 0.24 was buggy as of Jan 2026.
+
+**Cause**: noted in `pyproject.toml` comment.
+
+**Fix**: Retest periodically. As of v0.6.1 the pin is still in
+place; AWS Palace integration is the intended unblock for the
+broader pyaedt situation.
+
+## Qt / GUI / lazy-import
+
+### `import qiskit_metal` used to require PySide6
+
+**Symptom**: pre-v0.6.1, even setting `QISKIT_METAL_HEADLESS=1`
+would import `PySide6` at module load.
+
+**Cause**: `__setup_Qt_backend()` was called unconditionally at
+the bottom of `src/qiskit_metal/__init__.py`.
+
+**Fix (v0.6.1)**: Moved to opt-in `setup_qt_backend()`
+(idempotent), called automatically from `MetalGUI.__init__`.
+Top-level `MetalGUI` and `plt` are now lazy via PEP-562
+`__getattr__`. PySide6 imports in `mpl_interaction.py` are wrapped
+in `try/except ImportError` with `_require_qt()` gates on the
+functions that use them.
+
+**Reference**: PR #1060. Verify with:
+
+```bash
+QISKIT_METAL_HEADLESS=1 python3 -c "
+import sys
+class B:
+    def find_spec(self, name, path, target=None):
+        if name.startswith('PySide6'):
+            raise ImportError(f'BLOCKED: {name}')
+        return None
+sys.meta_path.insert(0, B())
+import qiskit_metal as qm
+fig = qm.view(qm.designs.DesignPlanar())
+print('OK without PySide6')
+"
+```
+
+### `QMplRenderer.canvas` is unused
+
+**Symptom**: You might think decoupling `QMplRenderer` from Qt
+requires a refactor of `PlotCanvas` interactions.
+
+**Cause**: It doesn't — `self.canvas` is stored on the instance
+and **never read by any method**.
+
+**Fix**: Make the `canvas` constructor arg optional. Done in
+v0.6.1.
+
+### `QMplRenderer.get_mask` had a silent bug
+
+**Symptom**: `hidden_layers={1}` had no effect when combined with
+hidden components.
+
+**Cause**: Two consecutive `mask = ...` lines, the second
+overwriting the first.
+
+**Fix**: OR the two filters. Now `mask = ... | ...`.
+
+**Reference**: `src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py`
+(PR #1060 fix). Caught by the new `test_view_hides_layers` test.
+
+### `_start_renderers` crashed on missing optional deps
+
+**Symptom**: `DesignPlanar()` raised `ModuleNotFoundError: No
+module named 'gmsh'` on lite installs.
+
+**Cause**: `_start_renderers` called `importlib.find_spec` (which
+succeeds because the renderer module exists in our source tree)
+then `importlib.import_module` (which fails because the EXTERNAL
+package isn't installed).
+
+**Fix**: Wrap `import_module` in `try/except ImportError`, log
+clear info pointing at the appropriate extras (`[fem]`,
+`[ansys]`).
+
+**Reference**: `src/qiskit_metal/designs/design_base.py`
+`_start_renderers` (PR #1060).
+
+## Release / CI
+
+### v0.6.0 tag exists but PyPI never received 0.6.0
+
+**Symptom**: GitHub tag `v0.6.0` exists with a published release
+page, but `pip install quantum-metal` still gets 0.5.4.
+
+**Cause**: The `bump-version` workflow failed at the
+commit-and-tag step (`HTTP 409: Could not update file: Changes
+must be made through a pull request`). Branch protection on `main`
+blocks the workflow's direct Contents API write. Tag was somehow
+created anyway (likely manually); it points at the v1054 merge
+commit where `pyproject.toml` still says 0.5.4. When `release.yml`
+fired from the tag push, `uv build` produced a `quantum-metal-0.5.4.whl`
+and `uv publish` failed with *"version already exists"*.
+
+**Fix** (applied for v0.6.1):
+1. Open a regular PR that bumps `pyproject.toml` (+ `uv.lock`).
+2. Merge via normal review flow.
+3. Push tag pointing at the merge commit.
+
+**Long-term fix**: Add `github-actions[bot]` to the branch-protection
+bypass list (Settings → Branches → Edit rule for `main`). Then the
+`bump-version` workflow works as written.
+
+**Reference**: PR #1056, `.claude/commands/release.md`.
+
+### `environment.yml` ↔ `pyproject.toml` drift
+
+**Symptom**: conda users get older versions of qutip/scqubits/etc.
+than pip users — silent runtime breakage.
+
+**Cause**: Two files declared the same package's lower bound
+independently. Drift accumulated across PRs.
+
+**Fix**: `scripts/check_env_consistency.py` parses both, asserts
+env.yml's allowed range ⊆ pyproject.toml's. Wired into CI as the
+`env-consistency` job. First run caught 5 drifts (geopandas,
+pandas, pint, shapely, pyaedt).
+
+**Reference**: PR #1057.
+
+### CLA bot fires on every Claude-authored PR
+
+**Symptom**: Every PR Claude opens gets a CLA-bot comment within
+seconds.
+
+**Cause**: Default CLA gate on the repo, treats `claude` as a new
+contributor.
+
+**Fix**: Only the human can satisfy it. Mention it in PR
+templates so users know to expect it.
+
+## Tutorials / docs
+
+### Notebook heading-level skips trip nbsphinx
+
+**Symptom**: Sphinx docs build prints `CRITICAL: Title level
+inconsistent` for many tutorial notebooks.
+
+**Cause**: Tutorial authors used `#` then `###`, skipping `##`.
+nbsphinx renders these to RST with corresponding heading levels;
+RST requires the hierarchy to be contiguous.
+
+**Fix**: Programmatic normalisation script (track parent depth via
+a stack, demote skipped levels to parent+1). Applied to 26 of 40
+notebooks in PR #1055.
+
+### Sphinx "document isn't included in any toctree" for `apidocs/`
+
+**Symptom**: ~100 warnings on every docs build.
+
+**Cause**: `apidocs/` contains auto-generated per-class stub
+files that are only linked from module pages, not the main
+toctree.
+
+**Fix**: Add a hidden `:glob:` toctree at the bottom of
+`docs/index.rst`:
+
+```rst
+.. toctree::
+    :hidden:
+    :glob:
+
+    apidocs/*
+```
+
+**Reference**: PR #1055.
+
+### CONTRIBUTING.md was telling people to use pylint+yapf
+
+**Symptom**: New contributors' PRs failed lint because they used
+the wrong tools.
+
+**Cause**: The guide hadn't been updated since the ruff migration.
+
+**Fix**: Updated to ruff with `charliermarsh.ruff` VSCode
+extension. PR #1057.
+
+## Ruff findings worth knowing
+
+### `is 0` / `is 1` worked by accident
+
+**Symptom**: ruff F632 flags `len(polys) is 2`, `xoff is 0`, etc.
+
+**Cause**: CPython interns small integers, so `5 is 5` returns
+True coincidentally. Per the language spec this is undefined.
+
+**Fix**: Change to `==`. Was a real bug that happened to not
+manifest. PR #1055 fixed 5 instances.
+
+### 13 deferred ruff findings live in HFSS/`_gui/`
+
+**Symptom**: `uvx ruff check src` reports 13 errors.
+
+**Cause**: All in do-not-touch zones (E711 None-comparisons in
+`renderer_ansys_pyaedt`, E721 type comparisons in `_gui/`, an
+F811 dead `render_chip` stub in `ansys_renderer.py:1053`).
+
+**Fix**: Documented in PR #1057's commit message. Wait for HFSS /
+Qt validation environment (AWS Palace, dedicated Windows
+runner) before fixing.
+
+## Geometry / pin / HFSS-adjacent
+
+### `LaunchpadWirebondDriven.in` pin normal points inward
+
+**Symptom**: `test_pin_normals_point_outward` fails for
+`LaunchpadWirebondDriven`.
+
+**Cause**: The `driven_pin_line` `LineString` is constructed in
+the same downward-y point order as its `main_pin_line`, but sits
+on the opposite side of the pad — so both pins get a `+x` normal
+even though `"in"` needs `-x`.
+
+**Fix**: Swap the two points in `driven_pin_line`. Single-line
+change. But it changes HFSS port orientation and needs Ansys
+validation before landing.
+
+**Reference**: `tests/test_qlibrary_pin_sanity.py`
+`KNOWN_INWARD_PINS`. PR #1062.
+
+### Pin `points` order determines the normal direction
+
+**Symptom**: A new component's pin renders "the wrong way" in
+HFSS — port plane inside the conductor.
+
+**Cause**: `add_pin` computes the normal from the cross product
+of the line tangent with z-up. Walking from point 0 to point 1,
+the normal is "to the right" — flip the order and the normal
+flips 180°.
+
+**Fix**: Verify visually with `qm.view(design)` before relying on
+HFSS results. Then use `test_pin_normals_point_outward` to gate
+in CI.
+
+## What this list doesn't include
+
+Stuff that's NOT a "lesson learned" — those go in
+`.claude/context/architecture.md` (how things are structured) or
+`.claude/context/ecosystem.md` (why things are the way they are).
+This file is **specifically things that bit us in production**.
+
+When you fix a real bug, add an entry here. Future agents will
+thank you.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md — Quantum Metal repo guide for AI agents
+
+> If you are a Claude (or other AI agent) opening this repo for the first
+> time, **read this file end-to-end before touching anything**. It points
+> at the rest of the context that will save you hours.
+
+## What this repo is
+
+**Quantum Metal** (formerly Qiskit Metal) is an open-source Python framework
+for designing and analysing superconducting quantum chips. The PyPI package
+is `quantum-metal`; the import path is still `qiskit_metal` for backward
+compatibility. The community-maintained successor to IBM's original
+Qiskit Metal — the rebrand is in progress through the v0.6.x line.
+
+Stack: Python 3.10–3.12 · `shapely` for geometry · `geopandas` /
+`pandas` for storage · `matplotlib` for headless viewing · `PySide6` for
+the optional desktop GUI · `pyEPR-quantum` / `pyaedt` / `gmsh` /
+`Elmer` for analysis backends.
+
+## Architecture map (skim these first)
+
+| Path | What lives there |
+|------|------------------|
+| `src/qiskit_metal/qlibrary/` | All `QComponent` subclasses (transmons, terminations, lumped, couplers, routes, sample shapes). The user-visible catalogue. |
+| `src/qiskit_metal/qlibrary/core/base.py` | `QComponent` — the load-bearing base class. Read end-to-end before touching any component. |
+| `src/qiskit_metal/designs/` | `QDesign` and subclasses (`DesignPlanar`, `DesignFlipChip`, ...). Components attach to a design. |
+| `src/qiskit_metal/renderers/renderer_base/` | `QRenderer` and `QRendererAnalysis` — the two abstract bases. See `docs/architecture/renderer_protocol.md`. |
+| `src/qiskit_metal/renderers/renderer_ansys/` | Legacy COM-based HFSS/Q3D renderer. Hard-touch zone. |
+| `src/qiskit_metal/renderers/renderer_ansys_pyaedt/` | New pyaedt-based HFSS/Q3D renderer. Migration in progress. |
+| `src/qiskit_metal/renderers/renderer_gds/` | `QGDSRenderer` — export to GDS. Pure-Python; safe to touch. |
+| `src/qiskit_metal/renderers/renderer_mpl/` | The matplotlib renderer used by both the Qt GUI and `qm.view`. `QMplRenderer` no longer requires Qt as of v0.6.1. |
+| `src/qiskit_metal/renderers/renderer_gmsh/`, `renderer_elmer/` | Open-source FEM path. Depends on `gmsh` (optional). |
+| `src/qiskit_metal/viewer/` | New (v0.6.1) — `qm.view(design)` headless entry point. |
+| `src/qiskit_metal/_gui/` | The Qt desktop GUI (`MetalGUI`). Hard-touch zone unless you have a Qt session to test in. |
+| `src/qiskit_metal/analyses/` | Pure-Python analyses (Hamiltonian, capacitance, EPR). qutip 5+. |
+| `tests/` | unittest-style suite. `pytest tests/` to run; gated in CI on every PR. |
+| `tutorials/` | 40+ Jupyter notebooks. Numbered (1-Overview / 2-Components / 3-Renderers / 4-Analysis). |
+| `docs/` | Sphinx. `tox -e docs` to build. |
+| `scripts/check_env_consistency.py` | CI gate that asserts `environment.yml` and `pyproject.toml` agree. |
+
+## Hard constraints — do not touch without explicit human approval
+
+1. **`renderers/renderer_ansys/`** — COM-based HFSS/Q3D. Requires Ansys
+   AEDT on Windows to validate. Even type-comparison changes have
+   shipped silent bugs.
+2. **`renderers/renderer_ansys_pyaedt/`** — same constraint for the
+   pyaedt-based replacement.
+3. **`_gui/` and everything inside it** — requires interactive Qt
+   session to verify behavior.
+4. **The pyEPR integration bridge** (`renderer_ansys/parse.py`,
+   `solution_types.py` interaction with `pyEPR.solution_types`).
+   Cross-repo coordination required.
+5. **Public method signatures on `QComponent`, `QDesign`,
+   `QRenderer`** — no breaking changes without deprecation path.
+
+**If you find a real bug in any of the above, document it (e.g. in a
+test's `KNOWN_*` skip list, see `tests/test_qlibrary_pin_sanity.py`)
+rather than silently fixing.** A drive-by "fix" without HFSS / Qt
+validation is how silent S-parameter errors ship.
+
+## Read these next — context files
+
+| File | Read when |
+|------|-----------|
+| `.claude/context/lessons-learned.md` | **Always.** Every hard-won fix from real debugging — pandas-2.2 indexing, qutip-5 API, lazy Qt, uv-auto-sync, the v0.6.0 release failure, etc. Avoids re-discovering each from scratch. |
+| `.claude/context/architecture.md` | When you need to make structural changes — class hierarchy, option flow, renderer dispatch, lazy-Qt design. |
+| `.claude/context/ecosystem.md` | When making roadmap / API / version decisions — who the users are, the pyEPR/pyaedt/AWS-Palace relationships, the v0.7.0 lite-by-default plan. |
+| `docs/architecture/renderer_protocol.md` | When adding or modifying a renderer. The full inheritance map and override matrix. |
+| `docs/headless-usage.rst` | When working on the Qt-free path or onboarding flow. |
+
+## Recurring tasks — slash commands
+
+| Command | What it does |
+|---------|--------------|
+| `.claude/commands/health-check.md` | `/health-check` — broad repo audit: CI status, deps, lint, test coverage, drift, recent activity. |
+| `.claude/commands/release.md` | `/release` — step-by-step release procedure including the post-mortem of the v0.6.0 failure. |
+| `.claude/commands/headless-check.md` | `/headless-check` — verify `import qiskit_metal` and `qm.view(design)` work without PySide6. Reproduces the `tests-lite` CI job locally. |
+| `.claude/commands/refresh-tutorial.md` | `/refresh-tutorial` — apply the standard "no-Qt callout" to a tutorial or batch of tutorials. |
+
+## Testing & CI quick reference
+
+- Full suite: `QISKIT_METAL_HEADLESS=1 uv run pytest tests/` (~30s)
+- Lint: `uvx ruff check src` (currently 13 known findings, all in
+  HFSS/`_gui/` zones — see lessons-learned)
+- Format: `uvx ruff format src`
+- Docs build: `tox -e docs`
+- Env-drift check: `uv run scripts/check_env_consistency.py`
+
+CI matrix on every PR: 9 test combos (py3.10/3.11/3.12 ×
+ubuntu/macos/windows) + `lint` + `env-consistency` + `coverage` +
+`tests-lite` (including notebook-execute).
+
+## Status snapshot (as of v0.6.1, May 2026)
+
+- Latest release: **v0.6.1** on PyPI (after the v0.6.0 tag-only
+  failure — see `.claude/commands/release.md`)
+- Test count: **~475 passing**, 0 failing, 0 flaky
+- New no-Qt path: `qm.view(design)` works with `pip install
+  quantum-metal[lite]` (and the default install too — additive in
+  v0.6.x; planned default flip in v0.7.0)
+- HFSS 2024.1+ solution-type rename: handled via
+  `solution_types.py` + pyEPR 0.9.5 normalisation
+- qutip 5+ compatibility: shipped in v0.6.0/0.6.1
+- 13 ruff findings deferred (all in HFSS/`_gui/` zones — need
+  validation)
+- 1 known HFSS bug deferred: `LaunchpadWirebondDriven.in` pin points
+  inward (see `tests/test_qlibrary_pin_sanity.py` `KNOWN_INWARD_PINS`)
+- AWS Palace integration on the roadmap — will unblock HFSS-free
+  validation of the above


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` + `.claude/` repo know-how, mirroring the pattern established in [`zlatko-minev/pyEPR`](https://github.com/zlatko-minev/pyEPR). The goal: a future Claude (or any AI agent) opening this repo for the first time can orient itself without re-discovering every wall from scratch.

## What's in this PR

```
CLAUDE.md                            top-level entry point — agents read this first
.claude/
├── context/                         deep background — read as needed
│   ├── lessons-learned.md          every hard-won fix from real debugging
│   ├── architecture.md             class hierarchy, option flow, lazy-Qt design
│   └── ecosystem.md                user groups, repo relationships, adoption strategy
└── commands/                       slash commands — load on demand
    ├── health-check.md             /health-check — broad repo audit
    ├── release.md                  /release — PyPI release procedure + v0.6.0 post-mortem
    ├── headless-check.md           /headless-check — reproduce tests-lite locally
    └── refresh-tutorial.md         /refresh-tutorial — add no-Qt callout to a tutorial folder
```

**8 files, 1666 lines added, 0 removed.** Pure documentation; no code changes.

## Why this matters

Without this, a future session has to:
- Re-discover that `uv run` auto-syncs and silently undoes manual venv setup
- Re-discover that `uv venv` doesn't ship pip
- Re-derive the lazy-Qt architecture introduced in v0.6.1
- Re-investigate the v0.6.0 release failure
- Re-find the 13 deferred ruff findings, the known-inward pin, the pandas 2.2 indexing gotcha
- Re-figure out which directories are hard-touch zones and why
- Re-derive the migration path to v0.7.0 lite-by-default

Each of those was a real hour-or-more debugging session this round. Captured here so we pay the cost once.

## Highlights from `lessons-learned.md`

15 entries spanning four categories:

- **Python / packaging**: `uv run` auto-sync, `uv venv` no-pip, `nbconvert --execute` kernel registration, `json.dump` unicode escaping
- **Dependency-version traps**: pandas 2.2 positional indexing, qutip 5 `Qobj` stacking, HFSS 2024.1+ rename, `numpy<2` blocker, `pyaedt<0.24` rationale
- **Qt / GUI / lazy-import**: the v0.6.1 refactor, `QMplRenderer.canvas` unused, `get_mask` silent bug, `_start_renderers` graceful skip
- **Release / CI**: v0.6.0 post-mortem, env-drift gate, CLA bot reality
- **Tutorials / docs**: notebook heading-level skips, `:glob:` toctree fix, CONTRIBUTING.md stale-tools, `is 0` latent bugs
- **Geometry / HFSS-adjacent**: `LaunchpadWirebondDriven.in` inward pin, pin `points` order

## Highlights from the four commands

- **`/health-check`**: standard audit checklist + expected ruff baseline (22 with 13 deferred), env-consistency expected output, dependabot fallback when MCP isn't available.
- **`/release`**: the cautionary v0.6.0 story up top (what failed and why), then a manual-PR procedure (what we actually did for v0.6.1) plus the workflow-based procedure for when branch-protection bypass is configured.
- **`/headless-check`**: reproduces `tests-lite` locally — lite venv, `uv pip install` (not `python -m pip`), `.venv/bin/python` (not `uv run`), ipykernel registration, traceback hook to find Qt-import culprits.
- **`/refresh-tutorial`**: the injection-script template, the relative-link-depth gotcha, the `ensure_ascii=False` warning, the idempotency check.

## Test plan

- [ ] CI green (docs-only change; only the env-consistency / lint jobs are relevant)
- [ ] `CLAUDE.md` renders correctly on github.com
- [ ] Future agents that read `CLAUDE.md` first don't need to ask me how `uv run` works

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_