### PR TITLE
tutorials: complete no-Qt callout rollout (65 notebooks) + verify qutip5/pyEPR sync

### DIFF
--- a/tutorials/3 Renderers/3.1 Introduction to QRenderers.ipynb
+++ b/tutorials/3 Renderers/3.1 Introduction to QRenderers.ipynb
@@ -10,6 +10,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/3 Renderers/3.2 Export your design to GDS.ipynb
+++ b/tutorials/3 Renderers/3.2 Export your design to GDS.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For convenience, let's begin by enabling [automatic reloading of modules](https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html?highlight=autoreload) when they change."
    ]
   },

--- a/tutorials/3 Renderers/3.3 Render your design to Ansys.ipynb
+++ b/tutorials/3 Renderers/3.3 Render your design to Ansys.ipynb
@@ -13,6 +13,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Prerequisite\n",
     "You need to have Ansys installed locally (any version) - at the time of this notebook, Ansys is only supported in Windows.\n",
     "\n",

--- a/tutorials/3 Renderers/3.4 How do I make my custom QRenderer.ipynb
+++ b/tutorials/3 Renderers/3.4 How do I make my custom QRenderer.ipynb
@@ -15,6 +15,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/tutorials/3 Renderers/3.5 Render your design to Gmsh.ipynb
+++ b/tutorials/3 Renderers/3.5 Render your design to Gmsh.ipynb
@@ -30,6 +30,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "53155980-d117-4a08-a59c-052eb4b389aa",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.01 Capacitance and LOM.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.01 Capacitance and LOM.ipynb
@@ -13,6 +13,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Create the design in Metal"
    ]
   },

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.02 Eigenmode and EPR.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.02 Eigenmode and EPR.ipynb
@@ -13,6 +13,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Sections\n",
     "### I. Transmon only\n",
     "1. Prepare the layout in qiskit-metal. <br>\n",

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.03 Impedance.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.03 Impedance.ipynb
@@ -11,6 +11,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "31117997",

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.04 New LOM and Fluxonium Example.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.04 New LOM and Fluxonium Example.ipynb
@@ -26,6 +26,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c5723516-ee06-4a8a-bb99-f47a163f5df1",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.05 New LOM and Two Coupled Transmon Example with sequence.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.05 New LOM and Two Coupled Transmon Example with sequence.ipynb
@@ -32,6 +32,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "32717ec8-f907-4902-bc2c-f5a17a7516bc",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/A. Core - EM and quantization/4.05 New LOM and Two Coupled Transmon Example.ipynb
+++ b/tutorials/4 Analysis/A. Core - EM and quantization/4.05 New LOM and Two Coupled Transmon Example.ipynb
@@ -34,6 +34,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "ae62a64a-ad98-4656-8882-c617a783f244",

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.11 Analyze and tune a transmon.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.11 Analyze and tune a transmon.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "452d9633",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.12 Analyze a resonator.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.12 Analyze a resonator.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b0b5c3a4",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.13 Analyze transmon and resonator.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.13 Analyze transmon and resonator.ipynb
@@ -11,6 +11,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "88653173",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.14 Analyze a double hanger resonator (S Param).ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.14 Analyze a double hanger resonator (S Param).ipynb
@@ -10,6 +10,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.15 CPW kappa calculation.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.15 CPW kappa calculation.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5955a435",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.16 Analyze S21 of Hange Geometry with WirebondLunchpadDriven.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.16 Analyze S21 of Hange Geometry with WirebondLunchpadDriven.ipynb
@@ -11,6 +11,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0b0da17a",

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.17 Fit S21 of Hanger Resonator Geometry.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.17 Fit S21 of Hanger Resonator Geometry.ipynb
@@ -14,6 +14,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "abc2b76d",
    "metadata": {},
    "source": []

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.18 Analyse a Resonator with Ports.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.18 Analyse a Resonator with Ports.ipynb
@@ -14,6 +14,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "abc2b76d",
    "metadata": {},
    "source": []

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Analyze a transmon using ElmerFEM.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Analyze a transmon using ElmerFEM.ipynb
@@ -39,6 +39,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "be3cbb43-2c24-4139-b690-1d56047a03c5",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/DrivenModal_pyaedt_multiplanar.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/DrivenModal_pyaedt_multiplanar.ipynb
@@ -12,6 +12,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "17e679bd-09ba-455f-bb7e-cf39d3a09549",

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/Eigenmode_pyaedt_multiplanar.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/Eigenmode_pyaedt_multiplanar.ipynb
@@ -11,6 +11,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/Q3D_pyaedt_multiplanar.ipynb
+++ b/tutorials/4 Analysis/B. Advanced - Direct use of the renderers/4.19 Multiplanar with pyaedt for Ansys/Q3D_pyaedt_multiplanar.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "859dc50e-c7b4-437f-8786-2e1d2ac2a82e",

--- a/tutorials/4 Analysis/C. Parametric sweeps/4.21 Capacitance matrix.ipynb
+++ b/tutorials/4 Analysis/C. Parametric sweeps/4.21 Capacitance matrix.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Prerequisite\n",
     "You need to have a working local installation of Ansys"
    ]

--- a/tutorials/4 Analysis/C. Parametric sweeps/4.22 Eigenmode matrix.ipynb
+++ b/tutorials/4 Analysis/C. Parametric sweeps/4.22 Eigenmode matrix.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Prerequisite\n",
     "You need to have a working local installation of Ansys"
    ]

--- a/tutorials/4 Analysis/C. Parametric sweeps/4.23 Impedance and scattering Z S Y matrices.ipynb
+++ b/tutorials/4 Analysis/C. Parametric sweeps/4.23 Impedance and scattering Z S Y matrices.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ced70c0a",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.31 Plot quantum oscillator wavefunction.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.31 Plot quantum oscillator wavefunction.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "incident-serial",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.32 Transmon analytics HCPB.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.32 Transmon analytics HCPB.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "velvet-cloud",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.33 Transmon analytics.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.33 Transmon analytics.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cc0856a2",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.34 Transmon qubit CPB hamiltonian charge basis.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/4.34 Transmon qubit CPB hamiltonian charge basis.ipynb
@@ -9,6 +9,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "(Zlatko Minev, Christopher Warren, Nick Lanzillo 2021)"
    ],

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/Design and Simulation of a Cross-Resonance Gate.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/Design and Simulation of a Cross-Resonance Gate.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c806b8fd",
    "metadata": {},
    "source": [

--- a/tutorials/4 Analysis/D. Hamiltonian models - after quantization/cQED with the Jaynes-Cummings Interaction Model.ipynb
+++ b/tutorials/4 Analysis/D. Hamiltonian models - after quantization/cQED with the Jaynes-Cummings Interaction Model.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "28a5580c",
    "metadata": {},
    "source": [

--- a/tutorials/Appendix A Full design flow examples/Example full chip design.ipynb
+++ b/tutorials/Appendix A Full design flow examples/Example full chip design.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix A Full design flow examples/Example used in the launch video.ipynb
+++ b/tutorials/Appendix A Full design flow examples/Example used in the launch video.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix A Full design flow examples/Exercise for the South Korea Hackathon'20.ipynb
+++ b/tutorials/Appendix A Full design flow examples/Exercise for the South Korea Hackathon'20.ipynb
@@ -10,6 +10,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix A Full design flow examples/Qiskit_Metal_IMS2022_Notebook.ipynb
+++ b/tutorials/Appendix A Full design flow examples/Qiskit_Metal_IMS2022_Notebook.ipynb
@@ -14,6 +14,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Qiskit Metal Tutorial for IMS 2022"
    ]
   },

--- a/tutorials/Appendix B Quick topics/JJ Demo Notebook.ipynb
+++ b/tutorials/Appendix B Quick topics/JJ Demo Notebook.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "This demo notebook describes two types of Josephson Junction (JJ) qcomponents available in Qiskit Metal, including a \"Manhattan\"-style JJ and a \"Dolan\"-style JJ. In addition, we demonstrate how to insert these realistic JJ structures in between the capacative pads of the transmon pocket qcomponent, forming a realistic qubit design. "
    ]
   },

--- a/tutorials/Appendix B Quick topics/Managing pins.ipynb
+++ b/tutorials/Appendix B Quick topics/Managing pins.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix B Quick topics/Managing variables.ipynb
+++ b/tutorials/Appendix B Quick topics/Managing variables.ipynb
@@ -9,6 +9,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix B Quick topics/Opening documentation.ipynb
+++ b/tutorials/Appendix B Quick topics/Opening documentation.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Website address"
    ]
   },

--- a/tutorials/Appendix B Quick topics/QComponent - 3-fingers capacitor.ipynb
+++ b/tutorials/Appendix B Quick topics/QComponent - 3-fingers capacitor.ipynb
@@ -9,6 +9,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix B Quick topics/QComponent - Interdigitated transmon.ipynb
+++ b/tutorials/Appendix B Quick topics/QComponent - Interdigitated transmon.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "looking-velvet",
    "metadata": {},
    "source": [

--- a/tutorials/Appendix B Quick topics/Testing QComponents for overlap and collisions.ipynb
+++ b/tutorials/Appendix B Quick topics/Testing QComponents for overlap and collisions.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "94731f0b",
    "metadata": {},
    "source": [

--- a/tutorials/Appendix C Circuit examples/A. Qubits/01-Transmon_cross.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/01-Transmon_cross.ipynb
@@ -14,6 +14,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/02-Transmon_floating.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/02-Transmon_floating.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/03-concentric_transmon.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/03-concentric_transmon.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/04-Interdigitated_Transmon.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/04-Interdigitated_Transmon.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "looking-velvet",
    "metadata": {},
    "source": [

--- a/tutorials/Appendix C Circuit examples/A. Qubits/05-Transmon_cross_fl.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/05-Transmon_cross_fl.ipynb
@@ -14,6 +14,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/06-Transmon_floating_6.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/06-Transmon_floating_6.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/07-Transmon_floating_cl.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/07-Transmon_floating_cl.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/08-JJ-Dolan.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/08-JJ-Dolan.ipynb
@@ -10,6 +10,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/09-JJ-Manhattan.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/09-JJ-Manhattan.ipynb
@@ -10,6 +10,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/10-Transmon_floating_teeth.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/10-Transmon_floating_teeth.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/A. Qubits/11-Star_shaped_qubit.ipynb
+++ b/tutorials/Appendix C Circuit examples/A. Qubits/11-Star_shaped_qubit.ipynb
@@ -14,6 +14,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "4920e2a9",

--- a/tutorials/Appendix C Circuit examples/B. Resonators/11-Resonator_Meander.ipynb
+++ b/tutorials/Appendix C Circuit examples/B. Resonators/11-Resonator_Meander.ipynb
@@ -16,6 +16,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/C. Composite-bi-partite/21-OneTransmonsWithMeanderAndOTG.ipynb
+++ b/tutorials/Appendix C Circuit examples/C. Composite-bi-partite/21-OneTransmonsWithMeanderAndOTG.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/D. Qubit-couplers/31-TwoCrossmonsTunableCoupler.ipynb
+++ b/tutorials/Appendix C Circuit examples/D. Qubit-couplers/31-TwoCrossmonsTunableCoupler.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/D. Qubit-couplers/32-TwoTransmonsDirectCoupling.ipynb
+++ b/tutorials/Appendix C Circuit examples/D. Qubit-couplers/32-TwoTransmonsDirectCoupling.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/D. Qubit-couplers/33-TwoTransmonsWithMeander.ipynb
+++ b/tutorials/Appendix C Circuit examples/D. Qubit-couplers/33-TwoTransmonsWithMeander.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/E. Input-output-coupling/41-LaunchPad.ipynb
+++ b/tutorials/Appendix C Circuit examples/E. Input-output-coupling/41-LaunchPad.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Preparations"
    ]
   },

--- a/tutorials/Appendix C Circuit examples/E. Input-output-coupling/42-ResonatorAndLaunchPad.ipynb
+++ b/tutorials/Appendix C Circuit examples/E. Input-output-coupling/42-ResonatorAndLaunchPad.ipynb
@@ -8,6 +8,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/E. Input-output-coupling/43-TransmonPocketCL.ipynb
+++ b/tutorials/Appendix C Circuit examples/E. Input-output-coupling/43-TransmonPocketCL.ipynb
@@ -13,6 +13,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/tutorials/Appendix C Circuit examples/F. Small-quantum-chips/51-Four_qubit_chip.ipynb
+++ b/tutorials/Appendix C Circuit examples/F. Small-quantum-chips/51-Four_qubit_chip.ipynb
@@ -11,6 +11,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Creates a complete quantum chip and exports it"
    ]
   },

--- a/tutorials/Appendix C Circuit examples/F. Small-quantum-chips/Full Physical Design of iSWAP Gates.ipynb
+++ b/tutorials/Appendix C Circuit examples/F. Small-quantum-chips/Full Physical Design of iSWAP Gates.ipynb
@@ -10,6 +10,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](../../1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../../../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3650bd31",
    "metadata": {},
    "source": [

--- a/tutorials/FlipChip_designtutorial.ipynb
+++ b/tutorials/FlipChip_designtutorial.ipynb
@@ -14,6 +14,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 💡 **Using this tutorial without the Qt GUI**\n",
+    "> \n",
+    "> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.\n",
+    "> \n",
+    "> See [1.4 Headless quick view](1%20Overview/1.4%20Headless%20quick%20view%20%28no%20Qt%20GUI%29.ipynb) for a complete runnable walkthrough and [`docs/headless-usage.rst`](../docs/headless-usage.rst) for the full reference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1ea0705e",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary

Two completions packaged together as requested:

1. **qutip / pyEPR version sync — verified** (no code changes; already correct on main)
2. **Tutorial no-Qt callout rollout completed** for the remaining 65 notebooks

Both verified against the existing test suite. Branch fresh off `main` — the originally-designated branch `claude/sync-qtip-pyepr-versions-tEJd1` is severely stale (would have reverted v0.6.1), so we ignored it.

## Part 1 — qutip / pyEPR version sync

### Already on main (no change needed)

| | Pin |
|---|---|
| `pyproject.toml` `requires-python` | `>=3.10,<3.13` |
| `pyproject.toml` `qutip` | `>=5.0.0` |
| `pyproject.toml` `pyEPR-quantum` | `>=0.9.5` |
| `environment.yml` `python` | `>=3.10` |
| `environment.yml` `qutip` | `>=5.0.0` |
| Installed in CI | qutip **5.2.2** / pyEPR **0.9.5** |

### qutip 5 API audit

The code already explicitly handles the v5 API breaks:

- **`states_energies.py:83-84`** — comment explicitly calls out that `np.array([Qobj, ...])` produces object-dtype in qutip>=5; calls `.full()` before stacking.
- **`states_energies.py:121-122`** — comment explains `Qobj` no longer supports `np.absolute` in v5; converts to numpy via `.full()` first.
- **`transmon_charge_basis.py`** — uses only the stable `qt.Qobj(numpy_array)` ctor.
- **`tests/test_analyses_2_functionality.py:844-846`** — explicitly tolerates both v4 `dims=[[3,3],[1]]` and v5 `dims=[[3,3],[1,1]]`.

### Test result

```
$ uv run pytest tests/test_analyses_2_functionality.py
30 passed in 17.2s

$ QISKIT_METAL_HEADLESS=1 uv run pytest tests/
446 passed, 36 warnings, 94 subtests in 31.30s
```

### One pre-existing finding (NOT fixed in this PR)

`src/qiskit_metal/toolbox_metal/about.py:49-50` unconditionally imports `PySide6.QtCore` inside the `about()` function body. This is a latent lite-mode bug — `qm.about()` crashes if PySide6 isn't installed. Left untouched because (a) it doesn't break `import qiskit_metal`, (b) it's not a regression, (c) the fix needs a small refactor that's out of scope here. Recorded for a follow-up.

## Part 2 — Tutorial callout rollout

Continues PRs #1061 / #1062 (which covered `1 Overview/` and `2 From components to chip/`). Finishes the rollout:

| Folder | Notebooks |
|---|---|
| `3 Renderers/` | 5 |
| `4 Analysis/{A,B,C,D}/` | 27 |
| `Appendix A Full design flow examples/` | 4 |
| `Appendix B Quick topics/` | 7 |
| `Appendix C Circuit examples/` | 21 |
| `tutorials/FlipChip_designtutorial.ipynb` (was loose at root) | 1 |
| **Total** | **65** |

### What gets injected

Per-tutorial, immediately after the title cell:

> 💡 **Using this tutorial without the Qt GUI**
> 
> This tutorial uses the desktop `MetalGUI`. To follow along on Colab, Binder, JupyterHub, or any environment where Qt isn't available, **replace any `gui.rebuild()` / `gui.screenshot()` call with `qm.view(design)`** — it renders the design to a matplotlib `Figure` you can display inline or save with `fig.savefig(...)`.
> 
> See [1.4 Headless quick view](...) for a complete runnable walkthrough and [`docs/headless-usage.rst`](...) for the full reference.

Relative links are **depth-aware** — the injection script computes the correct number of `../` based on each notebook's path (depths 0, 1, and 2 all produce valid links).

### Properties

- ✅ **Idempotent**: rerun reports `0 added, 65 skipped`
- ✅ **Purely additive**: `+717 / -2` lines. The 2 deletions are benign trailing-newline normalisations on two notebooks that lacked a final `\n`
- ✅ **JSON-valid**: 81/81 tutorials in the repo still parse
- ✅ **`ensure_ascii=False`** during `json.dump` — preserves `χ`, `ψ`, `π`, `ε`, etc. and keeps the diff small (see `.claude/context/lessons-learned.md`)
- ✅ **Notebooks NOT re-executed** — GUI screenshots and outputs preserved bit-for-bit

### After this PR

Every tutorial in the repo carries the headless callout. The `/refresh-tutorial` command in `.claude/commands/` is now effectively a maintenance tool — its idempotency check handles any new notebook that gets added later.

## Test plan

- [ ] CI green (docs/tutorials-only change; `lint`, `tests-lite`, `env-consistency` are the relevant gates)
- [ ] `tests-lite` notebook-execute step still passes (we only added markdown; no code cells changed)
- [ ] Spot-check rendered callouts on github.com look right and the `1.4` link clicks through

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_