### PR TITLE
fix(about): make qm.about() work without PySide6 (lite-mode crash)

### DIFF
--- a/src/qiskit_metal/toolbox_metal/about.py
+++ b/src/qiskit_metal/toolbox_metal/about.py
@@ -46,19 +46,21 @@ def about():
         str: About message
     """
     import qiskit_metal
-    from PySide6.QtCore import __version__ as QT_VERSION_STR
-    from PySide6 import __version__ as PYSIDE_VERSION_STR
 
+    # PySide6 is an optional extra (``quantum-metal[gui]``) — the lite
+    # install path omits it, so about() must not require it.
     try:
-        import matplotlib
-        #matplotlib_ver = matplotlib.__version__
-    except:
-        #matplotlib_ver = 'None'
-        pass
+        from PySide6.QtCore import __version__ as QT_VERSION_STR
+        from PySide6 import __version__ as PYSIDE_VERSION_STR
+    except ImportError:
+        QT_VERSION_STR = 'Not installed'
+        PYSIDE_VERSION_STR = 'Not installed'
+
+    import matplotlib
 
     try:
         from sip import SIP_VERSION_STR
-    except:
+    except ImportError:
         SIP_VERSION_STR = 'Not installed'
     # Riverbank: SIP is a tool for quickly writing Python modules that interface with
     # C++ and C libraries.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -199,5 +199,26 @@ class TestQMplRendererStandalone(unittest.TestCase):
         self.assertIs(renderer.canvas, sentinel)
 
 
+class TestAboutNoQt(unittest.TestCase):
+    """``qm.about()`` must not require PySide6 — it's a debug helper
+    that lite-mode users rely on. Lives in test_viewer.py because
+    that file is in the tests-lite suite; test_toolbox_metal.py is
+    not, so a regression there wouldn't be caught before users."""
+
+    def test_about_runs_without_pyside6(self):
+        """about() must return its summary string even when PySide6 /
+        SIP aren't installed. In the lite CI venv this exercises the
+        real ImportError branch; in the full venv it exercises the
+        success path but still confirms about() doesn't raise."""
+        from qiskit_metal.toolbox_metal import about as about_module
+        text = about_module.about()
+        self.assertIsInstance(text, str)
+        # The summary always reports something for these fields,
+        # even in lite mode where the value is "Not installed".
+        self.assertIn("PySide6 version", text)
+        self.assertIn("Qt version", text)
+        self.assertIn("SIP version", text)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`qm.about()` crashed in the lite install path because it imported `PySide6` unconditionally inside the function body. Fix: wrap the PySide6 imports in `try/except ImportError`, matching the pattern already used for the SIP import 10 lines below.

Flagged but left out of scope in #1064; addressing it here as a small focused PR.

## Root cause

`src/qiskit_metal/toolbox_metal/about.py:49-50` (before the fix):

```python
from PySide6.QtCore import __version__ as QT_VERSION_STR
from PySide6 import __version__ as PYSIDE_VERSION_STR
```

No guard. In a lite venv (`pip install quantum-metal[lite]`, Colab, Binder, JupyterHub, the upcoming v0.7.0 lite-by-default flip), calling `qm.about()` raised `ImportError` instead of reporting "Not installed".

## Why CI didn't catch this

`tests/test_toolbox_metal.py::test_toolbox_metal_about` does exercise the function, but `test_toolbox_metal.py` is **not** in the `tests-lite` job's allowlist (only `test_viewer.py`, `test_qlibrary_idempotency.py`, `test_qlibrary_pin_sanity.py`, `test_solution_types.py` run there). So the regression was invisible to CI even though we have a test for the function.

This PR fixes that by adding a new test class `TestAboutNoQt` to `test_viewer.py` (which **is** in the lite suite). In the lite venv it exercises the real `ImportError` branch; in the full venv it exercises the success path.

## Changes

**`src/qiskit_metal/toolbox_metal/about.py`** (-8 / +10):

- Wrap the two `PySide6` imports in `try/except ImportError`, defaulting `QT_VERSION_STR = PYSIDE_VERSION_STR = "Not installed"`.
- Drop the unreachable bare-`except` around `import matplotlib`. matplotlib is a hard core dep — it's always available, and the dead `try/except` would have `NameError`'d at line 82 if it ever fired.
- Change `except:` → `except ImportError:` on the SIP block for style consistency.

**`tests/test_viewer.py`** (+21): new `TestAboutNoQt::test_about_runs_without_pyside6` that calls `about()` and asserts the return is a string containing each of `"PySide6 version"`, `"Qt version"`, `"SIP version"`. Runs in the tests-lite suite.

## Verification

```
$ QISKIT_METAL_HEADLESS=1 uv run pytest tests/
447 passed, 0 failed       (was 446, +1 for the new test)

$ uvx ruff check src/qiskit_metal/toolbox_metal/about.py tests/test_viewer.py
All checks passed!

$ # Simulated lite mode (sys.meta_path block + clear PySide6 from
$ # sys.modules, then call about()):
PySide6 version     Not installed
Qt version          Not installed
SIP version         Not installed
OK: about() survives the lite-mode import block
```

## Test plan

- [ ] CI green — both `tests-lite` (now exercises the new `TestAboutNoQt` test under PySide6-absent conditions) and the full matrix
- [ ] `qm.about()` works in a fresh lite venv (manual smoke)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_