### PR TITLE
docs(conf): QT_API hint + archive working RTD config for future revival

### DIFF
--- a/docs/_archive/readthedocs/README.md
+++ b/docs/_archive/readthedocs/README.md
@@ -1,0 +1,90 @@
+# Archived: Read the Docs config
+
+This directory holds the Read the Docs (RTD) build configuration
+that was developed and **proven working** in PR
+[#1069](https://github.com/qiskit-community/qiskit-metal/pull/1069),
+but **not adopted** as the current docs host.
+
+Docs publishing currently lives on **GitHub Pages** via
+`.github/workflows/docs.yml`, deployed to
+https://qiskit-community.github.io/qiskit-metal/. Years of SEO,
+inbound links, and search-engine authority pointed at that URL
+made a hard cutover too expensive for now.
+
+This config is archived here so a future maintainer can revive it
+in minutes if/when the rebrand cutover, per-PR doc previews, or
+the versioned-docs UX become worth the switch.
+
+## How to revive
+
+1. `git mv docs/_archive/readthedocs/readthedocs.yaml .readthedocs.yaml`
+2. Sign in at https://readthedocs.org/ → **Import a Project** →
+   `qiskit-community/qiskit-metal`, project name `quantum-metal`
+3. **Important** — `qiskit-community` org restricts third-party
+   GitHub Apps. Have an org owner install the Read the Docs
+   GitHub App on the org (Settings → Integrations →
+   Installations) or whitelist it under
+   Settings → Third-party Access. Without this, RTD can't attach
+   the webhook and you only get manual rebuilds.
+4. Trigger a build on the RTD dashboard. First build takes
+   ~5–10 min.
+5. Update the three URL sites that point at the GH Pages address
+   so they show `https://quantum-metal.readthedocs.io/`:
+   - `pyproject.toml` `urls.documentation`
+   - `src/qiskit_metal/toolbox_metal/about.py` `open_docs()` default
+   - `src/qiskit_metal/_gui/main_window.py` `open_web_help()`
+6. Decide on the transition window for the existing GH Pages
+   site. Recommended: leave it running for 2–4 weeks with a
+   banner pointing to the new URL, then delete
+   `.github/workflows/docs.yml` and disable Pages in repo
+   settings.
+
+## What's known to work
+
+PR #1069 reached a green RTD build on the
+`claude/docs-to-rtd` branch. The config in this directory is the
+last-known-good version, with all fixes incorporated:
+
+- **`uv sync --group docs`** — uses the PEP 735 dependency group
+  declared in `[dependency-groups]` of `pyproject.toml`, not a
+  PEP 631 extra. (`--extra docs` fails with "extra not defined";
+  the local `tox -e docs` path uses the same group.)
+- **`QT_API=pyside6`** — required because
+  `renderers/__init__.py:99` eagerly imports `mpl_canvas` during
+  docs build, which pulls `matplotlib.backends.backend_qt5agg`.
+  Without the hint, matplotlib probes for PyQt5/PySide2 and
+  fails. RTD's minimal image only has PySide6 (the project's
+  binding); the hint makes the legacy qt5agg alias resolve to
+  the modern Qt-agnostic backend_qtagg. This is set in
+  `docs/conf.py`, NOT here, so it works for any docs build path.
+- **System libs in `apt_packages`**: `graphviz`, `pandoc`,
+  `libglu1-mesa`, `libxcursor1`, `libxft2`, `libxinerama1`,
+  `libxrender1`, `libfontconfig1`. The gmsh Python wrapper
+  dlopens libGLU and X11 libs at module load time; GH Actions
+  runners have these by default, RTD's image does not.
+
+## Why these issues hit RTD but not GH Pages
+
+GHA runners come pre-loaded with hundreds of system libraries
+and ship more of the python ecosystem implicitly through their
+toolchain caches. RTD's build image is minimal and only installs
+what `apt_packages` declares. The GH Pages workflow currently
+gets a number of system deps "for free" that it never asks for —
+which is convenient but means the workflow's dep declaration
+doesn't reflect reality.
+
+If the v0.7.0 lite-by-default flip ships before any RTD revival,
+many of these workarounds become unnecessary — moving pyside6,
+gmsh, and pyaedt out of base `[project.dependencies]` means
+``import qiskit_metal`` during a docs build won't pull them in at
+all, so no `QT_API` hint, no libGLU apt deps, no `mpl_canvas`
+import chain to worry about.
+
+## Related history
+
+- Original migration PR (with full discussion of pro/con, red-team,
+  and what made us choose the parallel-and-decide-later path):
+  https://github.com/qiskit-community/qiskit-metal/pull/1069
+- The `tests-lite` CI job in `.github/workflows/main.yml` already
+  proves the codebase runs without Qt / gmsh / pyaedt — that's
+  the foundation for the lite flip.

--- a/docs/_archive/readthedocs/readthedocs.yaml
+++ b/docs/_archive/readthedocs/readthedocs.yaml
@@ -1,0 +1,59 @@
+# ARCHIVED — see README.md in this directory.
+#
+# This config produced a green build on RTD in PR #1069 but was
+# not adopted. Docs publishing currently lives on GitHub Pages
+# via .github/workflows/docs.yml. To revive this config, move it
+# back to .readthedocs.yaml at the repo root and follow the
+# revive checklist in README.md.
+#
+# Read the Docs build configuration for Quantum Metal.
+# https://docs.readthedocs.com/platform/stable/config-file/v2.html
+#
+# Build pipeline:
+#   1. Install graphviz + pandoc via apt (nbsphinx needs pandoc;
+#      graphviz is used by the qiskit-sphinx-theme).
+#   2. Install ``uv`` via asdf, create the venv at the path RTD
+#      expects, sync the project with the ``docs`` dependency
+#      group (PEP 735, declared in pyproject.toml's
+#      ``[dependency-groups]`` — not a PEP 631 extra).
+#   3. RTD runs ``python -m sphinx`` against ``docs/conf.py``.
+#
+# The package is installed editable so autodoc can introspect
+# ``qiskit_metal`` and ``conf.py`` can read ``qiskit_metal.__version__``.
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - graphviz
+    - pandoc
+    # gmsh is a base project dep. ``import gmsh`` dlopens
+    # libGLU.so.1 (and X11 libs for its GUI mode) at module load
+    # time, which renderers/__init__.py triggers during docs build
+    # via ``if config.is_building_docs():``. GH Actions runners
+    # ship these libraries by default; RTD's image is more minimal
+    # and needs them declared.
+    - libglu1-mesa
+    - libxcursor1
+    - libxft2
+    - libxinerama1
+    - libxrender1
+    - libfontconfig1
+  jobs:
+    create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --group docs
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+formats:
+  - htmlzip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,15 @@ import os
 # Environment variables are per-process, not global
 os.environ["QISKIT_METAL_DOCS_BUILD"] = "1"
 
+# In docs-build mode, ``renderers/__init__.py`` imports the Qt-coupled
+# ``mpl_canvas`` module, which transitively  pulls
+# ``matplotlib.backends.backend_qt5agg``. Without a hint, matplotlib's
+# qt_compat probes for PyQt5 / PySide2 and fails on environments
+# (RTD, Colab) that only have PySide6 — the project's actual Qt
+# binding. Telling matplotlib to use PySide6 makes the legacy
+# qt5agg alias resolve to the modern Qt-agnostic backend_qtagg.
+os.environ.setdefault("QT_API", "pyside6")
+
 
 import qiskit_metal
 import qiskit_sphinx_theme
@@ -134,6 +143,7 @@ exclude_patterns = [
     "build",
     "**.ipynb_checkpoints",
     "_utility",  # '*.ipynb',
+    "_archive",  # archived configs / configs kept for revival
     "stubs/**",  # autosummary stub files are generated but not included in any toctree
 ]
 


### PR DESCRIPTION
## Summary

**Outcome of the RTD migration exploration: stay on GitHub Pages for now.** Years of SEO at `qiskit-community.github.io/qiskit-metal/`, inbound links, and search authority make a hard cutover too expensive right now.

This PR keeps the two pieces of the RTD work that are valuable regardless of host, and shelves the rest for later.

## Changes (3 files, +159 / -0)

| File | Purpose |
|---|---|
| `docs/conf.py` | Add `os.environ.setdefault("QT_API", "pyside6")` + `_archive` to `exclude_patterns` |
| `docs/_archive/readthedocs/readthedocs.yaml` | The working RTD config, parked for future revival |
| `docs/_archive/readthedocs/README.md` | What works, why we shelved, how to revive |

**No changes** to `.github/workflows/docs.yml`, `pyproject.toml` URLs, `about.py`, or `_gui/main_window.py`. GH Pages keeps publishing on every push to main, all user-visible URLs keep working.

## The `QT_API=pyside6` hint

`renderers/__init__.py:99` eagerly imports `mpl_canvas` during docs builds (in the `if config.is_building_docs():` branch), which pulls `matplotlib.backends.backend_qt5agg`. Without the hint, matplotlib's `qt_compat` probes PyQt5/PySide2 first and only falls back to PySide6 if explicitly told.

The current GH Pages build works because something in the GHA runner environment (probably `qtbase5-dev`'s transitive deps) provides a Qt5 binding. Making the hint explicit removes the dependency on that fragile fallback and unblocks any future RTD, Colab, or minimal-env build. `os.environ.setdefault` is a no-op if `QT_API` is already set, so harmless on the current setup.

## Why archive instead of delete the RTD config

PR #1069 reached a green build on RTD on this branch (after iterating through Qt + libGLU fixes). That working config is worth keeping because:

- The rebrand argument is real — `quantum-metal.readthedocs.io` is a better URL long-term
- Per-PR doc previews and versioned docs are genuine UX wins
- The migration cost is mostly the exploration we already did. Reviving means: move the yaml back, set up the project, get the qiskit-community org admin to install the RTD GitHub App, swap 3 URLs
- The archive README documents all of this so it's not lost institutional knowledge

The archived directory is in Sphinx's `exclude_patterns`, so the README and yaml don't get processed as doc sources.

## The next thing this enables

Per discussion, the **metal-lite-by-default flip** (moving `pyside6`, `gmsh`, `pyaedt` out of `[project.dependencies]` into extras) is queued as a follow-up. That flip would:

- Make `import qiskit_metal` during docs build no longer pull the heavies → no `QT_API` hint needed, no `libGLU` apt deps, no `mpl_canvas` import chain
- Fix Mac M-series / Windows install pain for users who don't need Ansys/gmsh
- Match the headless-by-default reality on Colab / Binder / cloud Jupyter
- Be the v0.7.0 headline change

## Test plan

- [ ] CI green — no code paths exercised by tests change. The QT_API hint only fires during sphinx-build.
- [ ] `tox -e docs` still produces HTML locally (the QT_API addition is additive)
- [ ] GH Pages workflow continues publishing to https://qiskit-community.github.io/qiskit-metal/ on next push to main

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj