### PR TITLE
docs: add v0.6.0/v0.6.1/v0.7.0 changelog entries + v0.7.0 migration guide

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,167 @@ For the offical user-facing changelog for a particular release can be found in t
 
 The changelog for all releases can be found in the release page: [![Releases](https://img.shields.io/github/release/Qiskit/qiskit-metal.svg?style=popout-square)](https://github.com/Qiskit/qiskit-metal/releases)
 
+## Quantum Metal v0.7.0 (Unreleased — planned)
+
+**Headline: lite-by-default install.** This release moves the heavy
+optional dependencies (`pyside6`, `qdarkstyle`, `pyaedt`,
+`pyEPR-quantum`, `gmsh`) out of `[project.dependencies]` and into
+extras. `pip install quantum-metal` becomes the small,
+orchestration-friendly base install; the GUI / Ansys / FEM stacks
+are opt-in.
+
+See [ROADMAP.md](./ROADMAP.md) and
+[`docs/migration-to-v0.7.0.rst`](./docs/migration-to-v0.7.0.rst) for
+the full picture.
+
+### Breaking changes — read this if you upgrade
+
+- `pip install quantum-metal` no longer pulls PySide6, AEDT, gmsh,
+  pyEPR, or qdarkstyle. If you used `MetalGUI` or any HFSS/Q3D /
+  gmsh / pyEPR-EPR code path, run one of:
+  - `pip install quantum-metal[full]` — restore the v0.6.x
+    all-batteries-included experience
+  - `pip install quantum-metal[gui]` — just MetalGUI + qdarkstyle
+    + PySide6
+  - `pip install quantum-metal[ansys]` — just AEDT/pyEPR (the EPR
+    analysis code paths and the HFSS/Q3D renderers)
+  - `pip install quantum-metal[fem]` — just gmsh (mesher for the
+    Elmer / Palace path)
+
+### Why
+
+- AI orchestration loops, Colab / Binder, cloud Jupyter, headless
+  CI, and any non-interactive workflow no longer have to install or
+  ignore hundreds of MB of Qt + AEDT they'll never use.
+- Designs build, render to GDS, view inline (via `qm.view(design)`),
+  and feed downstream solvers with a base install of a few dozen MB
+  instead of ~1 GB.
+
+### What didn't change
+
+- `import qiskit_metal` (the package name stays for backward
+  compatibility through the v0.6.x / v0.7.x line)
+- Public API on `QDesign`, `QComponent`, `QRenderer`
+- Tutorial notebooks (the analysis ones need the relevant extras to
+  run; this is now spelled out in each notebook's install cell)
+
+### In-flight as of this entry
+
+- pyEPR-in-analyses: lazified (PR #1074, landed)
+- Wirebond E712 audit note recorded in lessons-learned (PR #1073)
+- gmsh-in-renderer_gmsh: lazification PR pending
+- pyEPR/pyaedt-in-renderer_ansys*: lazification PR pending — these
+  live in the hard-touch HFSS zones, separate PR for review care
+- The actual `pyproject.toml` deps flip (the user-visible change):
+  blocked on the lazification PRs landing first
+
+### Deprecation path
+
+A v0.6.2 release before v0.7.0 will ship a
+`DeprecationWarning` on `import qiskit_metal` if it detects an
+"installed but won't be in v0.7.0 base" set, pointing users at
+`quantum-metal[full]` for a no-op migration.
+
+## Quantum Metal v0.6.1 (May 2026)
+
+Patch release after the v0.6.0 tag-only failure (PyPI publish step
+failed during the v0.6.0 cut; `pip install quantum-metal==0.6.0`
+404s. Don't tag-and-walk-away on releases — verify PyPI received
+the wheel before announcing). See `.claude/commands/release.md`
+post-mortem.
+
+User-visible changes vs v0.6.0:
+
+- Sphinx docs build warnings resolved
+- Tutorial notebook heading-level hierarchy normalized (nbsphinx
+  was choking on `# → ###` skips)
+- qutip 5 + pyEPR 0.9.5+ version sync — fixes `np.array([Qobj])`
+  stacking issue, `np.absolute(Qobj)` issue, and the HFSS 2024.1+
+  solution-type rename
+- Ruff auto-fixes + trailing-whitespace cleanup
+
+## Quantum Metal v0.6.0 (May 2026)
+
+**Major release.** Foundation for the lite-by-default flip in
+v0.7.0. All changes here are additive — current users on v0.5.x
+upgrade without code changes.
+
+### Highlights
+
+- **`qm.view(design)`** — standalone matplotlib viewer that works
+  without PySide6 / Qt installed. Renders in a Jupyter notebook
+  inline or to a file. The headless entry point for tutorials,
+  CI, agent workflows, and any environment where you don't want
+  to install a Qt binding. See `docs/headless-usage.rst`.
+- **Lazy Qt initialization** — `import qiskit_metal` no longer
+  requires PySide6 at module-load time. Set
+  `QISKIT_METAL_HEADLESS=1` to skip the Qt-backend probe entirely;
+  `MetalGUI` still works on full installs.
+- **`[gui]` / `[ansys]` / `[fem]` / `[full]` optional-dependency
+  extras** added to `pyproject.toml`. In v0.6.x they're
+  informational (every extra's deps are also in base), but the
+  `tests-lite` CI job exercises the lite-install path so it stays
+  green for v0.7.0's flip.
+- **`tests-lite` CI matrix entry** — runs the full test suite on
+  a venv built without PySide6 / pyaedt / gmsh, catching any
+  regression on the lite path.
+- **`qutip 5` + `pyEPR 0.9.5+` compatibility** — fixes
+  `np.array([Qobj])` no longer stacking, `np.absolute(Qobj)` no
+  longer working directly, and the HFSS 2024.1+
+  `solution_type` rename (`"DrivenModal"` →
+  `"HFSS Modal Network"`).
+- **Pandas 2.2 compatibility** — uses `.iloc[]` for positional
+  indexing where 2.2 stopped doing the old positional-fallback.
+- **Type annotations** on the core public API methods of
+  `QComponent`, `QDesign`, and the renderer bases — unlocks
+  downstream type-checking for orchestration tools.
+
+### New tests
+
+- `test_pin_normals_point_outward` — static sanity check that
+  every component's pins point away from the component centroid.
+  Catches HFSS port-flip bugs at component-author time, not at
+  HFSS-eval time. One known failing case logged:
+  `LaunchpadWirebondDriven.in` (see `KNOWN_INWARD_PINS`).
+- Static AST audit that every `self.options.X` access has a
+  matching key in `default_options`. Catches typos that would
+  silently fall through.
+- `test_view_hides_layers` — gates the new `qm.view(design)`
+  `hidden_layers={...}` parameter.
+
+### Tutorials
+
+- Every tutorial notebook now has a "no Qt required" callout
+  near the top, explaining when the tutorial does and doesn't
+  need `MetalGUI`.
+- New `1.4 Headless Quick View.ipynb` — short notebook showing
+  the `qm.view(design)` path end-to-end with no Qt.
+- The headless tutorial path is exercised in CI via
+  `nbconvert --execute` on `1.4 Headless Quick View.ipynb`
+  inside the `tests-lite` job.
+
+### Infrastructure
+
+- `CLAUDE.md` + `.claude/` directory: documents the repo's
+  hard-touch zones, recurring tasks, and lessons-learned for
+  future AI agents.
+- `tests-lite` uses `.venv/bin/python` directly (not `uv run`)
+  because `uv run` was re-syncing the venv and overwriting the
+  custom lite-install state. See
+  `.claude/context/lessons-learned.md`.
+
+### Known issues
+
+- `LaunchpadWirebondDriven.in` pin normal points inward (HFSS
+  validation blocked the fix in v0.6.0; documented in
+  `tests/test_qlibrary_pin_sanity.py::KNOWN_INWARD_PINS`).
+- 13 ruff findings in HFSS / `_gui/` deferred to v0.6.1+ for
+  validation environment. (**Resolved** in v0.6.1+ via the
+  ruff-sweep PR #1070, with one caveat documented in
+  `.claude/context/lessons-learned.md`.)
+- v0.6.0 PyPI publish failed; install
+  `quantum-metal>=0.6.1` instead. (**Fixed** in v0.6.1.)
+
 ## Quantum Metal v0.5.3.post1 (Jan 23, 2026)
 - Pinned pyaedt to less than v0.24 due to bugs. 
 - Updated gmsh dependency 4.11.1 → 4.15.0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -267,6 +267,7 @@ The goal of Qiskit Metal is to allow for easy quantum hardware modeling with red
     About<self>
     Installing Qiskit Metal<installation>
     Using Quantum Metal without the Qt GUI<headless-usage>
+    Migrating to v0.7.0 (lite install)<migration-to-v0.7.0>
 
 .. toctree::
     :maxdepth: 2

--- a/docs/migration-to-v0.7.0.rst
+++ b/docs/migration-to-v0.7.0.rst
@@ -1,0 +1,272 @@
+.. _migration-to-v0.7.0:
+
+Migrating to v0.7.0 (lite-by-default install)
+==============================================
+
+.. attention::
+
+    **v0.7.0 is not yet released.** This document describes the
+    migration path so you can prepare. Until v0.7.0 lands,
+    ``pip install quantum-metal`` keeps the v0.6.x behaviour of
+    pulling every dependency. See the changelog and
+    `ROADMAP <https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_
+    for status.
+
+.. contents::
+   :local:
+   :depth: 2
+
+TL;DR
+-----
+
+In v0.7.0, ``pip install quantum-metal`` no longer pulls
+PySide6, qdarkstyle, pyaedt, pyEPR-quantum, or gmsh. Those
+move into opt-in extras.
+
+The fastest migration is one of:
+
+.. code-block:: bash
+
+    # Want everything? Restore the v0.6.x experience:
+    pip install "quantum-metal[full]"
+
+    # Just MetalGUI?
+    pip install "quantum-metal[gui]"
+
+    # Just HFSS / Q3D / EPR (no GUI)?
+    pip install "quantum-metal[ansys]"
+
+    # Just gmsh meshing?
+    pip install "quantum-metal[fem]"
+
+    # Headless designs, GDS export, qm.view, no heavy deps?
+    pip install quantum-metal      # base install — much smaller
+
+
+Who is affected
+---------------
+
+You **need to do something** if any of these describe your
+v0.6.x install:
+
+- You run ``MetalGUI`` (the desktop Qt GUI)
+- You import or use the HFSS / Q3D renderers
+  (``QAnsysRenderer``, ``QHFSSPyaedt``, ``QQ3DPyaedt``,
+  ``QHFSSDrivenmodalPyaedt``, ``QHFSSEigenmodePyaedt``)
+- You import or use the EPR analyses
+  (``LOManalysis``, ``LumpedElementsSim``,
+  ``EigenmodeSim``, ``extract_transmon_coupled_Noscillator``)
+- You import or use the gmsh / Elmer renderers
+  (``QGmshRenderer``, ``Vec3DArray``, the
+  ``renderer_elmer`` module)
+
+You **probably don't need to do anything** if your workflow is:
+
+- Build a design (``DesignPlanar``, ``DesignFlipChip``, ...)
+- Add components from ``qiskit_metal.qlibrary``
+- View it inline with ``qm.view(design)``
+- Export to GDS via ``QGDSRenderer``
+- Run pure-Python analyses that don't touch
+  ``quantization/`` or ``simulation/`` modules
+
+The lite install covers the second list out of the box.
+
+
+What changed
+------------
+
+Base ``dependencies`` (the v0.7.0 ``pip install quantum-metal``
+slim install):
+
+- All current base deps **except** PySide6, qdarkstyle, pyaedt,
+  pyEPR-quantum, and gmsh.
+
+New ``optional-dependencies`` (extras you opt in to):
+
+================  ================================================
+Extra             Pulls
+================  ================================================
+``[gui]``         ``pyside6``, ``qdarkstyle``
+``[ansys]``       ``pyaedt``, ``pyEPR-quantum``
+``[fem]``         ``gmsh``
+``[full]``        all of the above — v0.6.x compatibility set
+================  ================================================
+
+The Python API surface itself is **unchanged**. ``MetalGUI``,
+``QHFSSPyaedt``, ``QGmshRenderer``, ``LOManalysis`` still exist
+in the same import paths. They just raise a clear
+``ModuleNotFoundError`` at *use* time if you didn't install the
+extra they need.
+
+
+Migration recipes
+-----------------
+
+I am a desktop GUI user
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If your workflow opens ``MetalGUI`` and edits designs visually:
+
+.. code-block:: bash
+
+    pip install "quantum-metal[gui]"
+
+You're done. Nothing else changes.
+
+
+I run HFSS / Q3D analyses
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Your workflow uses ``QHFSSPyaedt`` or any of the AEDT-based
+renderers, or the EPR analyses
+(``LOManalysis``, ``EigenmodeSim``, ``LumpedElementsSim``):
+
+.. code-block:: bash
+
+    pip install "quantum-metal[ansys]"
+
+If you also use ``MetalGUI``, install both:
+
+.. code-block:: bash
+
+    pip install "quantum-metal[gui,ansys]"
+
+
+I use the gmsh / Elmer FEM path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    pip install "quantum-metal[fem]"
+
+Note that gmsh on Apple Silicon Macs still needs the brew
+``gmsh`` package — see ``README_Gmsh_Elmer.md``.
+
+
+I want the v0.6.x all-batteries-included install
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+    pip install "quantum-metal[full]"
+
+This is the no-think migration — the install is bit-for-bit
+the same dep set you had on v0.6.x.
+
+
+I am driving Quantum Metal from an AI agent / orchestrator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the workflow v0.7.0 was designed for. The base install
+is now what you want:
+
+.. code-block:: bash
+
+    pip install quantum-metal
+
+You get the design builders, all of ``qlibrary``, all
+pure-Python analyses, GDS export, and the headless
+``qm.view(design)`` viewer in a few dozen MB instead of ~1 GB.
+
+If your orchestrator dispatches to a specific backend, install
+only that extra at the dispatch layer:
+
+.. code-block:: bash
+
+    # Worker pod handling HFSS jobs
+    pip install "quantum-metal[ansys]"
+
+    # Worker pod handling gmsh-based meshing
+    pip install "quantum-metal[fem]"
+
+
+Common errors and fixes
+-----------------------
+
+``ModuleNotFoundError: No module named 'PySide6'``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You instantiated ``MetalGUI`` on a lite install. Fix:
+
+.. code-block:: bash
+
+    pip install "quantum-metal[gui]"
+
+
+``ModuleNotFoundError: No module named 'pyEPR'``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You called an EPR-using analysis (``LOManalysis.run_lom``,
+``extract_transmon_coupled_Noscillator``, or any of the
+HFSS/Q3D renderers' simulation methods) on a lite install.
+Fix:
+
+.. code-block:: bash
+
+    pip install "quantum-metal[ansys]"
+
+
+``ModuleNotFoundError: No module named 'gmsh'``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You instantiated ``QGmshRenderer`` or the Elmer renderer on
+a lite install. Fix:
+
+.. code-block:: bash
+
+    pip install "quantum-metal[fem]"
+
+
+``Could not load the Qt platform plugin 'xcb'`` (and similar
+``QPA``-style errors)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These come from PySide6 starting up. On a lite install they
+shouldn't fire at all. If they do, you're either running
+``MetalGUI`` directly or you have a stray
+``import PySide6`` in your own code. See :doc:`headless-usage`
+for the Qt-free workflow.
+
+
+Why this change
+---------------
+
+Three forces drove it:
+
+- **AI orchestration**. Increasingly, Quantum Metal is used
+  inside LLM-driven design loops and multi-backend solver
+  pipelines. None of those need a desktop Qt GUI; they want
+  a fast, predictable, scriptable Python library.
+- **Cloud / Colab / Binder**. Hundreds of MB of Qt + AEDT in
+  the base install is friction every notebook environment
+  has to work around. Many just give up and pin an older
+  version.
+- **Academic and educational use**. Users without an Ansys
+  license shouldn't be forced to install pyaedt + pyEPR
+  to import ``qiskit_metal``.
+
+The Qt-free path was added in v0.6.0 (``qm.view(design)``,
+lazy Qt initialization). The v0.7.0 flip completes the
+story by making the lite install the **default**, with
+extras for the heavy backends.
+
+See :doc:`headless-usage` for what the lite install gives
+you today, and `ROADMAP.md
+<https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_
+for what's coming next.
+
+
+Reporting issues
+----------------
+
+If the migration recipe for your scenario isn't covered
+above, please open an issue at
+https://github.com/qiskit-community/qiskit-metal/issues with
+the label ``v0.7.0-migration``. Include:
+
+- Your previous install command (``pip install ...``)
+- Which Python entry points / classes you use
+- The error message you hit
+
+We'll add your case to this doc so the next person hits a
+search result instead of a wall.


### PR DESCRIPTION
## Summary

First half of the docs sweep for the lite-by-default direction. Pure-additive — no changes to user-visible existing docs (those are in **PR B**, coming after this).

```
 changelog.md                       | 156 +++++++++++++++++++++
 docs/index.rst                     |   1 +
 docs/migration-to-v0.7.0.rst       | 277 +++++++++++++++++++++++++++++++++++++
 3 files changed, 434 insertions(+)
```

## What's in here

### `changelog.md` — three new entries

Existing convention preserved: this file is the developer scratchpad; official user-facing notes still live in GitHub Releases. But entries here are written to *also* serve as draft release-note content.

| Entry | Why |
|---|---|
| **v0.7.0 (Unreleased — planned)** | The lite-flip headline. Breaking-changes block, the four install recipes (`[full]` / `[gui]` / `[ansys]` / `[fem]`), "why," what's in-flight, and the v0.6.2 deprecation cycle. This is the "major update notes" entry — the one to highlight when v0.7.0 ships. |
| **v0.6.1 (May 2026)** | Patch-release notes for the docs / heading-hierarchy / qutip-sync work after the v0.6.0 PyPI failure. Includes the don't-tag-and-walk-away post-mortem. |
| **v0.6.0 (May 2026)** | Full retrospective: `qm.view(design)`, lazy Qt init, optional-dep extras, `tests-lite` CI matrix, qutip 5 + pyEPR 0.9.5+ compat, pandas 2.2 compat, type annotations on public API, new pin / AST / view-layer tests, tutorial no-Qt callouts, `CLAUDE.md` infrastructure, known issues. |

### `docs/migration-to-v0.7.0.rst` — new file

Focused, action-oriented guide for users upgrading from v0.6.x → v0.7.0:

- **TL;DR** with the five install recipes up front
- **Who is affected** — two lists (need to act vs. already fine)
- **What changed** — base deps vs. extras table
- **Five migration recipes** by user persona — GUI / HFSS / FEM / batteries-included / **AI orchestrator** (this is the workflow v0.7.0 was designed for)
- **Five common-error patterns** with one-line fixes
- **Why this change** + cross-link to ROADMAP
- **Reporting issues** with a suggested label

### `docs/index.rst`

One toctree line wiring the migration doc into the main left nav, right below `headless-usage`.

## Verification

- `tox -e docs` succeeds locally (built in a sandbox with pandoc available)
- Nine Sphinx warnings — **all pre-existing** in package docstrings or the 1.1 tutorial heading underline (the known issue noted in `.claude/context/lessons-learned.md`). **None from the new content.**
- The rendered migration doc is 102KB HTML; preview was shared via the session interface before opening this PR

## What's NOT in this PR

By design, this is scope-limited to *new* docs. The sweep of existing user-visible docs lives in the next PR (PR B):

- `README.md` Quick Start — needs a `[gui]` extra note on the `MetalGUI` example
- `docs/installation.rst` — needs an extras matrix
- `docs/faq.rst` Qt error Q&A — needs an "applies to `[gui]` install" scoping
- `CONTRIBUTING.md` — CLA URL still points at the old `Qiskit/qiskit` org; needs the rebrand fix
- `README_Gmsh_Elmer.md` — claims gmsh auto-installs (true v0.6, false v0.7)

PR C (lowest priority): install callouts on the ~8-10 Analysis tutorial notebooks that use pyEPR/AEDT/gmsh.

## Test plan

- [x] `changelog.md` renders correctly on GitHub (markdown)
- [x] `docs/migration-to-v0.7.0.rst` builds with `tox -e docs`, no new warnings
- [x] Migration doc shows up in the left-nav toctree under "About / Installing / Headless / **Migrating to v0.7.0**"
- [ ] Reviewer: scan the migration doc for tone, completeness, and anything we've documented elsewhere that contradicts (especially the v0.6.2 deprecation timing — happy to adjust if the cadence is different from what's in the changelog draft)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_