### PR TITLE
docs(sweep): make existing README + install + FAQ docs lite-by-default aware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,20 @@
-# Contributing to Qiskit Metal
-Qiskit Metal follows the overall Qiskit project contributing guidelines. These are all included in the [Qiskit Documentation](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md).
+# Contributing to Quantum Metal
+
+Quantum Metal (formerly Qiskit Metal) is community-maintained — see [ROADMAP.md](./ROADMAP.md) for the direction. Contributions follow the guidelines below, with the original Qiskit-project guidelines as background reading: [Qiskit Documentation](https://github.com/Qiskit/qiskit/blob/main/CONTRIBUTING.md).
 
 Please read those general guidelines first, then the specific details for contributing to Metal below.
 
 ## CLA - Contributor License Agreement
-Contributors need to submit a CLA before they can be granted write access to the repository. The CLA is a one time action that allows you to contribute to all the Qiskit repositories.
+Contributors sign a CLA before their first contribution is merged. It's a one-time action and applies to all future contributions.
 
-During the early-access phase, follow the prompts at this link: https://cla-assistant.io/Qiskit/qiskit . After you are done, contact us via slack or e-mail to be granted write access to the repository.
+Sign here: https://cla-assistant.io/qiskit-community/qiskit-metal
 
-Past the early-access phase, the qiskit-metal repository will become public, which will allow to fully streamline and automate this process.
+Once you open a pull request, the CLA bot will leave a comment with a link to sign if you haven't already. The PR's required `license/cla` check turns green once signed.
 
 ## Adding a New Issue
 ### Reporting a Bug
 When you encounter a problem while using Metal, please open an issue in the
-[Issue Tracker](https://github.com/Qiskit/qiskit-metal/issues).
+[Issue Tracker](https://github.com/qiskit-community/qiskit-metal/issues).
 
 When reporting an issue, please follow this template::
 
@@ -186,4 +187,4 @@ If you make changes to the codebase and want to rebuild the documentation: `tox 
 Sometimes Sphinx can have bad cache state. Run `tox -e docs-clean` to reset Tox.
 
 ## Check-list for specific types of Pull Requests
-Please refer to [these instructions](https://github.com/Qiskit/qiskit-metal/blob/main/contributor_guidelines/pull_request_rules.md)
+Please refer to [these instructions](https://github.com/qiskit-community/qiskit-metal/blob/main/contributor_guidelines/pull_request_rules.md)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ python -m ipykernel install --user --name quantum-metal
 Now that Qiskit Metal is installed, it's time to begin working with it.
 We are ready to try out a quantum chip example, which is simulated locally using
 the Qiskit MetalGUI element. This is a simple example that makes a qubit.
+
+> **Install note:** the example below uses ``MetalGUI``, which requires PySide6. On v0.6.x this comes by default with ``pip install quantum-metal``. On v0.7.0+ (lite-by-default), install the GUI extra explicitly:
+> ```bash
+> pip install "quantum-metal[gui]"
+> ```
+> Prefer no-Qt? Replace ``gui = MetalGUI(design)`` and the ``gui.rebuild()`` / ``gui.autoscale()`` calls with ``fig = qm.view(design)`` — see [docs/headless-usage.rst](./docs/headless-usage.rst). The headless path also covers AI-orchestration / Colab / Binder / cloud-Jupyter use cases.
+
 ```python
 from qiskit_metal import designs, MetalGUI, open_docs, draw
 

--- a/README_Gmsh_Elmer.md
+++ b/README_Gmsh_Elmer.md
@@ -1,7 +1,10 @@
-# Softwares to Install for Open-source simulation toolchain for Qiskit Metal
+# Software to Install for the Open-source Simulation Toolchain (Quantum Metal)
 ## Gmsh
-- This is a design rendering and meshing software that we will be using to render our design and then divide it into fine elements (called a `mesh`), in order to solve the necessary differential equations (PDE's of Maxwell's Electromagnetic Laws). This is completely integrated with Qiskit Metal and is semi-automated.
-- This will be automatically installed when you make a new `venv` environment and install qiskit metal using the instructions given above (except in Apple Silicon Macs, see the Note below).
+- This is a design rendering and meshing software that we use to render a design and divide it into fine elements (a `mesh`), in order to solve the necessary differential equations (PDEs of Maxwell's Electromagnetic Laws). This is fully integrated with Quantum Metal and is semi-automated.
+- **How to install gmsh depends on which Quantum Metal install you have:**
+  - **v0.6.x (current):** gmsh installs by default with `pip install quantum-metal` — already there if you followed the standard install.
+  - **v0.7.0 (lite-by-default, upcoming):** you'll need to opt in with `pip install "quantum-metal[fem]"` — see [docs/migration-to-v0.7.0.rst](./docs/migration-to-v0.7.0.rst) and [ROADMAP.md](./ROADMAP.md).
+- **Apple Silicon Macs** (M-series chips): `pip install gmsh` doesn't always wire up the Python binding correctly. See the Note below for the Homebrew-based fix.
 
 ### Test if Gmsh is properly installed
 - Run the following in your terminal. A blank Gmsh window should open up. If it does, then hurray, you did it! 😄

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -119,11 +119,15 @@ Then open the applicable settings.json in your VS Code. (See how to open command
 
 **A:** it has been observed for pip installation on fresh conda environments that this error might show up: ``Could not load the Qt platform plugin "xcb" in "" even though it was found.``
 
-For `xcb`. Based on `this source <https://forum.qt.io/topic/93247/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it-was-found>`_ You might be able to resolve this error by installing the dependency with ``sudo apt-get install libxcb-xinerama0``
+.. note::
 
-For `windows`. This error intermittently shows in conda environments. It was found that the problem resolves if PySide2 is installed manually thorugh conda, with: `conda install pyside2`.
+   These errors come from PySide6 / Qt starting up — they only fire if you instantiate ``MetalGUI`` or import code that pulls Qt. If you're on the lite install (v0.7.0+ ``pip install quantum-metal`` without ``[gui]``) and you see one of these, you either need ``pip install "quantum-metal[gui]"`` or you should switch to the headless ``qm.view(design)`` path — see :doc:`headless-usage`.
 
-if the methods above do not work, consider utilizing an older version of python (and related dependencies)
+For ``xcb``: based on `this source <https://forum.qt.io/topic/93247/qt-qpa-plugin-could-not-load-the-qt-platform-plugin-xcb-in-even-though-it-was-found>`_, you might be able to resolve this error by installing the dependency with ``sudo apt-get install libxcb-xinerama0``.
+
+For ``windows``: this error intermittently shows in conda environments. It was found that the problem resolves if PySide6 is installed manually through conda: ``conda install pyside6``.
+
+If the methods above do not work, consider trying an older version of Python (and related dependencies).
 
 **Q: Why am I not able to start Jupyter Lab in the new environment?**
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -90,7 +90,66 @@ Quantum Metal v0.5+ is available on PyPI (Project page: https://pypi.org/project
 
 If you specifically need the legacy pre-0.5 package, install ``qiskit-metal`` instead. Otherwise, use ``quantum-metal`` to get the current release.
 
-.. For source installs or development, clone the repository and follow the advanced installation paths below.  
+.. For source installs or development, clone the repository and follow the advanced installation paths below.
+
+==================================================
+Optional extras (lite-by-default preview)
+==================================================
+
+Quantum Metal ships heavy backends — the Qt desktop GUI, the
+Ansys HFSS/Q3D bridge, the gmsh mesher — as **opt-in extras**.
+You can install only the subset you need.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 38 40
+
+   * - Extra
+     - Pulls
+     - When to use it
+   * - (none — base install)
+     - Core API, ``qm.view(design)`` headless viewer, GDS export, pure-Python analyses
+     - AI orchestration, Colab / Binder, cloud Jupyter, CI, any non-interactive workflow
+   * - ``[gui]``
+     - ``pyside6``, ``qdarkstyle``
+     - Desktop GUI (``MetalGUI``)
+   * - ``[ansys]``
+     - ``pyaedt``, ``pyEPR-quantum``
+     - HFSS / Q3D / EPR analyses (requires an Ansys AEDT license)
+   * - ``[fem]``
+     - ``gmsh``
+     - Gmsh-based meshing + Elmer FEM path
+   * - ``[full]``
+     - All of the above
+     - The v0.6.x "all batteries included" experience
+
+Install one or several extras (comma-separated, no spaces):
+
+.. code-block:: sh
+
+    # Just the GUI
+    pip install "quantum-metal[gui]"
+
+    # GUI + Ansys
+    pip install "quantum-metal[gui,ansys]"
+
+    # Everything
+    pip install "quantum-metal[full]"
+
+.. note::
+
+   **In v0.6.x**, every extra's deps are *also* in the base
+   ``[project.dependencies]`` — so ``pip install quantum-metal``
+   gives you everything regardless of whether you list extras.
+   The ``[gui]`` / ``[ansys]`` / ``[fem]`` / ``[full]`` selectors
+   are informational today; the ``tests-lite`` CI job exercises
+   what *would* be in the lite install so the path stays green.
+
+   **In v0.7.0**, the base install becomes lite — see
+   :doc:`migration-to-v0.7.0` for the migration recipes.
+
+For the headless / Qt-free workflow that the base install
+supports out of the box, see :doc:`headless-usage`.
 
 ==================================================
 Installation from source


### PR DESCRIPTION
## Summary

Second half of the docs sweep — updates the *existing* user-visible docs that the audit flagged as stale or missing lite-by-default context. Follow-up to PR #1075 (changelog + migration guide).

```
 CONTRIBUTING.md       | 15 +++++++------
 README.md             |  7 ++++++
 README_Gmsh_Elmer.md  |  9 +++++---
 docs/faq.rst          | 10 ++++++---
 docs/installation.rst | 61 ++++++++++++++++++++++++++++++++++++++++++++++++++-
 5 files changed, 88 insertions(+), 14 deletions(-)
```

## Changes

### `README.md` Quick Start *(audit: high severity)*

Added a callout above the `MetalGUI(design)` example explaining that the example requires PySide6 — auto-installed on v0.6.x, needs `pip install "quantum-metal[gui]"` on v0.7.0+. Points readers at `docs/headless-usage.rst` for the no-Qt alternative using `qm.view(design)`. The headless path is called out as the recommended one for AI orchestration / Colab / Binder / cloud Jupyter.

### `docs/installation.rst` *(audit: high severity)*

New section **"Optional extras (lite-by-default preview)"** immediately after Basic Installation. Documents the four extras (`[gui]`, `[ansys]`, `[fem]`, `[full]`) with a per-row "when to use it" column and example install commands (including comma-syntax `[gui,ansys]`). Includes the v0.6.x → v0.7.0 transition note (extras informational in 0.6.x, default-lite in 0.7.0) with a cross-link to the new `migration-to-v0.7.0` doc.

### `docs/faq.rst` Qt-error Q&A *(audit: medium severity)*

Added a scoping note to the "xcb / windows Qt plugin" Q&A: these errors come from PySide6 startup; on a lite install they should not fire. If they do, you either need `[gui]` or you should switch to the headless path. Also corrected `PySide2` → `PySide6` references in the body (the codebase migrated in PR #1002, the FAQ wasn't updated).

### `CONTRIBUTING.md` *(rebrand-stale URLs caught earlier in this session)*

The file still pointed at the old IBM-org URLs (`Qiskit/qiskit-metal`) and the wrong CLA endpoint (`cla-assistant.io/Qiskit/qiskit`). Fixes:

- CLA link → `cla-assistant.io/qiskit-community/qiskit-metal`
- Issue tracker → `qiskit-community/qiskit-metal`
- Contributor guidelines URL → `qiskit-community/qiskit-metal`
- Reworded the "early-access phase" framing (the repo is now public; that text was pre-graduation)

### `README_Gmsh_Elmer.md` *(audit: medium severity)*

Replaced the "automatically installed when you make a new venv" assertion with the v0.6.x vs v0.7.0 split (auto-installed on v0.6.x; `pip install "quantum-metal[fem]"` on v0.7.0+). Also bumped the title from "Qiskit Metal" → "Quantum Metal" to match the rebrand.

## Verification

- `tox -e docs` builds clean. Six Sphinx warnings — **same pre-existing set as PR #1075** (package docstrings + the 1.1 tutorial heading underline noted in `.claude/context/lessons-learned.md`). No new warnings from this PR's content.
- Manually previewed the rendered `installation.html` extras table — renders cleanly with the qiskit-sphinx-theme.

## What's NOT in this PR (deferred follow-ups)

- **Tutorial install callouts (PR C)** — the ~8-10 Analysis notebooks that import pyEPR / pyaedt / gmsh still don't say so explicitly. Lower priority; notebook editing is fiddlier (JSON, kernel metadata) and deserves its own pass.
- **`gmsh` version pin tightening** — surfaced in discussion: `gmsh>=4.11.1` (no upper bound) is loose; could become `gmsh>=4.15.0,<5` given the installed 4.15.0 and the lack of a v5 boundary today. Will land as a small follow-up PR or a ROADMAP entry under the Open FEM stack research arc.
- **Auto-generated `apidocs` stubs hygiene** — `sphinx-build` regenerates `docs/apidocs/qiskit_metal.renderers.PlotCanvas.rst` and adds two stray stubs at `docs/` root from autosummary side-effects. Reverted locally for this PR; they should be `.gitignore`d in a future hygiene pass.

## Test plan

- [x] Markdown files render correctly on GitHub
- [x] `tox -e docs` succeeds, no new Sphinx warnings
- [x] CLA URL is the correct cla-assistant.io endpoint for `qiskit-community/qiskit-metal`
- [x] Old `Qiskit/` org URLs replaced everywhere in this PR's scope
- [ ] **Reviewer**: tone-check on the README Quick Start callout — happy to adjust if you want it more or less prominent
- [ ] **Reviewer**: confirm the installation extras matrix matches your mental model of when each extra is useful

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_