### PR TITLE
docs(roadmap): add gmsh version audit research bullet

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,6 +131,18 @@ The open FEM stack is the long-term answer. Three pieces:
 - **gmsh mesher** — `renderer_gmsh/` already exists. The
   next step is tighter mesh control and port / boundary
   tagging that both Elmer and Palace can consume.
+- **gmsh version audit** `[research]` — we currently pin
+  `gmsh>=4.11.1` (no upper bound) with 4.15.0 shipped in
+  the dev env. The 30 distinct `gmsh.*` API entry points
+  we use are all stable core OCC + meshing + lifecycle
+  calls, but with gmsh 5 on the horizon we should
+  (a) tighten the pin to `>=4.15.0,<5`, (b) walk the API
+  call sites against the latest 4.x release notes to spot
+  anything deprecated, and (c) survey newer 4.x APIs
+  (e.g. richer mesh refinement, boundary-tag protocol
+  improvements) that would unblock cleaner Palace and
+  Elmer integration. Likely lands as one small PR for
+  the pin tighten + a research note for the API survey.
 - **Elmer eigenmode solver** — `renderer_elmer/` already
   exists. The integration needs a parity-check pass to
   confirm it still works against current Elmer releases,


### PR DESCRIPTION
## Summary

Adds a `gmsh version audit` research bullet under the existing "Open FEM stack" arc in ROADMAP.md. Captures the gmsh dependency-hygiene + API-survey work surfaced in discussion.

```
 ROADMAP.md | 12 ++++++++++++
 1 file changed, 12 insertions(+)
```

## Why

Two-part observation that deserves a public record:

1. **Pin hygiene.** We pin `gmsh>=4.11.1` with no upper bound; the dev env ships 4.15.0. A future gmsh 5 would install transitively without notice. Quick fix: tighten to `>=4.15.0,<5`.

2. **API survey.** The 30 distinct `gmsh.*` entry points used across `renderer_gmsh/` (111 call sites total) are all stable core OCC + meshing + lifecycle calls. But the Open FEM stack roadmap (Palace + Elmer) would benefit from surveying newer 4.x APIs — richer mesh refinement, better boundary-tag protocols — that could unblock cleaner port/boundary integration with both solvers.

## Scope

Pure docs change to ROADMAP.md. The actual pin-tighten PR and the API survey are separate follow-ups, tracked under this bullet rather than as new top-level sections (to keep the roadmap from sprawling).

## Test plan

- [x] ROADMAP.md renders correctly on GitHub
- [x] New bullet slots cleanly under "Open FEM stack" → "gmsh mesher" with `[research]` status marker matching surrounding entries

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_