### PR TITLE
v0.6.2: deprecation notice + gmsh lazification (pre-flip for v0.7.0)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,48 @@ For the offical user-facing changelog for a particular release can be found in t
 
 The changelog for all releases can be found in the release page: [![Releases](https://img.shields.io/github/release/Qiskit/qiskit-metal.svg?style=popout-square)](https://github.com/Qiskit/qiskit-metal/releases)
 
+## Quantum Metal v0.6.2 (deprecation-notice release)
+
+**Pre-flip release.** All v0.6.x install behaviour is unchanged
+— but a `FutureWarning` now fires on `import qiskit_metal` letting
+users know v0.7.0 will move the heavy dependencies (PySide6,
+qdarkstyle, pyaedt, pyEPR-quantum, gmsh) out of base into opt-in
+extras. To preserve current behaviour, install with
+`pip install 'quantum-metal[full]'` before upgrading to v0.7.0.
+
+This release also lazifies the last remaining eager heavy-dep
+import — gmsh — so the `tests-lite` CI matrix can validate the
+full v0.7.0 install behaviour ahead of the actual deps flip.
+
+### What landed
+
+- **gmsh lazification** in `renderer_gmsh/gmsh_utils.py` and
+  `renderer_gmsh/gmsh_renderer.py`: same `try/except` +
+  `_require_gmsh()` pattern as the pyEPR/pyaedt lazification in
+  v0.6.x. `QGmshRenderer.__init__` raises a clear
+  `ImportError: ... pip install 'quantum-metal[fem]'` when gmsh
+  isn't available. The `_start_renderers` skip-and-log path
+  catches it.
+- **gmsh version pin tighten**: `gmsh>=4.11.1` → `gmsh>=4.15.0,<5`.
+  The dev env already ships gmsh 4.15.0 (bumped in v0.5.3.post1
+  but the floor wasn't updated). Upper bound caps before any
+  future gmsh 5 lands.
+- **`FutureWarning` on `import qiskit_metal`** advertising the
+  v0.7.0 lite-flip. Fires once per process via Python's standard
+  warning deduplication. Suppress with
+  `QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1`.
+- **Version bumped** to 0.6.2.
+
+### Nothing else changed
+
+- Public API: unchanged
+- Test behaviour: unchanged (all 458 tests still pass)
+- Install behaviour: unchanged (heavies still in base)
+- Headless / lite paths: unchanged
+
+The next release (v0.7.0) will flip `pyproject.toml`'s base
+dependencies and the warning becomes truth.
+
 ## Quantum Metal v0.7.0 (Unreleased — planned)
 
 **Headline: lite-by-default install.** This release moves the heavy

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,6 @@ dependencies:
   - pip
   - pip:
       - pyaedt>=0.21,<0.24 # Synced with pyproject.toml ceiling (pyaedt 0.24 has bugs).
-      - gmsh>=4.11.1
+      - gmsh>=4.15.0,<5
       - gdstk~=0.9 # Used to be gdspy>=1.6.12
       - pyside6~=6.8 # Critical to building gui, can causes lots of problems, careful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
     readme = { file = "README.md", content-type = "text/markdown" }
     requires-python = ">=3.10,<3.13"
     urls = { bugtracker = "https://github.com/qiskit-community/qiskit-metal/issues", documentation = "https://qiskit-community.github.io/qiskit-metal/", source = "https://github.com/qiskit-community/qiskit-metal" }
-    version = "0.6.1"
+    version = "0.6.2"
     # Core deps required for ``import qiskit_metal`` + ``qm.view()``
     # to work in any environment. Heavy / optional deps (Qt GUI,
     # pyaedt, gmsh) live in the ``[project.optional-dependencies]``
@@ -51,7 +51,7 @@
         "scipy>=1.10.0",
         "shapely>=2.0.1",
         "scqubits>=4.1.0",
-        "gmsh>=4.11.1",
+        "gmsh>=4.15.0,<5",
         "pyaedt>=0.21,<0.24", # pyaedt 0.24 has some bugs (Jan 23, 2026)
         "pyyaml>=6.0", # Used for the Elmer runner.
     ]
@@ -72,14 +72,14 @@
             "pyEPR-quantum>=0.9.5",
         ]
         fem = [
-            "gmsh>=4.11.1",
+            "gmsh>=4.15.0,<5",
         ]
         full = [
             "pyside6>=6.8",
             "qdarkstyle>=3.1",
             "pyaedt>=0.21,<0.24",
             "pyEPR-quantum>=0.9.5",
-            "gmsh>=4.11.1",
+            "gmsh>=4.15.0,<5",
         ]
 
 [build-system]

--- a/src/qiskit_metal/__init__.py
+++ b/src/qiskit_metal/__init__.py
@@ -184,3 +184,46 @@ from qiskit_metal.toolbox_metal.about import about, open_docs
 
 # Headless matplotlib viewer (``qm.view(design)``) — no Qt required.
 from qiskit_metal.viewer import view
+
+
+# -----------------------------------------------------------------------------
+# v0.7.0 lite-by-default deprecation notice (shipped in v0.6.2)
+# -----------------------------------------------------------------------------
+# Heads-up for users upgrading via ``pip install --upgrade quantum-metal``:
+# v0.7.0 will move PySide6 / qdarkstyle / pyaedt / pyEPR-quantum / gmsh out of
+# ``[project.dependencies]`` and into opt-in extras (``[gui]`` / ``[ansys]`` /
+# ``[fem]`` / ``[full]``). To preserve the current v0.6.x experience, run
+# ``pip install 'quantum-metal[full]'`` before upgrading.
+#
+# Fires once per process via Python's default warning deduplication. Users
+# who want it silent can set ``QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1`` or
+# ``warnings.filterwarnings("ignore", category=FutureWarning, module="qiskit_metal")``.
+def _maybe_warn_lite_flip() -> None:
+    import os
+    import warnings
+
+    if os.environ.get("QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING") == "1":
+        return
+
+    msg = (
+        "quantum-metal v0.7.0 will move PySide6, qdarkstyle, pyaedt, "
+        "pyEPR-quantum, and gmsh out of base dependencies into opt-in "
+        "extras. To preserve the current v0.6.x install behaviour, run "
+        "`pip install 'quantum-metal[full]'` before upgrading. See "
+        "ROADMAP.md and docs/migration-to-v0.7.0.rst for details. "
+        "Set QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1 to silence."
+    )
+
+    # Log via metal's logger so the message is *visible* by default. The
+    # logger fires before ``logging.captureWarnings(True)`` (set by
+    # ``setup_logger`` higher in this file) would redirect a plain
+    # ``warnings.warn`` to a silent py.warnings logger.
+    logger.warning("[FutureWarning] %s", msg)
+
+    # Also raise via the warnings module so programmatic callers (tests,
+    # ``warnings.catch_warnings``, etc.) can detect the upcoming change.
+    warnings.warn(msg, FutureWarning, stacklevel=1)
+
+
+_maybe_warn_lite_flip()
+del _maybe_warn_lite_flip

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -1,9 +1,21 @@
+from __future__ import annotations
+
 from typing import Union, List, Optional
 from collections import defaultdict
 import pandas as pd
-import gmsh
 import numpy as np
 
+# gmsh is an opt-in dependency (``quantum-metal[fem]``). Keep this
+# module importable on the lite install — ``QGmshRenderer.__init__``
+# raises a clear ``ImportError`` via ``_require_gmsh`` if gmsh isn't
+# available. The "renderer skipped" path in
+# ``QDesign._start_renderers`` catches that and logs.
+try:
+    import gmsh
+except ImportError:  # pragma: no cover — exercised on lite installs
+    gmsh = None
+
+from qiskit_metal.renderers.renderer_gmsh.gmsh_utils import _require_gmsh
 from qiskit_metal.renderers.renderer_base import QRenderer
 
 from qiskit_metal.renderers.renderer_gmsh.gmsh_utils import (
@@ -95,6 +107,7 @@ class QGmshRenderer(QRenderer):
             initiate (bool): True to initiate the renderer (Default: False).
             options (Dict, optional): Used to override default options. Defaults to None.
         """
+        _require_gmsh()
         super().__init__(design=design, initiate=initiate, render_options=options)
         self._model_name = "gmsh_model"
 

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
@@ -1,7 +1,28 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Union, List, Tuple
 import numpy as np
-import gmsh
+
+# gmsh is an opt-in dependency (``quantum-metal[fem]``). Keep this
+# module importable on the lite install — the free functions below
+# that call into ``gmsh.model`` raise via ``_require_gmsh()`` at use
+# time rather than at ``import qiskit_metal`` time.
+try:
+    import gmsh
+except ImportError:  # pragma: no cover — exercised on lite installs
+    gmsh = None
+
+
+def _require_gmsh() -> None:
+    """Raise a clear error if gmsh isn't installed."""
+    if gmsh is None:
+        raise ImportError(
+            "renderer_gmsh requires gmsh. Install with: "
+            "pip install 'quantum-metal[fem]'"
+        )
+
+
 from qiskit_metal.draw.utility import Vec3D
 
 


### PR DESCRIPTION
## Summary

**Pre-flip release.** Adds the deprecation notice for the v0.7.0 lite-flip and lazifies the last remaining eager heavy-dep import (gmsh). All v0.6.x install behaviour is unchanged — but users running `pip install --upgrade quantum-metal` will now see a heads-up about v0.7.0's breaking change.

```
 changelog.md                                                  | 42 ++++++++++
 pyproject.toml                                                |  8 +--
 src/qiskit_metal/__init__.py                                  | 43 +++++++++++
 src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py     | 15 +++-
 src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py        | 23 +++++-
 5 files changed, 125 insertions(+), 6 deletions(-)
```

## Changes

### gmsh lazification (renderer_gmsh/)

Same try/except + `_require_gmsh()` + `__init__` check pattern as the pyEPR/pyaedt lazification in #1078. Files:

- `gmsh_utils.py` — wraps the `import gmsh` in try/except. The free functions still call `gmsh.X(...)` directly; they fail with a clear `ImportError` pointing at `pip install 'quantum-metal[fem]'` via `_require_gmsh()` at the call site if gmsh isn't installed.
- `gmsh_renderer.py` — same pattern; `QGmshRenderer.__init__` calls `_require_gmsh()`. The `_start_renderers` skip-and-log path catches it on lite installs.

Not a hard-touch zone (CLAUDE.md only lists `renderer_ansys*/`, `_gui/`, and the pyEPR-bridge). Mechanical change, low risk.

### gmsh version pin tightening

`gmsh>=4.11.1` → `gmsh>=4.15.0,<5` in 3 places (base deps + `[fem]` extra + `[full]` extra). The dev env has been shipping 4.15.0 since v0.5.3.post1 (changelog entry from Jan 2026) — this matches reality. Upper bound caps before any future gmsh 5.

### Version bump

`0.6.1` → `0.6.2`. `qiskit_metal.__version__` reports the same (it reads from package metadata).

### The deprecation warning itself

New `_maybe_warn_lite_flip()` in `qiskit_metal/__init__.py`, called once at module init. Two-channel emission:

1. **Logs via metal's logger** — visible by default. Without this, users wouldn't see the warning at all because `setup_logger(capture_warnings=True)` higher up in `__init__.py` calls `logging.captureWarnings(True)`, redirecting plain `warnings.warn` to the silent `py.warnings` logger. (This was a non-obvious wrinkle — debugging session worth its own lessons-learned entry, will follow up.)
2. **Raises `FutureWarning` via `warnings.warn`** — catchable by `warnings.catch_warnings`, test suites, programmatic callers.

Output looks like:

```
03:13AM 38s WARNING [_maybe_warn_lite_flip]: [FutureWarning]
quantum-metal v0.7.0 will move PySide6, qdarkstyle, pyaedt,
pyEPR-quantum, and gmsh out of base dependencies into opt-in extras.
To preserve the current v0.6.x install behaviour, run `pip install
'quantum-metal[full]'` before upgrading. See ROADMAP.md and
docs/migration-to-v0.7.0.rst for details. Set
QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1 to silence.
```

Suppress with `QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1` (verified empty output) or the normal `warnings.filterwarnings(...)` mechanisms.

### Changelog

New `v0.6.2 (deprecation-notice release)` section at the top of `changelog.md` describing this release. Explains what's changing in v0.7.0, what users need to do, and that the public API / test behaviour / install behaviour are all unchanged in this release.

## Verification

- **Version**: `pyproject.toml` says 0.6.2, `qiskit_metal.__version__` reports 0.6.2, `docs/conf.py` reads it from `__version__`. All consistent.
- **Full test suite**: 458 passed, 0 failed
- **Lite install** (PySide6 / gmsh / pyEPR / pyaedt / ansys.aedt blocked at meta-path): `import qiskit_metal` + `qm.view` succeed; all 5 renderer types skip cleanly with friendly hints (hfss / q3d / gmsh / aedt_hfss / aedt_q3d)
- **Warning visible by default** — confirmed via `python -c "import qiskit_metal"` in a clean subprocess
- **Suppress env var works** — confirmed
- **ruff check / format**: clean

## Release plan

This PR is the pre-release for v0.6.2. After merge, run `/release` (or the manual steps in `.claude/commands/release.md`) to:
1. Tag v0.6.2
2. Verify PyPI upload succeeds (the v0.6.0 lesson — don't tag and walk away)
3. Update GitHub release notes from the new changelog entry

Then **v0.7.0** is a follow-up PR that just flips `pyproject.toml`'s base dependencies (removes pyside6/qdarkstyle/pyaedt/pyEPR-quantum/gmsh from the `[project.dependencies]` list — they stay in the extras). One-line semantic change, mechanical risk is zero (everything's already lazy).

## Test plan

- [x] `pyproject.toml` version is 0.6.2; matches `qiskit_metal.__version__`
- [x] Full test suite green (458 passed)
- [x] Warning visible on plain `import qiskit_metal`
- [x] `QISKIT_METAL_SUPPRESS_LITE_FLIP_WARNING=1` silences it
- [x] Lite install (all 5 heavies blocked) imports + `qm.view` works; renderers skip with friendly hints
- [x] ruff clean
- [ ] **Reviewer**: tone check on the warning message — currently 5 sentences, want it shorter?

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_