### PR TITLE
chore: bump uv.lock to quantum-metal 0.6.2 (required pre-tag)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2524,7 +2524,7 @@ wheels = [
 
 [[package]]
 name = "quantum-metal"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },
@@ -2602,9 +2602,9 @@ requires-dist = [
     { name = "addict", specifier = ">=2.4.0" },
     { name = "gdstk", specifier = ">=0.9" },
     { name = "geopandas", specifier = ">=1.0" },
-    { name = "gmsh", specifier = ">=4.11.1" },
-    { name = "gmsh", marker = "extra == 'fem'", specifier = ">=4.11.1" },
-    { name = "gmsh", marker = "extra == 'full'", specifier = ">=4.11.1" },
+    { name = "gmsh", specifier = ">=4.15.0,<5" },
+    { name = "gmsh", marker = "extra == 'fem'", specifier = ">=4.15.0,<5" },
+    { name = "gmsh", marker = "extra == 'full'", specifier = ">=4.15.0,<5" },
     { name = "matplotlib", specifier = ">=3.7.0" },
     { name = "numpy", specifier = ">=1.24.2,<2" },
     { name = "pandas", specifier = ">=2.1.1" },


### PR DESCRIPTION
## Summary

Sync `uv.lock` with the 0.6.1 → 0.6.2 version bump from #1080. **Required before tagging v0.6.2** — otherwise `release.yml` would build and publish the lockfile-declared version (0.6.1), exactly reproducing the v0.6.0 failure pattern that left PyPI stuck at the old version.

```
uv.lock | 8 ++++----
1 file changed, 4 insertions(+), 4 deletions(-)
```

## What changed

Two trivial syncs in `uv.lock`:

1. `quantum-metal` package version `0.6.1` → `0.6.2`
2. `gmsh` constraint `>=4.11.1` → `>=4.15.0,<5` in three lockfile entries (base, `[fem]` extra, `[full]` extra) — matches the pin tighten from #1080

Generated by `uv lock`; no manual edits.

## Why this is its own PR

`uv.lock` was forgotten in #1080. Per `.claude/commands/release.md` (the v0.6.0 post-mortem), this is the exact failure mode where `pyproject.toml` says one version and `uv.lock` says another:

1. We tag `v0.6.2` 
2. `release.yml` fires, runs `uv build`, produces `quantum-metal-0.6.1.whl` (from lockfile)
3. `uv publish` to PyPI fails with "version already exists"
4. Tag exists, no PyPI artifact, repeat of v0.6.0

Keeping this fix as its own small PR makes the lockfile bump easy to review and explicitly gates the tag step.

## Test plan

- [x] `uv lock` regenerated cleanly (no spurious drift in other deps)
- [x] Diff is 4 lines: just the quantum-metal version field + gmsh constraint sync
- [ ] CI green (will surface on this PR)
- [ ] After merge: tag `v0.6.2` from `origin/main` and verify `release.yml` succeeds

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_