### PR TITLE
ci(docs): build on PRs too; only deploy on push-to-main (unblocks auto-merge)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Publish Documentation
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main, "stable/*"]
   workflow_dispatch:
 
 jobs:
@@ -34,6 +36,10 @@ jobs:
       - name: Bypass Jekyll Processing # Necessary for setting the correct css path
         run: touch docs/_build/html/.nojekyll
       - name: Deploy
+        # Only publish on push-to-main. On PRs we just want the build
+        # to gate merge; deploying to GitHub Pages from a PR branch
+        # would clobber the live docs with in-progress content.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/html/


### PR DESCRIPTION
## Summary

Fixes the **"Waiting for status to change"** auto-merge blocker.

```
.github/workflows/docs.yml | 6 ++++++
1 file changed, 6 insertions(+)
```

## Why

Branch protection requires **"Build and Publish Documentation"** as a status check, but the workflow only triggered on `push: [main]` — so every PR sat in `Waiting for status to change` forever and auto-merge could never fire. Hence the symptom you noticed.

## What changed

Two-line workflow edit:

1. **Add `pull_request:` trigger** with the same branch filter as the tests workflow. The build now runs on every PR.
2. **Gate the `JamesIves/github-pages-deploy-action@v4` step** on `github.event_name == 'push' && github.ref == 'refs/heads/main'`. On PRs the workflow builds + validates but does NOT deploy — deploying from a PR branch would clobber the live docs site with in-progress content.

## Effect

- PRs get a real docs-build gate — catches Sphinx errors, toctree drift, RST mistakes **before** merge instead of after, in a workflow whose name still includes "Publish."
- Live docs at https://qiskit-community.github.io/qiskit-metal/ still only update on push-to-main, identical to current behaviour.
- Branch-protection's required check actually fires on every PR, unblocking auto-merge.

## Test plan

- [x] Local diff is 6 lines, surgical
- [ ] CI run on this PR proves the build step works on a PR event
- [ ] CI run does NOT execute the Deploy step on a PR (workflow log will show "Skipped" for the conditional step)
- [ ] After merge: next push-to-main still deploys docs as before
- [ ] Auto-merge can now be set on future PRs once all checks pass (no more "Waiting for status to change")

## Separate from the CLA-bot blocker

This unblocks **one** of the two auto-merge issues you raised. The other (CLA-bot fires on every Claude-authored PR) is a config on cla-assistant.io — separate fix, no repo change needed. See the chat for the step-by-step.

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_