### PR TITLE
_dev + docs: Palace coordination scoping, ecosystem map, group/lab adoption roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,38 @@ covering the full API) or the
 
 ## 🌐 Ecosystem
 
-Quantum Metal is one of the core tools in a growing community ecosystem for
-superconducting quantum device design and education:
+Quantum Metal is the **open-source chip-design layer** for superconducting
+quantum hardware. A growing community of tools builds on it, extends it
+with new simulation backends, and plugs into it for quantization and
+discovery. **Full map: [docs.../ecosystem](https://qiskit-community.github.io/qiskit-metal/ecosystem.html)**.
+
+### Built on Quantum Metal
+
+- 🔬 **[SQuADDS](https://github.com/LFL-Lab/SQuADDS)** (LFL-Lab @ USC) —
+  validated qubit-design database + parameter interpolation. Published
+  in *Quantum* journal (Sept 2024).
+- 🧲 **[SQDMetal](https://github.com/sqdlab/SQDMetal)** (SQDLab @ UQ) —
+  simulation wrapper for `QDesign` → AWS Palace / COMSOL.
+- 🤖 **[ML_qubit_design](https://github.com/CosmiQuantum/ML_qubit_design)**
+  (Fermilab + Northwestern) — ML-based inverse design predicting Quantum
+  Metal parameters from target qubit properties.
+- 🌐 **[pypalace](https://pypalace.readthedocs.io/)** (Northwestern) —
+  Python toolkit for AWS Palace with Quantum Metal gmsh export.
+
+### Solvers Quantum Metal integrates with
+
+[AWS Palace](https://github.com/awslabs/palace) (roadmap) ·
+[Ansys HFSS/Q3D](https://www.ansys.com/products/electronics/ansys-hfss)
+(via `[ansys]`) · [Elmer FEM](https://www.elmerfem.org/) (via `[mesh]`) ·
+[gmsh](https://gmsh.info/) (via `[mesh]`).
+
+### Quantization & analysis
+
+[pyEPR](https://github.com/zlatko-minev/pyEPR) ·
+[scqubits](https://github.com/scqubits/scqubits) ·
+[QuTiP](https://github.com/qutip/qutip).
+
+### Community organization & events
 
 - **[Quantum Device Workshop (QDW)](https://qdw-ucla.squarespace.com/)** — annual
   workshop at UCLA/USC with invited leaders in the field. Recent speakers:
@@ -168,9 +198,11 @@ superconducting quantum device design and education:
   [Video recordings](https://www.youtube.com/@uclaqcsa) ·
   [Sign for 2026](https://qdw-ucla.squarespace.com/qdw2026).
 - **[Quantum Device Consortium (QDC)](https://qdc-qcsa.vercel.app)** — the
-  community organization stewarding Quantum Metal alongside companion tools
-  (SQUADDS, SQDMetal, scqubits, pyEPR, and others).
+  community organization stewarding Quantum Metal alongside the tools above.
   [Join the QDC Discord](https://discord.gg/kaZ3UFuq).
+
+**Building something on Quantum Metal?** [Open an issue](https://github.com/qiskit-community/qiskit-metal/issues/new/choose)
+or ping us on Discord — we'd love to add you to the list.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,13 +21,23 @@ based on user demand and contributor availability.
 
 ## Vision
 
-Quantum Metal is the open-source design plane for
-superconducting quantum chips: a Python library where you
-build a chip from `QComponent`s, attach analyses, and hand
-the result to whichever solver / fab / orchestrator you
-want. The library itself is solver-agnostic; the renderers
-are the integration layer with the outside world (GDS,
-HFSS, Q3D, gmsh, Elmer, AWS Palace, ...).
+Quantum Metal is the open-source **chip-design layer** for
+superconducting quantum hardware: a Python library where
+you build a chip from `QComponent`s, attach analyses, and
+hand the result to whichever solver / fab / orchestrator
+you want. The library itself is solver-agnostic; the
+renderers are the integration layer with the outside world
+(GDS, HFSS, Q3D, gmsh, Elmer, AWS Palace, ...).
+
+We sit inside a broader open-source ecosystem — design
+discovery ([SQuADDS](https://github.com/LFL-Lab/SQuADDS)),
+Palace simulation wrappers ([SQDMetal](https://github.com/sqdlab/SQDMetal),
+[pypalace](https://pypalace.readthedocs.io/)),
+mesh utilities, quantization tools. Full map:
+[`docs/ecosystem.rst`](./docs/ecosystem.rst) (rendered at
+the docs site). Items below are about Metal's own
+direction; ecosystem-level coordination is tracked
+alongside.
 
 Two things shape the next year:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,65 @@ Items shipped under this initiative (across v0.6.1 → v0.7.1):
 
 ---
 
+## Downstream ecosystem rollout `[in-progress]`
+
+The v0.7.0 / 0.7.1 lite flip changed the install surface
+downstream packages depend on (extras-by-default, lazified
+Qt / pyaedt / gmsh, friendlier `ImportError` UX, the
+`MetalGUI` → `qm.view()` headless path). To finish the
+rollout, each downstream package needs install instructions,
+lockfiles, and pins updated against `quantum-metal>=0.7.1`.
+
+Coordination plan: file an issue on each downstream repo
+with a recipe for the upgrade, link to
+`docs/migration-to-v0.7.0.rst`, and point at a worked
+example.
+
+Worked example to point at:
+[qdw26-workshop PR #1](https://github.com/quantum-device-consortium/qdw26-workshop-materials/pull/1)
+swapped a forked-Metal pin for mainline
+`quantum-metal[full]>=0.7.1` and includes the Apple-Silicon
+Docker pin, `schemdraw` addition, and palace auto-discovery
+fixes — a full migration in one diff.
+
+Per-issue contents:
+
+1. New install command (`pip install quantum-metal[ansys]`,
+   `[mesh]`, `[full]`, etc. — whichever extras that
+   downstream actually uses).
+2. Any lazy-import / `ImportError` UX changes that affect
+   their code paths.
+3. Link to `docs/migration-to-v0.7.0.rst`.
+4. Reminder about the `qiskit_metal` → `quantum_metal`
+   import-path rename targeted for v0.8 / v1.0, so they can
+   plan import updates ahead of that release.
+
+Known downstream packages:
+
+- **[SQuADDS](https://github.com/LFL-Lab/SQuADDS)**
+  (LFL-Lab @ USC) — design-discovery database, consumes
+  Metal `QDesign` objects. **`[planned]`** — issue to file.
+- **[SQDMetal](https://github.com/sqdlab/SQDMetal)**
+  (SQDLab @ UQ) — Palace simulation wrapper. **`[planned]`**
+  — issue to file; same migration plus the
+  `MetalGUI` → `qm.view()` story for headless Docker /
+  Brev contexts.
+- **[pypalace](https://pypalace.readthedocs.io/)**
+  (Northwestern) — Palace wrapper. **`[planned]`** —
+  issue to file.
+- **[pyEPR](https://github.com/zlatko-minev/pyEPR)** —
+  **`[shipped]`** — co-maintained, compatibility through
+  v0.7.1 verified.
+- **[QDW 2026 workshop materials](https://github.com/quantum-device-consortium/qdw26-workshop-materials)**
+  — **`[shipped]`**, PR #1 merged; the canonical worked
+  example referenced above.
+
+If you maintain a package that depends on Metal and we
+haven't listed it, please open an issue here so we can
+add it (and help with the upgrade).
+
+---
+
 ## Next — AI-orchestration profile (v0.7.x – v0.8.0)
 
 Once the lite flip lands, `pip install quantum-metal`
@@ -178,17 +237,160 @@ but are worth tracking:
   full hints unlock static analysis for orchestrators
   and make the LLM-driven code-generation path more
   reliable.
-- **Plugin discovery via entry points.** External
-  renderers and component libraries currently require
-  monkey-patching or vendoring. A
-  `qiskit_metal.renderers` and
-  `qiskit_metal.qlibrary` entry-point namespace lets the
-  community ship third-party packages.
+- **Plugin discovery via entry points** `[planned, v0.8.x]`
+  External renderers and component libraries currently
+  require monkey-patching or vendoring. A
+  `qiskit_metal.renderers` and `qiskit_metal.qlibrary`
+  entry-point namespace lets the community ship third-party
+  packages — and gives lab and community PDKs a clean
+  `pip install <pdk>` distribution channel without
+  requiring any change to Metal itself.
+- **Functional component API alongside class hierarchy** `[research]`
+  Add a `@qm.cell`-decorator path so a component can be a
+  Python function returning a `QComponent`, in parallel to
+  the existing class-based subclassing. Doesn't replace
+  the class API. Motivation: LLM / agent codegen is
+  measurably more reliable against pure functions returning
+  values than against class hierarchies with stateful
+  side-effects, so a functional surface is a useful
+  on-ramp for the AI-orchestration profile above.
+- **JAX-differentiable parametric components** `[research]`
+  Inverse-design / qubit-frequency tuning via `grad()` is
+  unlocked once a small set of geometric primitives are
+  JAX-traceable. Start with `TransmonPocket` as a pilot
+  (pad width / gap → frequency gradient via an analytical
+  capacitance model, no FEM in the loop). Big win for the
+  research audience that currently hand-rolls finite-difference
+  sweeps; pairs naturally with EPR analysis for
+  Hamiltonian-aware optimisation.
 - **Docs hosting reassessment.** GH Pages is current
   (years of SEO). Read the Docs config archived at
   `docs/_archive/readthedocs/` — revivable in minutes
   if/when per-PR previews, versioned docs, or the
   rebrand cutover make the switch worth it.
+
+---
+
+## Group and lab adoption pathway
+
+The next-tier adopters for Metal — research groups, university
+labs, multi-PI consortia — evaluate against a recurring set of
+questions: *Is it maintained? Can we plug our own PDK in?
+Does the GDS round-trip cleanly through downstream tooling?
+Will it scale to Python-agent-driven design loops?* This
+section groups items aimed at those questions. Several
+overlap with the Adoption / DevRel section below; the cut is
+by *audience* — DevRel is about attracting individual users,
+this section is about clearing the path for groups and labs.
+
+*Items in this section reflect open-source community
+direction discussed within the Quantum Device Consortium
+(QDC) and the broader contributor base. They are
+aspirations, not commitments by any individual contributor
+or their employer.*
+
+### High impact, low effort
+
+- **Ship a Metal `.lyp` layer-property file** `[planned, v0.7.x]`
+  Users who open a Metal-exported GDS in KLayout currently
+  see grey-on-grey because no layer colours / names ship
+  with our GDS files. A one-page `.lyp` under
+  `docs/_static/` (linked from the GDS export docs) gives
+  them a named, coloured view out of the box. KLayout is
+  the de-facto open-source viewer in the GDS-handoff path;
+  making this handoff frictionless removes a real papercut.
+  ~2 hours.
+- **"Metal → KLayout" how-to page** `[planned, v0.7.x]`
+  Document the GDS-export → KLayout-DRC / visual inspection
+  flow, paired with the `.lyp` and a starter DRC deck
+  (below). Most superconducting-design flows in the
+  community already do both — making the combination
+  first-class instead of folklore reduces onboarding
+  friction. ~3 hours.
+- **"Built for AI agents" docs page** `[planned, v0.7.x]`
+  Companion to `docs/orchestration.rst` already on the
+  roadmap. The lite-by-default flip and `qm.view()`
+  removed the dependency surface that made agent-driven
+  workflows painful; this page makes the workflow
+  visible. Importantly, position Metal *with* the
+  ecosystem here — design discovery via
+  [SQuADDS](https://github.com/LFL-Lab/SQuADDS), solver
+  dispatch via [SQDMetal](https://github.com/sqdlab/SQDMetal)
+  / [pypalace](https://pypalace.readthedocs.io/),
+  quantisation via [pyEPR](https://github.com/zlatko-minev/pyEPR)
+  and [scqubits](https://github.com/scqubits/scqubits) —
+  rather than implying Metal does it all. The story is the
+  composable open-source stack, not Metal in isolation.
+  ~3 hours.
+
+### High impact, medium effort
+
+- **Tighten release cadence to monthly minimum** `[planned]`
+  Even pure-docs / test-only point releases. Prospective
+  adopters check commit + release pulse before committing
+  engineering time, and read steady cadence as a
+  maintenance signal more strongly than raw feature
+  surface. Quarterly is fine for features; monthly is
+  cheap and changes the perception.
+- **Starter DRC deck for superconducting basics** `[planned]`
+  A `qm.drc(design, deck="sc_basics")` helper that shells
+  out to KLayout with a minimal rule set: min line width,
+  min gap, JJ overlap minimums, ground-plane keep-outs.
+  Doesn't need to be comprehensive — needs to *exist*, so
+  PDK authors and labs have a template to extend instead
+  of starting from blank.
+- **"When to use Quantum Metal" docs page** `[planned]`
+  Use-case-driven framing (not framework-comparison):
+  which problems Metal is shaped for (qubit-first design
+  with energy-participation analysis, Hamiltonian
+  extraction, integration with the open-source SC qubit
+  toolchain), which adjacent workflows hand off elsewhere
+  (mask-level DRC, process-specific PDK rules, photonics).
+  Highly searched by evaluators; framing the fit ourselves
+  is more useful to readers than leaving them to
+  assemble it.
+- **Gallery + thumbnail component icons**
+  `[promoted from research]`
+  Already on the Adoption list and the Wish-list. Promote
+  to planned: visual component catalogue is a natural
+  strength of the class-based qlibrary and is currently
+  under-used. Pairs with the "When to use Metal" page
+  above as the visual half of the answer.
+
+### High impact, high effort
+
+- **Reference PDK** (`metal-pdk-academic` or similar)
+  `[research]`
+  Demonstrates the entry-points pattern from a realistic
+  angle, so subsequent community PDKs have a worked example
+  to follow. Without one, the entry-points hook is
+  abstract.
+- **Hosted web design viewer** `[research]`
+  Already on the Adoption / Bigger plays list. Flagship
+  demo plus a real adoption unlock — closes the "I want
+  to look at a Metal design without installing anything"
+  gap that today forces evaluators to clone the repo
+  before they see a chip.
+
+### Wish-list
+
+- **Salt-style extension marketplace / index page** `[wish]`
+  The simpler `awesome-quantum-metal` (already on the
+  adoption list) covers most of the need; a richer
+  in-app discovery surface is a stretch goal.
+- **Format converters to / from adjacent Python design
+  libraries** `[wish]`
+  Quantum and RF design teams increasingly use multiple
+  Python frameworks side by side. Clean component-level
+  converters would make Metal a friendly neighbour in
+  mixed pipelines. Best owned jointly with the relevant
+  project teams if there's interest.
+- **Annual "State of Quantum Metal" report** `[wish]`
+  Already on the Adoption list as research. Doubles as
+  community visibility for grant proposals and external
+  reporting.
+
+---
 
 ---
 
@@ -250,15 +452,18 @@ trial viable).
 - **`awesome-quantum-metal` companion repo** `[research]` — curated list:
   papers using Metal, lab tooling on top of Metal, talks, integrations.
   Community-curated, standard `awesome-*` pattern.
-- **Comparison page** ("Metal vs. ...") `[research]` — honest comparison
-  vs. Ansys Workbench / commercial EDA / hand-coded GDS. Highly searched
-  by evaluators.
+- **"When to use Metal" page** `[research]` — use-case-driven
+  framing of which problems Metal is shaped for and which
+  workflows hand off elsewhere. Highly searched by evaluators.
+  (Superseded direction for the older "comparison page" idea —
+  see the parallel item under "Group and lab adoption pathway".)
 - **Web-based read-only design viewer** `[research]` — overlaps with the
   Jupyter widget viewer in the renderer roadmap; a web-hosted version on
   the docs site would be a flagship demo.
 - **Annual / quarterly community report** `[research]` — "State of Quantum
   Metal 202X" with downloads, contributors, papers citing, new features.
-  Doubles as institutional fundraising / partnership signal.
+  Community visibility artefact, useful for grant proposals and
+  external reporting.
 
 ---
 

--- a/_dev/ecosystem_landscape.md
+++ b/_dev/ecosystem_landscape.md
@@ -1,0 +1,270 @@
+# Quantum Metal in the open-source SC-quantum design ecosystem
+
+**Status**: 🟡 research / analysis. Not a commitment to anything specific.
+**Audience**: Quantum Metal maintainers. **Companion to**:
+[`palace_replaces_ansys.md`](./palace_replaces_ansys.md) +
+[`sqdmetal_coordination_issue_draft.md`](./sqdmetal_coordination_issue_draft.md).
+
+---
+
+## TL;DR
+
+Quantum Metal sits at the **chip-design** layer. Around it, distinct
+layers each have one (or several) actively-maintained open-source
+projects that already integrate with us — or could. Today there's no
+shared map; users discover this ecosystem by accident.
+
+**Recommendation**: ship a single `ECOSYSTEM.md` (or `docs/ecosystem.rst`)
+that maps the layers, names the tools, links to each, and labels the
+current integration status with Metal. Add a brief "Used with" section
+to the main `README.md` that points there. **Reach out to the active
+adjacents** (SQDMetal, SQuADDS, pypalace) with a light touch — let them
+know we're framing this as an ecosystem and want their links / blurbs
+to be accurate.
+
+**Don't** try to coordinate every project into a single governance
+structure. The ecosystem is healthier when projects stay independent
+but are well-mapped.
+
+---
+
+## The layered model
+
+```
+                     ┌─────────────────────────────────────────┐
+   Design discovery  │  SQuADDS (LFL-Lab) — qubit design DB    │
+                     │  ✅ already uses Qiskit Metal           │
+                     └────────────────────┬────────────────────┘
+                                          │
+   ┌──────────────────────────────────────▼────────────────────────────┐
+   │  CHIP DESIGN  ────  Quantum Metal (us) ───────────────────────────│
+   │  Build QDesigns from QComponents, render to backends              │
+   └──┬──────────┬──────────┬──────────┬──────────────┬───────────────┘
+      │          │          │          │              │
+      ▼          ▼          ▼          ▼              ▼
+   GDS         GUI        Ansys      Open FEM      Quantization
+   (gdstk)   (PySide6)    (pyaedt)   (gmsh/Elmer)  (pyEPR, scqubits, qutip)
+   in core   [gui]        [ansys]    [mesh]        in core
+                                       │
+                                       ├── SQDMetal (sqdlab)     ✅ active; their PALACE module
+                                       │   wraps Palace ← uses our QDesign
+                                       ├── pypalace (Northwestern) 🟡 newer; also Palace
+                                       │   wrapper; uses Qiskit Metal gmsh export
+                                       ├── meshwell (simbilod)   🟡 2.5D meshing helper
+                                       │   on top of gmsh/OCC; GPL-3.0
+                                       └── AWS Palace            ← the solver itself
+                                                  (open-source, Apache 2.0)
+```
+
+The picture above is the actual relationship — Metal in the center, the
+ecosystem branching out at each backend axis. None of these are
+competitors. **All are doing useful things at adjacent layers.**
+
+---
+
+## Inventory — each project with its actual role
+
+### Already deeply integrated with Metal (in our codebase or required deps)
+
+| Tool | Role | License | Status |
+|---|---|---|---|
+| [pyEPR-quantum](https://github.com/zlatko-minev/pyEPR) | EPR quantization from HFSS field data | BSD-3 | In our `[ansys]` extra |
+| [scqubits](https://github.com/scqubits/scqubits) | Closed-form qubit-spectra / quantization | BSD-3 | In our base deps |
+| [QuTiP](https://github.com/qutip/qutip) | Quantum dynamics | BSD-3 | In our base deps |
+| [gmsh](https://gmsh.info/) | Mesh generation | GPL-2.0 | In our `[mesh]` extra |
+| [Elmer FEM](https://www.elmerfem.org/) | Open FEM solver (capacitance / LOM) | LGPL | External binary, driven via subprocess |
+| [pyaedt](https://github.com/ansys/pyaedt) | Python wrapper for Ansys AEDT | MIT | In our `[ansys]` extra |
+| [Qiskit](https://github.com/Qiskit/qiskit) | Algorithm / circuit library | Apache 2.0 | Historical namespace (we're "Quantum Metal" now) |
+
+### Community-aligned, separate projects that touch Metal
+
+| Tool | Role | License | Integration with Metal today |
+|---|---|---|---|
+| **[SQDMetal](https://github.com/sqdlab/SQDMetal)** (SQDLab @ UQ) | Simulation wrapper for QDesign → Palace / COMSOL / capacitance / inductance / driven / eigenmode | Apache 2.0 | Accepts our `QDesign` objects directly. **Active outreach** ([draft issue](./sqdmetal_coordination_issue_draft.md)) on Palace coordination. |
+| **[SQuADDS](https://github.com/LFL-Lab/SQuADDS)** (LFL-Lab @ USC, Sadman Shanto) | Validated qubit design database + interpolation tools; physics-based parameter prediction across geometries | MIT | Heavy Qiskit Metal integration; uses HFSS, Palace, and physics models. Has its own MCP server for AI agents (!). Lead dev Sadman was a v0.5 Metal contributor. |
+| **[pypalace](https://pypalace.readthedocs.io/)** (Firas Abouzahr @ Northwestern) | Python toolkit for AWS Palace — config builders, mesh utils, sim launcher, LOM analysis | unclear (need to verify) | Supports gmsh export from Qiskit Metal layouts. **Recent / smaller** than SQDMetal. |
+| **[AWS Palace](https://github.com/awslabs/palace)** (AWS Center for Quantum Computing) | Maxwell solver (eigenmode + driven + electrostatic + magnetostatic + AMR) | Apache 2.0 | No direct integration with Metal yet — the entire point of the scoping doc. |
+| **[meshwell](https://github.com/simbilod/meshwell)** (Simon Bilodeau, single maintainer) | 2.5D meshing on top of gmsh + OCC via Shapely geometry inputs | **GPL-3.0** ⚠️ | Not currently used by Metal. Could be useful for cleaner extruded geometry, but the **GPL-3.0 vs our Apache 2.0** would force us into copyleft if we depend at runtime. |
+
+### Adjacent ecosystem tools (not Metal-specific but worth knowing)
+
+| Tool | Role | License | Why it's in the picture |
+|---|---|---|---|
+| [KQCircuits](https://github.com/iqm-finland/KQCircuits) (IQM) | GDS-based superconducting-circuit design framework | GPL-3.0 | The other major open-source SC design tool. Different philosophy (GDS-first vs `QComponent`-first). Some shared users. |
+| [CircuitQ](https://github.com/PhilippAumann/CircuitQ) | Quantization of arbitrary superconducting circuits | MIT | Adjacent to scqubits; narrower scope; smaller community. |
+| [KLayout](https://github.com/KLayout/klayout) | GDS viewer/editor | GPL-3.0 | Where users open our GDS exports for inspection. Standard fab-pipeline tool. |
+| [ParaView](https://www.paraview.org/) / [PyVista](https://github.com/pyvista/pyvista) | Field-data visualization (.pvtu, .vtk) | BSD | Where users view Palace / Elmer simulation outputs. SQDMetal's `PVDVTU_Viewer` builds on PyVista. |
+| [meshio](https://github.com/nschloe/meshio) | Mesh format conversion | MIT | Useful glue if mesh formats diverge between tools. |
+
+---
+
+## Hard architecture question: how does pypalace fit?
+
+**The complication**: there are now **two Python-side wrappers for Palace that integrate with Qiskit Metal** — SQDMetal/PALACE and pypalace.
+
+What we know:
+- **SQDMetal/PALACE** — mature, multi-contributor, comprehensive (eigenmode + capacitance + driven + inductance + PVD/VTU viewer), Apache 2.0.
+- **pypalace** — newer (release status unclear), apparently single-maintainer (Northwestern), supports gmsh export from Metal layouts and LOM analysis.
+
+**Three honest scenarios for how this resolves:**
+
+1. **One emerges as the obvious choice.** If SQDMetal's Palace module is significantly more complete and active (looks that way today), pypalace may converge on it or fade. Metal coordinates with whichever ends up canonical.
+2. **They have distinct niches.** pypalace might be optimized for a different workflow (e.g. AI-agent-driven sims, or specific Northwestern-group workflows). Both stay relevant.
+3. **They merge or one absorbs the other.** Unlikely without active facilitation, but possible if both teams talk.
+
+**What this means for our SQDMetal outreach (issue #1089's draft)**:
+
+We should **briefly acknowledge pypalace exists** in the SQDMetal issue — not as a competing offer but as honest disclosure: *"we've also seen pypalace; we don't know how it intersects with your work and would value your read."* Otherwise the SQDMetal team finds out via the rendered issue and wonders why we didn't mention it.
+
+**What this means for our action items**:
+
+- Open a **lighter-touch issue** at pypalace too, after the SQDMetal conversation gets going. Same ideation framing: *"hi, we're mapping the ecosystem, would love to understand how you'd like to be referenced from Quantum Metal docs and what coordination (if any) makes sense."*
+- **Do NOT** try to force a merger. Both teams should make their own calls. We just don't want to silently bless one project as canonical.
+
+**What this means for the scoping doc** (`palace_replaces_ansys.md`):
+
+Add pypalace as an alternative in §3 (Prior art and allies). Doesn't change the recommendation but makes the analysis honest.
+
+---
+
+## SQuADDS: a different conversation
+
+SQuADDS is at a **different layer** than SQDMetal / pypalace. It's not "another Palace wrapper" — it's the **design-discovery / parameter-interpolation database** that sits *above* the chip-design layer (Metal) and uses Metal to generate designs from database queries.
+
+The relationship to Metal is already strong:
+- Heavy Metal integration (tutorials, codebase)
+- Sadman Ahmed Shanto (lead dev) was a v0.5 Metal contributor
+- They have their own MCP server for AI agents — directly aligned with our AI-orchestration roadmap
+- Published in *Quantum* journal (Sept 2024), 26 releases, 55 stars
+
+**Action**: This isn't a coordination issue like SQDMetal — we're already aligned. The action is making the relationship **visible in our docs**:
+- Add SQuADDS prominently to the ecosystem map
+- Link to their MCP server from our AI-orchestration ROADMAP entry (it's a real example of the orchestration profile we said we want)
+- Light outreach to Sadman to coordinate cross-linking and ensure our descriptions of each other are accurate
+
+**Possible follow-up later**: a Metal tutorial that uses SQuADDS to pull a known design from their database, render in Metal, simulate in Palace. End-to-end ecosystem demo. Compelling story for QDW.
+
+---
+
+## meshwell: probably skip for now
+
+**Verdict**: don't depend on it.
+
+Why:
+- **GPL-3.0** vs our Apache 2.0 — if we depend at runtime, we'd have to relicense Metal or carry a license-incompatibility risk.
+- We don't have a strong need today. Our `QGmshRenderer` uses gmsh directly via its Python bindings.
+- It's a single-maintainer project at the moment.
+
+When we *might* revisit:
+- If we hit specific 2.5D meshing edge cases that meshwell's Shapely-based abstractions handle cleanly and gmsh's raw API doesn't.
+- If meshwell relicenses or dual-licenses (unlikely but possible).
+
+Worth noting in our ecosystem map for completeness, but not actionable for us right now.
+
+---
+
+## Did we miss any popular repos?
+
+Yes — several worth knowing about, added to the ecosystem map.
+
+### Now included in `docs/ecosystem.rst`
+
+**Built on Metal (the headline category)**:
+- **[ML_qubit_design](https://github.com/CosmiQuantum/ML_qubit_design)**
+  (Fermilab + Northwestern, Olivia Seidel as primary contact) — ML-based
+  inverse design predicting Quantum Metal parameters from target qubit
+  properties via multi-layer perceptrons. Notebook-driven research
+  project, modest stars (~5), 287 commits. **Important to highlight
+  because it exemplifies the "built on Metal" story** — they explicitly
+  use Quantum Metal simulation data as training material. AI-orchestration
+  adjacent.
+
+**SC-quantum-design adjacent**:
+- **[KQCircuits](https://github.com/iqm-finland/KQCircuits)** (IQM
+  Finland) — the other major open-source SC chip design framework.
+  GDS-centric philosophy vs our QComponent-centric. Some users straddle.
+- **[CircuitQ](https://github.com/PhilippAumann/CircuitQ)** — small but
+  active quantization tool, alternative to scqubits for arbitrary circuits.
+
+**Visualization / glue**:
+- **[PyVista](https://github.com/pyvista/pyvista)** — standard Python
+  ParaView wrapper. Both SQDMetal and pypalace use it.
+- **[meshio](https://github.com/nschloe/meshio)** — mesh format
+  conversion. Useful glue when formats diverge.
+
+### Deliberately NOT in the ecosystem doc
+
+- **`gdsfactory`** — primarily photonic, with growing SC use. Does not
+  build on Metal, doesn't integrate with us, and listing them in our
+  ecosystem doc would either misframe the relationship ("they use us"
+  — they don't) or amplify a project we're sometimes evaluated against.
+  We don't owe a comprehensive industry survey; the page is about
+  Quantum Metal's ecosystem specifically.
+- **`femwell`** (Helge Gehring) — photonics-focused FEM library
+  (eigenmode + thermal + RF CPW). 1,549 commits, 170 stars, GPL-3.0.
+  Came onto the radar because it's gdsfactory-adjacent. Same logic
+  applies: photonic-primary, GPL-3.0 (license-incompatible for runtime
+  depending), not used by anyone in our ecosystem today.
+- **Commercial-only tools** (CST Studio, IE3D, etc.) — outside the
+  open-source ecosystem story.
+- **[Qiskit](https://github.com/Qiskit/qiskit)** — historical namespace,
+  not a design tool. Mention only when explaining the rebrand.
+
+If any of these become relevant later (e.g. a user actually builds a
+Metal ↔ gdsfactory bridge), we add them. Until then, they're noise.
+
+### What we still don't highlight
+
+- **[Qiskit](https://github.com/Qiskit/qiskit)** — historical namespace,
+  not a design tool. Mention only when explaining the rebrand.
+- Commercial-only tools (CST Studio, IE3D, etc.) — outside the
+  open-source ecosystem story.
+
+The honest answer to "did we miss any": **the SC-quantum design
+ecosystem has 10–15 distinct active projects across the layers**. We
+list every one that either (a) builds on Metal directly, (b) is a
+solver / library we integrate with, or (c) is widely-known enough that
+users will encounter it. The ecosystem doc curates this — it isn't
+exhaustive.
+
+---
+
+## Concrete deliverables
+
+### Recommended for this round
+
+1. **Ship an ecosystem doc** — either as `ECOSYSTEM.md` at repo root or `docs/ecosystem.rst` in the docs site. Probably `docs/ecosystem.rst` so it renders into the published docs and is searchable. Roughly the structure of the "Inventory" section above.
+2. **Add an "Ecosystem" section to `README.md`** that's 5 lines max and links to the full ecosystem doc. Don't bloat the README.
+3. **Update `ROADMAP.md`** to reference the ecosystem doc and acknowledge tools beyond Metal.
+4. **Light update to the SQDMetal issue draft** — add one sentence acknowledging pypalace exists.
+5. **Add pypalace mention to `palace_replaces_ansys.md`** §3 — honest disclosure that there are two existing Palace wrappers in the Metal ecosystem.
+
+### Recommended for follow-up (not this PR)
+
+6. **Light outreach to SQuADDS** — Sadman Shanto. Coordinate cross-linking and accurate descriptions; possibly propose a joint tutorial later.
+7. **Light outreach to pypalace** — Firas Abouzahr. After the SQDMetal conversation gets traction, same ideation-style "we're mapping the ecosystem" issue.
+8. **Joint QDW 2026 panel?** "Ecosystem of open-source SC quantum design tools." Brings SQDMetal, SQuADDS, pypalace, Metal teams together publicly. Maybe a poster session. Low cost, high community signal.
+
+### Explicitly **not** recommended
+
+- A single governance body. The ecosystem is healthier when projects stay independent.
+- A monorepo / mega-package. Same reason.
+- Forks or vendoring without conversation.
+- Trying to be exhaustive — we'll never list every tool. Curate the meaningful ones.
+
+---
+
+## Sources / references
+
+- [SQDMetal](https://github.com/sqdlab/SQDMetal) (Apache 2.0; SQDLab @ UQ)
+- [SQuADDS](https://github.com/LFL-Lab/SQuADDS) (MIT; LFL-Lab @ USC)
+- [pypalace](https://pypalace.readthedocs.io/en/latest/) (Northwestern)
+- [AWS Palace](https://github.com/awslabs/palace) (Apache 2.0; AWS CQC)
+- [meshwell](https://github.com/simbilod/meshwell) (GPL-3.0; simbilod)
+- [pyEPR](https://github.com/zlatko-minev/pyEPR) (BSD-3)
+- [scqubits](https://github.com/scqubits/scqubits) (BSD-3)
+- [KQCircuits](https://github.com/iqm-finland/KQCircuits) (GPL-3.0; IQM Finland)
+- [gdsfactory](https://github.com/gdsfactory/gdsfactory) (MIT)
+- [CircuitQ](https://github.com/PhilippAumann/CircuitQ) (MIT)
+- [SQuADDS paper, Quantum journal Sept 2024](https://arxiv.org/abs/2312.13483)
+- [SQDMetal paper, arXiv Nov 2025](https://arxiv.org/pdf/2511.01220)

--- a/_dev/palace_replaces_ansys.md
+++ b/_dev/palace_replaces_ansys.md
@@ -1,0 +1,386 @@
+# Making Palace a first-class peer to Ansys in Quantum Metal
+
+**Audience**: Quantum Metal maintainers (and any SQDMetal folks who care
+to peek). **Status**: scoping analysis — internal thinking to help us
+reason about the option space. **Not a commitment.**
+
+> A note on what this doc is and isn't:
+>
+> - It's Metal-side scoping: how we'd architect a Palace path **if** we
+>   build one, and how that interacts with prior work in the community.
+> - The "recommended" path below is our tentative working preference,
+>   not a decision. It's framed concretely so the conversation has
+>   something to push back on, not because anything is locked in.
+> - Coordination with SQDMetal is the gating question. The shape of any
+>   integration depends on what works for them — see
+>   [`sqdmetal_coordination_issue_draft.md`](./sqdmetal_coordination_issue_draft.md)
+>   for the open conversation. Outcomes range from "we partner deeply"
+>   to "we just promote SQDMetal from our docs and don't ship our own
+>   Palace integration at all" — both are genuinely fine.
+> - Phase numbers and week estimates are illustrative ranges, not
+>   commitments. Calendar reality depends on who picks this up and how
+>   the coordination conversation lands.
+
+> "Replace" is shorthand. HFSS / Q3D stay supported in Metal for years;
+> too many users have AEDT licenses and existing workflows. This doc is
+> about making **Palace a first-class peer** to Ansys: default for new
+> tutorials, recommended path for users without AEDT, both backends
+> coexisting in the analysis layer.
+
+---
+
+## 1. What Ansys does in the workflow today
+
+Four services that downstream analyses consume, plus a fifth thing
+(live AEDT GUI) that Palace can't replace because it's batch/CLI:
+
+| # | Service | Ansys tool | Consumed by | Output shape |
+|---|---|---|---|---|
+| 1 | Capacitance matrix | Q3D electrostatic | `LOManalysis` | Maxwell C matrix |
+| 2 | Eigenmode freqs + Q | HFSS Eigenmode | `EigenmodeSim` | mode freqs, Q, field snapshots |
+| 3 | EPR (participation ratios, anharmonicity, cross-Kerr) | HFSS Eigenmode + field integration | `EPRanalysis` | participation matrix + derived |
+| 4 | S-parameters / impedance | HFSS Driven Modal | `ScatteringImpedanceSim` | S-params, Z matrix |
+
+"First-class peer" means Palace produces data with the same downstream
+shape for #1–#4, so the analysis classes don't need to know which
+backend ran.
+
+---
+
+## 2. Palace ↔ Ansys solver mapping — and where the cracks are
+
+| Ansys service | Palace equivalent | Difficulty | Where it gets thorny |
+|---|---|---|---|
+| Q3D electrostatic | Palace `Electrostatic` | 🟢 same physics | Mesh-convergence behavior differs; coarse-mesh results may diverge from Q3D |
+| HFSS Eigenmode | Palace `Eigenmode` | 🟢 modes + Q | Loss models are younger; Q on lossy geometries needs careful validation |
+| HFSS Driven Modal | Palace `Driven` (freq-domain) | 🟡 port tagging is real work | Adaptive frequency-sweep more limited than HFSS; wave-port impedance has fewer knobs |
+| HFSS → EPR | Palace eigenmode + field integration + EPR | 🔴 hardest | pyEPR was written against HFSS field-export format; doesn't read `.pvtu` |
+
+EPR is the hard one because of plumbing, not physics. Two routes:
+
+- **(a)** Teach pyEPR to read Palace `.pvtu`. Cross-project change.
+- **(b)** Do the EPR field integration ourselves in `renderer_palace/`,
+  hand pyEPR pre-computed participation matrices. **Conservative default.**
+
+### Honest gaps vs HFSS
+
+Palace covers the four categories; it doesn't match HFSS at every edge.
+Real differences a user can hit:
+
+- **PML / absorbing boundaries** — HFSS has decades of tuning recipes;
+  Palace's PML is younger.
+- **Frequency-dependent materials** — both support it; HFSS has more
+  packaged material libraries and forum recipes.
+- **Convergence diagnostics** — HFSS's adaptive-solve + S-conv / Δf-conv
+  reporting is more mature.
+- **Edge cases** — complex 3D (flip-chip with TSVs, airbridges) likely
+  converges faster in HFSS today. Not because Palace can't, but because
+  the recipes aren't written down.
+- **Documentation** — 20+ years of HFSS forum posts vs. Palace's young
+  community.
+
+None of these block "first-class peer". They're reasons to be honest
+with users about when each tool fits better, and to validate against
+designs that are well-understood in both — not just one.
+
+---
+
+## 3. Prior art and allies — SQDMetal (and pypalace)
+
+There are **two** existing Python wrappers for AWS Palace that already
+integrate with Quantum Metal:
+
+1. **[sqdlab/SQDMetal](https://github.com/sqdlab/SQDMetal)** (SQDLab @ UQ)
+   — community-aligned (self-described as "an extension of Qiskit Metal",
+   Apache 2.0, accepts `QDesign` objects directly). More active than
+   Metal right now: ~30 commits in 6 months, 6+ contributors, MRU
+   2026-05-20. Their PALACE module covers all four services end-to-end,
+   including EPR-flavoured analysis on Palace outputs.
+   **They are friends, not competitors.**
+2. **[pypalace](https://pypalace.readthedocs.io/)** (Firas Abouzahr @
+   Northwestern) — newer Python toolkit for Palace, supports gmsh export
+   from Qiskit Metal layouts, includes LOM analysis utilities. Smaller /
+   more recent than SQDMetal; maintenance cadence and exact API surface
+   less established.
+
+We prioritize the SQDMetal conversation first because their work is more
+mature and `QDesign`-direct, but we should **not** silently bless one
+project as the canonical Palace wrapper. Both deserve to be referenced
+in our ecosystem docs, and the [SQDMetal outreach draft](./sqdmetal_coordination_issue_draft.md)
+explicitly acknowledges pypalace exists. See also the broader ecosystem
+map at [`_dev/ecosystem_landscape.md`](./ecosystem_landscape.md).
+
+**Honest caveats on the prior-art claim:**
+
+1. **I haven't independently verified their EPR math** against a known
+   HFSS result. Their integration runs and produces numbers; whether
+   those numbers agree with HFSS within the release-gate tolerance (§5)
+   is something we have to *actually validate*, not assume. Strong
+   starting point, not a guarantee.
+2. **Packaging tension** — their `pyproject.toml` declares `quantum-metal`
+   as a hard dep (circular if we depend on them), pins Python 3.11-only,
+   and treats COMSOL bindings (`mph`) as mandatory not optional. We
+   can't simply `pip install sqdmetal` from Metal. The fix has to be on
+   their side, or take the form of a shared module.
+3. **Coordination friction is real** — aligning on architecture, code
+   review across two teams, joint release cadence. Realistic adds
+   4–6 weeks of calendar vs going alone. Worth it for the community
+   signal and the existing work; we shouldn't pretend it's free.
+
+**Default operating mode**: coordinate from week 1. Open the
+conversation, share this doc, agree on integration shape before cutting
+production code.
+
+---
+
+## 4. Integration shapes (architecture on Metal's side)
+
+Independent of *who* does the work — that's the SQDMetal coordination
+question. These are about how the renderer fits Metal.
+
+### A. API-compatible renderer; analyses unchanged
+
+`QPalaceRenderer(QRendererAnalysis)` matches the public API of
+`QHFSSPyaedt` / `QQ3DPyaedt` method-for-method. Existing analyses work
+unchanged. User swap:
+
+```python
+sim = EigenmodeSim(design, renderer="palace")    # was "hfss_pyaedt"
+```
+
+- **Pros**: smallest user change; analyses don't change; opt-in via `[palace]` extra.
+- **Cons**: carries forward HFSS API idiosyncrasies; "API-compatible" ≠
+  "drop-in identical results" (mesh / convergence differ); hides EPR
+  approach (a vs b) inside the renderer.
+
+### B. Strategy pattern in analysis classes
+
+Refactor `EigenmodeSim`, `LumpedElementsSim`, `ScatteringImpedanceSim` to
+dispatch to a backend interface. Renderers emit normalized data; analyses
+transform it.
+
+- **Pros**: right long-term shape; aligns with the
+  `design.render(backend=...)` direction on the roadmap; new solvers
+  plug in cheaply.
+- **Cons**: touches mature analysis code; destabilization risk on the
+  HFSS path while we build the Palace path; bigger upfront design.
+
+### C. Minimal v1 — skip EPR
+
+`renderer_palace/` covers capacitance + eigenmode-freq only. EPR and
+S-params slip to v2. HFSS stays the path for EPR users for now.
+
+- **Pros**: smallest scope; sidesteps EPR risk for v1.
+- **Cons**: doesn't help academic users without AEDT (who need EPR);
+  full peer-status story stays incomplete; v2 is a bigger push.
+
+### D. Workflow-first parallel path
+
+Don't try to match Ansys's renderer API. New Palace-native tutorials
+replace 4.01 / 4.02 / 4.11 / 4.12 as the primary path; renderer API is
+whatever fits Palace cleanly.
+
+- **Pros**: not constrained by HFSS API; lets Palace's strengths
+  (AMR, MPI, no licensing) drive the story.
+- **Cons**: two parallel workflow paths to maintain; user mental-model
+  split right when we unified it with lite-by-default.
+
+| Option | First-class peer? | EPR risk | Existing analyses touched? |
+|---|---|---|---|
+| A | ✅ full | 🔴 | 🟢 no |
+| B | ✅ full + future-proof | 🔴 | 🔴 yes (mature code) |
+| C | 🟡 partial | ✅ skipped | 🟢 no |
+| D | 🟡 augments not peers | 🟡 separable | 🟢 no |
+
+---
+
+## 5. Working preference (tentative, subject to the SQDMetal conversation)
+
+If we end up building, our current best-guess shape would be:
+**Architecture: Option A. Coordination: co-developed with SQDMetal from
+week 1, whatever "co-developed" ends up meaning to them.**
+
+But the entire plan below is contingent on the
+[SQDMetal coordination conversation](./sqdmetal_coordination_issue_draft.md)
+landing in a way that makes sense for both sides. Any of these are
+acceptable outcomes:
+
+- They prefer **option 1** (we just promote SQDMetal from our docs) →
+  the phased plan below collapses to "update some docs"; we ship no
+  Palace renderer of our own. Smallest possible footprint and
+  arguably the right answer.
+- They prefer **option 2** (shared `quantum-metal-palace` package) →
+  phasing below largely applies but lives in a separate repo we
+  co-own.
+- They prefer **option 3** (upstream their PALACE module into Metal) →
+  the plan below is what it looks like.
+- They prefer **no formal coordination** → we re-evaluate. We do not
+  fork without their blessing.
+
+Coordinate first; phase second.
+
+### Phase 0 — coordination (calendar 2–4 weeks; engineering ~3 days)
+
+Open the conversation with SQDLab. Share this doc. Propose three
+coordination shapes and let them pick:
+
+1. **Co-maintained module upstreamed into Metal** as `renderer_palace/`,
+   with SQDLab as `CODEOWNERS`. Cleanest packaging (Metal's pyproject is
+   not circularly self-dependent, supports 3.10–3.12, doesn't require
+   COMSOL).
+2. **Shared `quantum-metal-palace` package** that both projects consume.
+   They publish; both depend.
+3. **Status quo** — they keep SQDMetal/PALACE; Metal vendors with
+   attribution if needed. Last resort.
+
+Calendar dominated by their response cycle; engineering is small (read
+their code, write a coordination proposal, exchange a few rounds). **Do
+this before cutting Phase 1 code.**
+
+### Phase 1 — capacitance + eigenmode-freq (4–8 weeks)
+
+Ship the renderer skeleton covering services #1 and #2 (cap matrix +
+eigenmode freqs+Q). Wire through `LOManalysis` and the freq half of
+`EigenmodeSim`. Cross-validate (see "Validation" below).
+
+This is Option C's scope — covers the LOM tutorial workflow. Ship as
+v0.8.x preview with `[palace]` extra, labeled experimental.
+
+Estimate range reflects:
+- Best case 4w: SQDMetal co-developing, their module ports cleanly.
+- Worst case 8w: more refactoring of their meshing pipeline to align
+  with our `QGmshRenderer`, coordination latency.
+
+### Phase 2 — EPR (4–8 weeks)
+
+Port SQDMetal's field-integration to `renderer_palace/` (approach (b);
+keep pyEPR unchanged). Wire through `EPRanalysis`. Validate.
+
+Estimate range:
+- Best case 4w: their EPR code is correct and ports easily.
+- Worst case 8w: cross-validation fails first attempt, need to dig into
+  field-integration math (real risk).
+
+If we miss the validation gate, Phase 2 slips and v0.8.x ships Phase 1
+scope only.
+
+### Phase 3 — S-parameters (3–4 weeks; can slip to v0.9)
+
+`Driven` solver + port tagging + `ScatteringImpedanceSim` integration.
+Lowest priority of the four services in tutorials today.
+
+### Phase 4 — Docker image (4–6 weeks calendar; can run concurrent with Phase 2+)
+
+`quay.io/qdc/quantum-metal-palace:VERSION` bundling Quantum Metal lite +
+Palace (built) + gmsh + Jupyter. **This is the actual user-adoption
+unlock** — Palace's C++ build (CMake / MPI / MFEM / libCEED) is what
+keeps newcomers out, not the renderer code.
+
+Estimate accounts for: base-image choice, MFEM + libCEED build pinning,
+keeping it under ~2 GB, joint testing, ongoing maintenance for each
+Palace release. **Realistic minimum 4w, not "1 week concurrent".**
+Propose joint ownership with SQDLab; both projects' users benefit.
+
+### Phase 5 — tutorial migration (1–2 weeks)
+
+Migrate **one** Section-4 tutorial (4.02 Eigenmode + EPR) to use Palace
+as the primary path; keep an HFSS variant labeled "for AEDT users".
+**Don't migrate every tutorial** — let users self-select. We'll learn
+what to convert next based on which existing Ansys tutorials get the
+most JupyterLite hits and issue reports.
+
+### Honest total
+
+**12–28 weeks** of engineering, **with SQDMetal co-development**, **for
+the v1 first-class-peer story**. Add coordination calendar (2–4w upfront,
+ongoing review latency). HFSS path stays in place throughout.
+
+If we go alone (no SQDMetal coordination), estimates roughly double on
+Phases 1 and 2.
+
+### Validation — what counts as "it works"
+
+Not one design. Three:
+
+| Design | Source | What we measure |
+|---|---|---|
+| **Simple**: `TransmonPocket` default options | `tutorials/1 Overview/1.2` | cap matrix elements, single-mode freq, Q |
+| **Medium**: transmon + CPW readout resonator coupled | `tutorials/4 Analysis/4.02` | 2-mode freqs, EPR matrix, χ |
+| **Complex**: 4-qubit ring chip | `tutorials/2.../C.../2.21 Design a 4 qubit full chip` | 8+ modes, EPR cross-coupling |
+
+For each, **document the HFSS reference result** (mesh settings, solve
+settings, version) so the comparison is reproducible. Without a documented
+HFSS reference, the comparison is meaningless.
+
+**Release gates** (Palace vs HFSS, on each of the three designs):
+
+| Quantity | Target | What "fail" means |
+|---|---|---|
+| Eigenmode frequencies | ±2% | Either a real physics gap or a port/boundary mismodel — dig in. |
+| Capacitance matrix elements | ±5% | Mesh-convergence issue most likely; bump mesh and re-test. |
+| Q values | ±20% | Loss-model differences expected; document, accept if explainable. |
+| EPR participation ratios | ±10% on dominant element; ±25% on sub-dominant | Sub-dominant slop tolerable; if dominant fails, EPR ships v0.8.x |
+
+Failure mode for v0.8.0 release:
+- If Phase 1 designs all pass → ship Phase 1.
+- If Phase 2 EPR fails on the Complex design only → ship Phase 2 anyway,
+  document the gap, file follow-up for v0.8.x.
+- If Phase 2 EPR fails on Simple or Medium → Phase 2 slips out of v0.8.0
+  entirely; ship Phase 1 alone, EPR comes later.
+
+---
+
+## 6. What this still doesn't solve
+
+1. **Palace build pain** — Phase 4 Docker image, but users wanting to
+   build from source still have a C++ problem.
+2. **EPR correctness** — release gate is concrete but still a real risk.
+3. **AEDT GUI workflow** — gone. Inherent Palace limitation.
+4. **HFSS edge cases** — flip-chip / TSV / airbridge designs likely
+   work better in HFSS for the foreseeable future. We document this; we
+   don't try to fix it in v1.
+5. **Resource constraint** — 12–28 engineering weeks assumes someone is
+   doing them. Today that's Metal maintainer(s) + SQDLab contributors +
+   community. **If the people aren't there, calendar stretches further.**
+   Real assumption to validate before kickoff.
+6. **License check on Palace itself** — AWS Palace is Apache 2.0
+   (verified). Same for SQDMetal. Same for Quantum Metal. No compatibility
+   issues.
+7. **Long-term maintenance** — Palace ships new releases; JSON schema
+   evolves. We pin to a tested version and bump deliberately. Tracking
+   cost is real, ~2–4 weeks per Palace major bump.
+
+---
+
+## 7. What needs to happen next (no decision in this doc)
+
+This doc doesn't decide anything. Two questions to answer next, in this
+order:
+
+**Step 1 — open the SQDMetal conversation.** Send the issue draft at
+[`sqdmetal_coordination_issue_draft.md`](./sqdmetal_coordination_issue_draft.md)
+to the SQDLab team. Their answer drives everything else.
+
+**Step 2 — depending on their answer, then we pick from these:**
+
+Architecture (only matters if we end up building):
+
+- Option A with phased delivery — our tentative preference if we build
+- Option C (capacitance + eigenmode-freq only, no EPR for v1) — if EPR cross-validation risk is the dealbreaker
+- Option B (strategy pattern first, defer Palace 3–4 months) — if we'd rather invest in the long-term shape
+- Option D (workflow-first parallel, not full peer)
+
+Coordination shape (depends entirely on SQDMetal's preference):
+
+- Option 1 from the SQDMetal issue (we just promote them from our docs, no code coupling)
+- Option 2 (shared `quantum-metal-palace` package)
+- Option 3 (upstream their PALACE module into Metal)
+- No formal coordination (we re-evaluate; don't fork without their blessing)
+
+**Suggested cadence:**
+
+- Day 1: send the SQDMetal issue.
+- Days 2–14: their response window. No internal Phase-1 work yet — we don't want to walk into the conversation with code that presumes an answer.
+- Week 3+: based on their response, pick the architecture + coordination combination from above; start whatever shape of work it implies (which may be "very little").
+
+If they're slow or unresponsive: re-ping after 2 weeks. If still silence after another week, we re-think — most likely landing on option 1 (just promote them from our docs) since starting our own integration without their blessing would be poor community practice.

--- a/_dev/sqdmetal_coordination_issue_draft.md
+++ b/_dev/sqdmetal_coordination_issue_draft.md
@@ -1,0 +1,107 @@
+# Draft GitHub issue for sqdlab/SQDMetal
+
+**Where to file**: <https://github.com/sqdlab/SQDMetal/issues/new>
+**Status**: DRAFT — not filed. Local scratch in `_dev/`.
+**Read time**: ~2 min.
+
+---
+
+## Title
+
+Ideation / open thinking: how (if at all) might Quantum Metal and SQDMetal coordinate on Palace?
+
+## Labels (suggested)
+
+`discussion` · `question`
+
+## Body (copy-paste ready — no blockquote markers)
+
+---
+
+Hi SQDLab team — friendly hello from the Quantum Metal / QDC maintainers 👋
+
+This is more "thinking out loud" than a concrete ask. We've been brainstorming how Quantum Metal might offer a first-class Palace path one day, and pretty quickly landed on "the obvious starting point is to talk to the people who've already done this well." Hence this issue — we'd love your take while everything's still ideas, rather than show up with a half-built thing later.
+
+### What we're noodling on
+
+The idea of making AWS Palace a first-class peer to HFSS/Q3D inside Quantum Metal — not replacing Ansys (existing users would keep working) but giving academic users and AI-orchestration workflows a real no-AEDT option for eigenmode + capacitance + EPR + S-parameter analyses.
+
+Nothing decided. Just an idea we've been kicking around and wanted to think through with you before going further.
+
+### Why we wanted to talk to you first
+
+[`SQDMetal/PALACE/`](https://github.com/sqdlab/SQDMetal/tree/main/SQDMetal/PALACE) already covers all four of those services end-to-end, accepts Quantum Metal `QDesign` objects directly, and is more actively maintained than Quantum Metal is right now. The work is real and the math is already there — it would feel silly to reimplement it in parallel when the community win is to coordinate (in some form, or none at all if that's what fits best).
+
+(For full honesty: we've also seen [pypalace](https://pypalace.readthedocs.io/) on the radar — Northwestern's newer Python toolkit for AWS Palace that also supports gmsh export from Quantum Metal layouts. We don't know how (or if) it intersects with your work and we'd value your read. We're reaching out to SQDMetal first because of the maturity and `QDesign`-direct integration, not as an exclusive offer.)
+
+### One thing we noticed while reading around
+
+Currently SQDMetal's `pyproject.toml` has three properties that make "Quantum Metal pip-depends on SQDMetal" structurally tricky:
+
+1. SQDMetal lists `quantum-metal` in `install_requires` → circular dep.
+2. `requires-python = ">=3.11,<3.12"` → Quantum Metal supports 3.10–3.12.
+3. `mph` (COMSOL bindings) is a hard dep → would forcibly pull COMSOL onto every Quantum Metal user installing `[palace]`.
+
+Not at all a criticism — these all make sense for your existing user base (SQDMetal-installs-Quantum-Metal is the natural direction, and the Python pin / COMSOL coupling presumably reflects what your users actually run). It's just context for whichever direction this conversation goes.
+
+### A few coordination shapes we've been kicking around
+
+Sketching these less as a proposal and more as "here's the spectrum we see — does any of these (or some fourth thing we haven't thought of) fit how you'd want this to work?"
+
+1. **Promote SQDMetal as the canonical Palace path** from Quantum Metal docs (no code coupling). Lowest coordination cost; keeps SQDMetal fully independent. Trade-off: users running `pip install quantum-metal[palace]` wouldn't get Palace from us — they'd switch libraries mentally. Lightweight and friendly; might honestly be the right answer.
+
+2. **Spin out a shared `quantum-metal-palace` package** that both projects consume. Independent versioning, distributed governance. Quantum Metal maintainers can help with extracting / packaging / publishing if you'd like — happy to do the grunt work.
+
+3. **Upstream the SQDMetal/PALACE module to Quantum Metal** as `renderer_palace/`, with SQDLab folks as `CODEOWNERS`. The COMSOL bits stay in SQDMetal; the Palace path lives in Quantum Metal where the packaging is cleaner. Quantum Metal maintainers would happily drive most of the merge / migration work (history preservation, refactor to fit our `QRendererAnalysis` protocol, CI integration) so this wouldn't become a workload on you. Sidesteps the three packaging notes above because Quantum Metal's `pyproject.toml` is the one in control.
+
+### A few things we're curious about
+
+- Does any of those resonate (or actively not resonate) from your side?
+- Are there constraints (funding, IP, lab affiliation, planned features we don't know about) that shape what's feasible or desirable?
+- Are there pain points we could help solve as part of this — e.g. shared CI for the Palace path, joint Docker-image ownership for the "Palace + gmsh + Jupyter" runtime, unified geometry processing on top of Quantum Metal's `qgeometry`?
+- Is "no formal coordination, we each keep doing our thing" actually the answer? Genuinely fine if so.
+
+### What Quantum Metal could bring to whichever shape we land on
+
+CI matrix (3.10/3.11/3.12 × ubuntu/macos/windows), docs site, PyPI distribution, JupyterLite tutorials, the QDC community network (Discord, QDW conference). Plus maintainer time on the merge / migration / refactoring work itself if shape 2 or 3 ends up interesting — we wouldn't want this to land as extra workload on you. For shapes 2 and 3, CODEOWNERS / governance would keep SQDLab in the driver's seat for the Palace module.
+
+### No urgency at all
+
+We'd rather take 6 weeks and land it well than rush — or take longer, or land it nowhere if that's the right outcome. Happy to:
+
+- Continue async in this thread
+- **Discuss at [QDW 2026](https://qdw-ucla.squarespace.com/) if and how this makes sense** — would be lovely to think this through in person if any of you are attending
+
+Background reading (once it lands publicly): the fuller scoping analysis at [`_dev/palace_replaces_ansys.md`](https://github.com/qiskit-community/qiskit-metal/blob/main/_dev/palace_replaces_ansys.md) in Quantum Metal. To be clear, that doc is internal Metal-side thinking — it contains a "tentative working preference" so the conversation has something concrete to push back on, but nothing in it is decided. The architecture phasing only applies *if* we end up building, and the shape depends on what works for you.
+
+Looking forward to hearing whatever shape (or non-shape!) feels right to you.
+
+Cheers,
+the Quantum Metal / QDC maintainers
+
+---
+
+## If they say...
+
+| Response | Our move |
+|---|---|
+| "Option 1 — just promote SQDMetal from your docs" | Update Quantum Metal docs to point at SQDMetal as the recommended Palace path. No code coupling. Keep SQDMetal links prominent in our install / headless / migration docs. |
+| "Option 2 — shared `quantum-metal-palace` package" | Joint kickoff. Quantum Metal maintainers help extract / package / publish so it doesn't fall on SQDLab. Agree on package name, owner repo, governance, release cadence. Both projects depend on it. |
+| "Option 3 — upstream into Quantum Metal" | Open a coordinated PR. Quantum Metal maintainers drive the merge / migration / refactor work; SQDLab folks become `CODEOWNERS` for `renderer_palace/`. Migrate module with attribution and full git history. |
+| "We need time / let us think" | Don't push. Start Phase 1 in our scoping doc against SQDMetal/PALACE as a reference (Apache 2.0 lets us read & learn) with explicit attribution. Re-engage when they're ready. |
+| (No response in 2 weeks) | Re-ping once. Two more weeks of silence → proceed with option 1 ("promote from docs, attribute, link") and document we tried. Door stays open. |
+| "We have concerns about [X]" | Listen first. Don't ship anything that touches their work until they're comfortable. |
+| "Let's chat at QDW" | Great — bring the SCOPING doc + this draft, hash it out in person. |
+
+---
+
+## What this draft deliberately does NOT do
+
+- Demand a response on any timeline.
+- Pitch Quantum Metal as the "real" home for Palace integration.
+- Critique their packaging choices — only describe the constraints
+  factually and note they're presumably reasonable for their user base.
+- Assume option 1 (upstream) is what they'll pick. All three are real
+  offers.
+- Mention v0.8.0 release deadlines (don't put their work on our calendar).
+- Hide the AI-orchestration framing — we're honest about why we care.

--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -1,0 +1,165 @@
+.. _ecosystem:
+
+The Quantum Metal Ecosystem
+###########################
+
+Quantum Metal is the **open-source chip-design layer** for superconducting
+quantum hardware. A growing community of tools builds on top of it,
+extends it with new simulation backends, and plugs into it for
+quantization, visualization, and parameter discovery.
+
+This page maps that ecosystem so you can find the right tool for what
+you're trying to do — and so we can highlight the projects that already
+choose Quantum Metal as their substrate.
+
+If you maintain a project we should list here, please
+`open an issue <https://github.com/qiskit-community/qiskit-metal/issues/new/choose>`_
+or ping us on `Discord <https://discord.gg/kaZ3UFuq>`_.
+
+
+Built on Quantum Metal
+======================
+
+These projects use Quantum Metal directly — they consume ``QDesign``
+objects, extend the ``QComponent`` library, or treat Metal as their
+foundation:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 56 18
+
+   * - Project
+     - What it does
+     - License
+   * - `SQuADDS <https://github.com/LFL-Lab/SQuADDS>`_
+       (LFL-Lab @ USC)
+     - Validated qubit-design database + physics-based parameter interpolation. Search the DB, interpolate to your target Hamiltonian, generate the design in Quantum Metal. Published in *Quantum* journal (Sept 2024). Includes an MCP server for AI agents.
+     - MIT
+   * - `SQDMetal <https://github.com/sqdlab/SQDMetal>`_
+       (SQDLab @ UQ)
+     - Simulation wrapper for ``QDesign`` → AWS Palace / COMSOL workflows. Covers eigenmode, capacitance, driven, inductance simulations end-to-end. Accepts Quantum Metal ``QDesign`` objects directly.
+     - Apache 2.0
+   * - `ML_qubit_design <https://github.com/CosmiQuantum/ML_qubit_design>`_
+       (Fermilab + Northwestern)
+     - ML-based inverse design — predicts Quantum Metal design parameters from target qubit, resonator, coupler, and Hamiltonian properties using multi-layer perceptrons. Notebook-driven research project.
+     - see repo
+   * - `pypalace <https://pypalace.readthedocs.io/>`_
+       (Northwestern)
+     - Python toolkit for AWS Palace with Quantum Metal gmsh export, JSON config builders, LOM analysis utilities.
+     - see repo
+
+**This list grows with the community.** If you're building on Quantum
+Metal in a research project, an internal tool, or a startup, we'd
+genuinely love to know — open an issue and we'll add you.
+
+
+Solvers Quantum Metal integrates with
+=====================================
+
+These are the simulation backends Quantum Metal drives via its renderer
+protocol. Each is its own project; we wrap, we don't fork.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 56 18
+
+   * - Solver
+     - Role
+     - Integrated via
+   * - `AWS Palace <https://github.com/awslabs/palace>`_
+       (AWS Center for Quantum Computing)
+     - Maxwell solver — eigenmode + driven + electrostatic + magnetostatic + AMR. Apache 2.0.
+     - Roadmap (see `ROADMAP.md <https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_)
+   * - `Ansys HFSS / Q3D <https://www.ansys.com/products/electronics/ansys-hfss>`_
+     - Industrial-grade EM solvers. Closed-source, requires AEDT license.
+     - ``[ansys]`` extra → `pyaedt <https://github.com/ansys/pyaedt>`_
+   * - `Elmer FEM <https://www.elmerfem.org/>`_
+     - Open-source FEM solver. Today: capacitance for LOM analysis.
+     - ``[mesh]`` extra (gmsh + Elmer external binary)
+   * - `gmsh <https://gmsh.info/>`_
+     - Workhorse mesh generator (used by Elmer today, Palace tomorrow).
+     - ``[mesh]`` extra
+
+
+Quantization & analysis libraries
+=================================
+
+After simulation produces fields / S-parameters / capacitance, these
+libraries turn the results into qubit physics:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 56 18
+
+   * - Library
+     - Role
+     - Integration
+   * - `pyEPR-quantum <https://github.com/zlatko-minev/pyEPR>`_
+     - Energy-Participation-Ratio quantization from HFSS field data. The math we use to turn eigenmodes into Hamiltonians.
+     - ``[ansys]`` extra
+   * - `scqubits <https://github.com/scqubits/scqubits>`_
+     - Closed-form qubit-spectra and circuit-Hamiltonian library.
+     - Base deps
+   * - `QuTiP <https://github.com/qutip/qutip>`_
+     - Quantum dynamics — time evolution, master equations, etc.
+     - Base deps
+   * - `CircuitQ <https://github.com/PhilippAumann/CircuitQ>`_
+     - Quantization of arbitrary superconducting circuits.
+     - Aware, not yet integrated
+
+
+Visualization
+=============
+
+For viewing simulation outputs (Palace / Elmer field data, mesh files):
+
+- `PyVista <https://github.com/pyvista/pyvista>`_ — Python ParaView wrapper, MIT.
+- `ParaView <https://www.paraview.org/>`_ — the underlying renderer, BSD.
+
+The ``[mesh]`` extra and Palace renderers emit ``.vtu`` / ``.pvtu``
+files these tools open natively.
+
+
+How the layers fit together
+===========================
+
+A typical workflow walks through several of these projects:
+
+1. **Discover** a candidate design via SQuADDS (search the DB,
+   interpolate to your target parameters) — or hand-design from scratch
+   using Quantum Metal's ``QComponent`` library.
+2. **Build** the ``QDesign`` in Quantum Metal — instantiate
+   ``QComponents``, place + route, set options.
+3. **Simulate** via the renderer of your choice — Ansys via ``[ansys]``,
+   open-FEM via ``[mesh]`` + Elmer, or AWS Palace via SQDMetal /
+   pypalace (coordination underway — see `ROADMAP.md
+   <https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_).
+4. **Analyse** — EPR (``pyEPR``), LOM (``LOManalysis``), spectra
+   (``scqubits``), dynamics (``QuTiP``).
+5. **Export** to GDS via the built-in ``QGDSRenderer``; view in KLayout
+   or hand off to fab.
+
+Some users also close the loop with **ML inverse design** —
+``ML_qubit_design`` trains on Quantum Metal simulation data to predict
+``QDesign`` parameters from target qubit properties, enabling fast
+parameter exploration without running full EM simulations.
+
+
+Why we ecosystem-map instead of building it all
+================================================
+
+Quantum Metal's job is to be the best chip-design layer it can be —
+``QComponent`` library, renderer protocol, headless ``qm.view()``, GDS
+export, the lite-by-default install. We're explicitly **not** the right
+place to reimplement a Maxwell solver, a qubit-design database, an ML
+inverse-design framework, or a photonic-FEM library. Other projects do
+those well.
+
+The community wins when these projects coordinate at the edges — shared
+``QDesign`` formats, compatible meshing conventions, mutual docs links —
+rather than competing for the same maintainer-hours.
+
+If you want to help shape that coordination, see the
+**Adoption / DevRel section** in `ROADMAP.md
+<https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_
+or reach out on `Discord <https://discord.gg/kaZ3UFuq>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,6 +180,13 @@ in a simple, open, community-driven framework.
     Videos & Education<videoseducation>
 
 .. toctree::
+    :maxdepth: 1
+    :caption: Ecosystem
+    :hidden:
+
+    Built on / with Quantum Metal<ecosystem>
+
+.. toctree::
     :maxdepth: 2
     :caption: Concepts
     :hidden:


### PR DESCRIPTION
Two commits on this branch, jointly shaping the post-v0.7.1 community direction:

## 1. Palace coordination scoping + ecosystem map (8370eb91f)

**Internal scoping (`_dev/`, scratch):**
- `palace_replaces_ansys.md` — architecture analysis for making AWS Palace a first-class peer to HFSS/Q3D. Explicitly framed as contingent on the SQDMetal conversation; honest about effort ranges (12–28 engineering weeks) and validation gates (±2% freq, ±5% C-matrix, ±20% Q, ±10/25% EPR on 3 designs).
- `sqdmetal_coordination_issue_draft.md` — ideation-style draft GitHub issue for sqdlab/SQDMetal opening coordination. Three shapes offered (promote-from-docs / shared package / upstream); explicit invitation for "no formal coordination" as a valid answer. Acknowledges pypalace exists.
- `ecosystem_landscape.md` — internal map with honest reads, "did we miss any popular repos" coverage, "NOT in the doc" section explaining why gdsfactory / femwell / KQCircuits / commercial tools aren't listed.

**User-facing docs:**
- `docs/ecosystem.rst` — new doc, promoted to its own top-level toctree caption "Ecosystem" (between Tutorials and Concepts). Lead section is **Built on Quantum Metal** (SQuADDS, SQDMetal, ML_qubit_design, pypalace) — the platform-play angle. KQCircuits / gdsfactory / femwell deliberately not listed.
- `README.md` 🌐 Ecosystem section restructured to match.
- `ROADMAP.md` Vision section repositioned with ecosystem callout.

## 2. Group/lab adoption pathway + downstream rollout (d6183b4ad)

(Parallel session's commit — substantive roadmap expansion.)

- New **"Group and lab adoption pathway"** section targeting research-group / university-lab / multi-PI adopters (distinct from individual-user DevRel). Organised by effort: ship `.lyp` layer file + Metal→KLayout how-to + "Built for AI agents" framing (low); monthly release cadence + SC-basics DRC deck + "When to use Metal" page (medium); reference PDK + hosted web viewer (high).
- New **"Downstream ecosystem rollout"** section tracking post-lite-flip coordination work — SQuADDS, SQDMetal, pypalace as planned issues; pyEPR + QDW26-workshop as shipped. Per-issue template; qdw26-workshop PR #1 as canonical worked example.
- **Plugin discovery via entry points** promoted from `[research]` to `[planned, v0.8.x]` — load-bearing for PDK pluggability.
- Two new architectural research items: functional `@qm.cell` decorator (LLM-friendly codegen) and JAX-differentiable parametric components (inverse design + Hamiltonian-aware optimisation).
- Softens two pre-existing Adoption items to community-visibility framing.

## What this PR does NOT do

- Doesn't commit Metal to building a Palace renderer (scoping only).
- Doesn't file the SQDMetal issue (draft only).
- Doesn't change any user-facing code or existing renderers / analyses.

## What this PR DOES do

- Lands the scoping + ecosystem framing publicly so the SQDMetal outreach (and other coordination conversations) can reference stable URLs.
- Updates user-facing docs and README to position Metal as the chip-design platform with a visible ecosystem.
- Captures the group/lab adoption pathway as roadmap commitments / aspirations.

## Test plan

- [x] `tox -e docs` exits 0 (verified locally)
- [x] Pre-commit + pre-push hooks both green
- [x] No changes to source code; CI matrix should be no-op or near-it
- [ ] CI green across the full matrix
- [ ] Docs deploy preview shows the new Ecosystem section

🤖 Generated with [Claude Code](https://claude.com/claude-code)