### PR TITLE
Fix two undefined-name regressions in analyses/ (closes #1101)

### DIFF
--- a/src/qiskit_metal/analyses/simulation/eigenmode.py
+++ b/src/qiskit_metal/analyses/simulation/eigenmode.py
@@ -222,6 +222,19 @@ class EigenmodeSim(QSimulation):
             _display (bool, optional): Display the plot? Defaults to True.
         """
 
+        # Imported lazily (at the use-site) so ``import qiskit_metal`` and the
+        # Qt-free path stay pyEPR-free; see the lite-flip in commit 9b8f502.
+        # These four helpers were dropped from the module-level imports there
+        # on the mistaken assumption they had no in-file uses -- they are
+        # called below, so a non-lazy removal turned this method into a
+        # ``NameError``. Keep the import here, not at module top.
+        from pyEPR.reports import (
+            plot_convergence_f_vspass,
+            plot_convergence_max_df,
+            plot_convergence_maxdf_vs_sol,
+            plot_convergence_solved_elem,
+        )
+
         if convergence_t is None:
             convergence_t = self.convergence_t
         if convergence_f is None:

--- a/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
+++ b/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
@@ -13,7 +13,7 @@
 # that they have been altered from the originals.
 """Sweep a qcomponent option, and get results of analysis."""
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 import pandas as pd
 
 from qiskit_metal import Dict

--- a/tests/test_analyses_1_inst_options.py
+++ b/tests/test_analyses_1_inst_options.py
@@ -25,6 +25,7 @@ from qiskit_metal.analyses.simulation.lumped_elements import LumpedElementsSim
 from qiskit_metal.analyses.simulation.eigenmode import EigenmodeSim
 from qiskit_metal.analyses.simulation.scattering_impedance import ScatteringImpedanceSim
 from qiskit_metal.analyses.hamiltonian.transmon_charge_basis import Hcpb
+from qiskit_metal.analyses.sweep_and_optimize.sweeping import Sweeping
 
 from .assertions import AssertionsMixin
 from qiskit_metal import designs
@@ -42,6 +43,16 @@ class TestAnalyses(unittest.TestCase, AssertionsMixin):
     def tearDown(self):
         """Tie any loose ends."""
         pass
+
+    def test_analyses_sweeping_importable(self):
+        """Regression guard: sweeping.py used an unquoted ``Union`` return
+        annotation without importing it, so ``class Sweeping`` raised
+        ``NameError`` at definition time and the whole module was
+        unimportable (nothing imported it, so CI never noticed). The
+        top-level import above already fails the suite if it regresses;
+        this asserts the class and the previously-affected method survive."""
+        self.assertTrue(callable(Sweeping))
+        self.assertTrue(hasattr(Sweeping, "_extract_min_passes"))
 
     def test_analyses_instantiate_hcpb(self):
         """Test instantiation of Hcpb in analytic_transmon.py."""

--- a/tests/test_pyepr_integration.py
+++ b/tests/test_pyepr_integration.py
@@ -231,5 +231,52 @@ class TestMetalParseWrapper(unittest.TestCase, AssertionsMixin):
         self.assertAlmostEqualRel(unparse_units(meters), 1.0, rel_tol=1e-12)
 
 
+class TestEigenmodeConvergencePlotHelpers(unittest.TestCase, AssertionsMixin):
+    """`analyses/simulation/eigenmode.py::plot_convergences` calls four
+    helpers from ``pyEPR.reports``. Regression guard for #1101: the lite-flip
+    (commit 9b8f502) removed the module-level import on the mistaken belief
+    they were unused, turning ``plot_convergences`` into a ``NameError``. The
+    import was restored lazily inside the method; these tests fail loudly if
+    either pyEPR relocates the helpers or the in-file import is dropped again."""
+
+    HELPERS = (
+        "plot_convergence_f_vspass",
+        "plot_convergence_max_df",
+        "plot_convergence_maxdf_vs_sol",
+        "plot_convergence_solved_elem",
+    )
+
+    def test_pyepr_reports_exposes_helpers(self):
+        """The four convergence-plot helpers must remain in pyEPR.reports."""
+        import pyEPR.reports as reports
+
+        for name in self.HELPERS:
+            self.assertTrue(
+                callable(getattr(reports, name, None)),
+                f"pyEPR.reports no longer exposes {name}",
+            )
+
+    def test_plot_convergences_runs_without_nameerror(self):
+        """End-to-end guard: plot_convergences must resolve its helpers
+        (the actual #1101 symptom was a NameError at the first helper call)."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import pandas as pd
+
+        from qiskit_metal import designs
+        from qiskit_metal.analyses.quantization import EPRanalysis
+
+        sim = EPRanalysis(designs.DesignPlanar(), "hfss").sim
+        # Minimal frames matching the iloc[:, 0] / iloc[:, 1] access pattern.
+        sim.convergence_t = pd.DataFrame(
+            {"Solved Elements": [100, 200, 300], "Max Delta Freq. %": [5.0, 1.0, 0.2]},
+            index=[1, 2, 3],
+        )
+        sim.convergence_f = pd.DataFrame({"re(Mode(1))": [5.10, 5.05, 5.04]})
+        # Must not raise NameError; returns a matplotlib Figure.
+        sim.plot_convergences(_display=False)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #1101, and fixes a second, related crash found while sweeping for more of the same.

Both are the same class of bug: a name used in code but never imported, which only blows up at call-time / definition-time — so CI (which has no Ansys license and didn't import the affected paths) never caught them.

## 1. `EigenmodeSim.plot_convergences` → `NameError` (#1101)

`eig_qb.sim.plot_convergences()` raised `NameError: name 'plot_convergence_f_vspass' is not defined` (+ three sibling helpers). Anyone following tutorial *4.02 Eigenmode and EPR analysis* hit it.

**Cause:** the lite-flip (commit `9b8f502`) removed `from pyEPR.reports import (...)` from `eigenmode.py` with the note *"the four imported plot helpers had no in-file uses"* — but they're called inside `plot_convergences()` (lines 238–241). The check missed the in-method call sites.

**Fix:** restore the import **lazily at the use-site** inside the method — fixes the crash while keeping `import qiskit_metal` / the Qt-free path pyEPR-free (the same per-method pattern that commit applied to the other `analyses/` files).

## 2. `analyses/sweep_and_optimize/sweeping.py` unimportable → `NameError: Union`

The entire `Sweeping` class was dead: `_extract_min_passes` (line 1236) has an **unquoted** `-> Union[None, float]` return annotation, but the module only imported `Optional, Tuple` from `typing`. With no `from __future__ import annotations`, the annotation is evaluated when `class Sweeping` is defined, so **importing the module raised `NameError: name 'Union' is not defined`.**

It went unnoticed because nothing in the package or test suite imports `sweeping.py` (`analyses/__init__.py` only names it in a docstring) — it only breaks for a user doing `from qiskit_metal.analyses.sweep_and_optimize.sweeping import Sweeping`, which is how the sweep tutorials use it.

**Fix:** add `Union` to the `typing` import (one line).

## How these were found

Repo-wide `ruff check --select F821` (undefined-name) sweep, prompted by #1101. After filtering out quoted forward-reference type hints (harmless — they're strings, never evaluated), the `sweeping.py` `Union` was the **only** other real undefined-name crash in the codebase.

## Tests

- `test_pyepr_integration.py`: the four convergence helpers stay importable from `pyEPR.reports`, and `plot_convergences()` resolves them without `NameError` (runs in `tests-extras-ansys`).
- `test_analyses_1_inst_options.py`: top-level import of `Sweeping` (so the suite fails to collect if the module breaks again) + an explicit class/method check.

## Validation

- No-pyEPR path: `import qiskit_metal` + the eigenmode module still load with pyEPR blocked.
- With pyEPR: `plot_convergences()` runs clean; `Sweeping` imports.
- `test_pyepr_integration.py` (18) and `test_analyses_1_inst_options.py` (14) pass; `ruff format`/`check` clean.

Both are `analyses/` (pure-Python) zones — no renderer-semantics or HFSS-validation concerns.