### PR TITLE
Fix MetalGUI segfault at interpreter exit + add Xvfb GUI CI coverage (#1048)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,6 +315,61 @@ jobs:
             tests/test_solution_types.py \
             -v
 
+  tests-gui-display:
+    # The ONLY job that launches the real Qt MetalGUI on a (virtual) display.
+    # Every other job runs headless (QISKIT_METAL_HEADLESS=1 / qm.view), so the
+    # on-screen Qt path had zero coverage -- which is how the exit segfault in
+    # issue #1048 shipped. Here we install the [gui] extra, give Qt a real X
+    # server via Xvfb, and assert that building MetalGUI and exiting does not
+    # crash (the regression test checks the subprocess return code).
+    name: tests-gui-display
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_COLOR: "1"
+      QT_QPA_PLATFORM: "xcb"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      - name: Install Xvfb + Qt runtime libraries
+        # PySide6's xcb platform plugin needs these system libs to load and
+        # show a window; Xvfb provides the headless X server.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            xvfb \
+            libegl1 libgl1 libglib2.0-0 \
+            libxkbcommon0 libxkbcommon-x11-0 libdbus-1-3 \
+            libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+            libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 \
+            libxcb-shm0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 \
+            libxcb-xkb1 libxcb-glx0 libxcb-util1 \
+            libfontconfig1 libxrender1 libsm6 libice6
+      - name: Install with the GUI extra
+        run: |
+          uv venv --python 3.12
+          uv pip install -e '.[gui]'
+          uv pip install 'pytest>=8.4.1' 'pytest-rich>=0.2.0'
+      - name: Sanity — a raw Qt window shows under Xvfb
+        # If this fails it's the CI environment (missing Qt lib), not metal.
+        run: |
+          xvfb-run -a .venv/bin/python -c "
+          from PySide6.QtWidgets import QApplication, QMainWindow
+          app = QApplication([]); QMainWindow().show()
+          print('OK: raw Qt window shown under Xvfb')
+          "
+      - name: Run GUI tests on a virtual display (issue #1048 regression)
+        # NOTE: deliberately NOT headless — we want the real MetalGUI.
+        run: |
+          xvfb-run -a .venv/bin/python -m pytest \
+            tests/test_gui_basic.py \
+            tests/test_gui_teardown.py \
+            -v
+
   coverage:
     name: coverage
     runs-on: ubuntu-24.04

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 """GUI front-end interface for Quantum Metal, built on PySide6."""
 
+import atexit
 import logging
 import os
 import webbrowser
@@ -20,6 +21,7 @@ from typing import TYPE_CHECKING, List
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QIcon, QPixmap, QAction
 from PySide6.QtWidgets import (
+    QApplication,
     QWidget,
     QDialog,
     QDockWidget,
@@ -71,6 +73,38 @@ if not config.is_building_docs():
 
 if TYPE_CHECKING:
     from ..renderers.renderer_mpl.mpl_canvas import PlotCanvas
+
+
+_TEARDOWN_REGISTERED = False
+"""Module flag: the at-exit Qt teardown is registered only once, the first
+time a :class:`MetalGUI` is created (so headless users never pay for it)."""
+
+
+def _teardown_qt_widgets():
+    """Delete every top-level Qt widget before the interpreter finalizes.
+
+    Fixes the segfault-at-exit reported in issue #1048. PySide6 otherwise
+    destroys the ``QApplication`` during ``Py_FinalizeEx`` while ``MetalGUI``'s
+    window is still alive; a ``QWidget`` destructor then dispatches an event
+    through the main window's ``QMenuBar`` event filter whose target is already
+    half-deleted, jumping to a null vtable entry and killing the process (in a
+    Jupyter kernel this surfaces as "the kernel appears to have died").
+
+    Deleting the widgets here -- while the interpreter and ``QApplication`` are
+    still alive -- destroys them in the correct order. ``deleteLater`` is used
+    rather than ``close()`` so this never triggers the "save unsaved changes?"
+    dialog (which would block forever on a headless machine). The function is
+    idempotent and exception-safe: it is only a best-effort cleanup.
+    """
+    try:
+        app = QApplication.instance()
+        if app is None:
+            return
+        for widget in list(app.topLevelWidgets()):
+            widget.deleteLater()
+        app.processEvents()
+    except Exception:  # pragma: no cover - cleanup must never raise at exit
+        pass
 
 
 class QMainWindowExtension(QMainWindowExtensionBase):
@@ -350,6 +384,14 @@ class MetalGUI(QMainWindowBaseHandler):
         self.qApp = kick_start_qApp()
         if not self.qApp:
             logging.error("Could not start Qt event loop using QApplication.")
+
+        # Register the at-exit Qt teardown once (issue #1048). Done here, on
+        # first GUI construction, so a pure headless / ``qm.view`` user who
+        # never builds a MetalGUI never registers it.
+        global _TEARDOWN_REGISTERED
+        if not _TEARDOWN_REGISTERED:
+            atexit.register(_teardown_qt_widgets)
+            _TEARDOWN_REGISTERED = True
 
         super().__init__()
 

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -75,11 +75,6 @@ if TYPE_CHECKING:
     from ..renderers.renderer_mpl.mpl_canvas import PlotCanvas
 
 
-_TEARDOWN_REGISTERED = False
-"""Module flag: the at-exit Qt teardown is registered only once, the first
-time a :class:`MetalGUI` is created (so headless users never pay for it)."""
-
-
 def _teardown_qt_widgets():
     """Delete every top-level Qt widget before the interpreter finalizes.
 
@@ -385,13 +380,13 @@ class MetalGUI(QMainWindowBaseHandler):
         if not self.qApp:
             logging.error("Could not start Qt event loop using QApplication.")
 
-        # Register the at-exit Qt teardown once (issue #1048). Done here, on
-        # first GUI construction, so a pure headless / ``qm.view`` user who
-        # never builds a MetalGUI never registers it.
-        global _TEARDOWN_REGISTERED
-        if not _TEARDOWN_REGISTERED:
-            atexit.register(_teardown_qt_widgets)
-            _TEARDOWN_REGISTERED = True
+        # Register the at-exit Qt teardown exactly once (issue #1048), no
+        # matter how many MetalGUIs are built. Done lazily here so a pure
+        # headless / ``qm.view`` user who never builds a MetalGUI never
+        # registers it. ``unregister`` is a no-op the first time and keeps
+        # this idempotent across repeated construction.
+        atexit.unregister(_teardown_qt_widgets)
+        atexit.register(_teardown_qt_widgets)
 
         super().__init__()
 

--- a/tests/test_gui_teardown.py
+++ b/tests/test_gui_teardown.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Regression test for the MetalGUI exit segfault (issue #1048).
+
+Building a ``MetalGUI`` and letting the interpreter exit must not crash the
+process. Before the at-exit Qt teardown (``main_window._teardown_qt_widgets``),
+PySide6 destroyed the ``QApplication`` during ``Py_FinalizeEx`` while the
+window was still alive; a ``QWidget`` destructor then dispatched an event
+through the main window's ``QMenuBar`` event filter -> null call -> SIGSEGV
+(exit code 139 / -11). In a Jupyter kernel that surfaced as "the kernel
+appears to have died".
+
+The GUI is launched in a *subprocess* so a regression shows up as a nonzero
+return code instead of taking the test runner down with it. The test needs a
+display (a real desktop or ``Xvfb``); it skips otherwise, and the whole module
+skips when the optional GUI extras (PySide6) are not installed.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+# Minimal reproducer from the issue: build the GUI, then exit.
+_SNIPPET = (
+    "import qiskit_metal as qm\n"
+    "from qiskit_metal import designs, MetalGUI\n"
+    "from qiskit_metal.qlibrary.qubits.transmon_pocket import TransmonPocket\n"
+    "design = designs.DesignPlanar()\n"
+    "gui = MetalGUI(design)\n"
+    "# also exercise a second instance + rebuild (the 're-run' path)\n"
+    "gui2 = MetalGUI(designs.DesignPlanar())\n"
+    "TransmonPocket(design, 'Q1', options=dict(connection_pads=dict(a=dict())))\n"
+    "gui.rebuild()\n"
+    "print('MARKER_BUILT', flush=True)\n"
+)
+
+
+class TestGUITeardown(unittest.TestCase):
+    """Issue #1048 — MetalGUI must not segfault at interpreter exit."""
+
+    def test_metalgui_process_exits_cleanly(self):
+        """A process that builds MetalGUI must exit with code 0, not a
+        segfault (139 / -11)."""
+        if not os.environ.get("DISPLAY"):
+            self.skipTest("no display available (needs Xvfb or a desktop session)")
+
+        proc = subprocess.run(
+            [sys.executable, "-X", "faulthandler", "-c", _SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+
+        self.assertIn(
+            "MARKER_BUILT",
+            proc.stdout,
+            msg=f"GUI failed to build.\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr[-2000:]}",
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=(
+                f"MetalGUI subprocess exited with {proc.returncode} "
+                f"(negative / 139 == segfault, i.e. issue #1048 regression).\n"
+                f"stderr tail:\n{proc.stderr[-2000:]}"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Addresses #1048 (and the duplicate #1103). MetalGUI crashed the process at interpreter shutdown — in a Jupyter kernel this is exactly the *"the kernel appears to have died"* the reporters saw.

## Root cause (native backtrace)

Reproduced on the **current release** (quantum-metal 0.7.3, PySide6 6.11.1, Python 3.12) on a real X server via Xvfb. A raw `QMainWindow().show()` is fine, but `MetalGUI(design)` segfaults at exit. `gdb` backtrace:

```
Py_FinalizeEx
 -> PySide::runCleanupFunctions
 -> PySide::destroyQCoreApplication
 -> QWidget::~QWidget -> QObject::~QObject -> QObjectPrivate::setParent_helper   (sends an event)
 -> QApplication::notify ... -> QMenuBar::eventFilter
 -> 0x0000000000000000   ← call to a null vtable entry  (SIGSEGV)
```

At interpreter finalization PySide6 destroys the `QApplication` **while `MetalGUI`'s window is still alive**. A `QWidget` destructor then reparents children, which dispatches an event through the main window's `QMenuBar` event filter — whose target is already half-deleted — and jumps to null.

> Note on the "tested latest, works fine" report on #1048: that environment's `pip list` showed `quantum-metal 0.5.3.post1`, not the current 0.7.3, so it didn't actually exercise this. It reproduces deterministically on 0.7.3.

## Fix

Register a one-shot `atexit` handler — the first time a `MetalGUI` is constructed, so a headless / `qm.view` user who never builds a GUI never pays for it — that deletes all top-level Qt widgets via `deleteLater()` + `processEvents()` **while the interpreter and `QApplication` are still alive**, so they tear down in the correct order before PySide6's fragile finalize-time path runs.

- `deleteLater()` (not `close()`) is used deliberately: `close()` triggers MetalGUI's "Save unsaved changes?" `QMessageBox`, which blocks forever on a headless machine (I hit this while developing the fix).
- The handler is idempotent and exception-safe (cleanup must never raise at exit).

Verified under Xvfb (xcb) with the `[gui]` extra: a single `MetalGUI`, a **second** instance, and `rebuild()` all now exit `0` (were SIGSEGV / 139).

## Coverage — before and after

This is `_gui` (a hard-touch zone), so coverage was established both ways:

- **`tests/test_gui_teardown.py`** (new): builds `MetalGUI` in a *subprocess* (so a regression shows up as a nonzero return code instead of taking the test runner down) and asserts a clean `0` exit. I confirmed it **fails with `-11` (SIGSEGV) without the fix** and **passes with it**. Skips cleanly when PySide6 or a display is absent.
- **`tests-gui-display`** (new CI job): installs `[gui]` + the Qt runtime libs, gives Qt a real X server via Xvfb, and runs the GUI tests on-screen. **This is the first CI job that launches the actual Qt `MetalGUI` at all** — every existing job runs `QISKIT_METAL_HEADLESS=1` / `qm.view`, which is precisely why this segfault had zero coverage and shipped. (`tests-extras-gui` installs the extra but only smoke-tests `qm.view`.)
- Existing suites unaffected: the change is additive and lazy; `import qiskit_metal` + `qm.view` still work with PySide6 blocked, and the no-Qt suites pass.

## Scope / honesty

This fixes the **reproducible exit/teardown segfault**. Some users also report an on-screen crash at `.show()` on Windows/macOS; I could **not** reproduce that under Xvfb (windows show fine there), so it may be a separate platform-specific issue. I've asked the affected reporters on #1048 for `-X faulthandler` traces to confirm whether it shares this call path. Keeping this PR scoped to what's reproducible and verified.

## Files
- `src/qiskit_metal/_gui/main_window.py` — `_teardown_qt_widgets()` + one-shot `atexit` registration (+42 lines, purely additive).
- `tests/test_gui_teardown.py` — subprocess regression test.
- `.github/workflows/main.yml` — `tests-gui-display` Xvfb job.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk)_