### PR TITLE
gui: Windows MetalGUI init safety + diagnostic switch + on-screen CI repro (#1048 / #1109)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,11 +364,58 @@ jobs:
           "
       - name: Run GUI tests on a virtual display (issue #1048 regression)
         # NOTE: deliberately NOT headless — we want the real MetalGUI.
+        # ``test_gui_init.py`` was added to guard the on-screen
+        # initialization branch of #1048 / #1109; ``test_gui_teardown.py``
+        # already guards the exit segfault PR #1104 fixed.
         run: |
           xvfb-run -a .venv/bin/python -m pytest \
             tests/test_gui_basic.py \
             tests/test_gui_teardown.py \
+            tests/test_gui_init.py \
             -v
+
+  tests-gui-display-windows:
+    # Sibling of tests-gui-display, but on a real Windows runner. The
+    # on-screen MetalGUI init crash that several reporters hit on Windows
+    # 11 (#1109, the still-open branch of #1048) does NOT reproduce under
+    # Linux Xvfb -- we need an actual Windows session to chase it. GHA's
+    # windows-2025 runner has a console session that Qt's ``windows``
+    # platform plugin can attach to without any virtual-display shim.
+    #
+    # ``continue-on-error: true`` keeps this from blocking PRs while the
+    # bug is still being diagnosed -- we want the *signal* (does the
+    # repro fire on the GHA Windows image?) without gating unrelated
+    # work on a hunt that may still be in progress.
+    name: tests-gui-display-windows
+    runs-on: windows-2025
+    continue-on-error: true
+    env:
+      FORCE_COLOR: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      - name: Install with the GUI extra
+        run: |
+          uv venv --python 3.12
+          uv pip install -e ".[gui]"
+          uv pip install "pytest>=8.4.1" "pytest-rich>=0.2.0"
+      - name: Sanity — a raw Qt window shows on the Windows runner
+        # If this fails it's the GHA Windows image (no console session),
+        # not metal. Splits "Qt can't show" from "MetalGUI can't init".
+        run: |
+          .venv\Scripts\python -c "from PySide6.QtWidgets import QApplication, QMainWindow; app = QApplication([]); QMainWindow().show(); print('OK: raw Qt window shown on Windows runner')"
+      - name: Run GUI init + teardown tests on Windows native (issues #1048 / #1109)
+        # Targets the *on-screen* init crash branch of #1048 that PR #1104
+        # could not reproduce under Xvfb. Faulthandler-instrumented; if
+        # the kernel-death symptom fires here, we have a deterministic
+        # reproducer for the first time.
+        run: |
+          .venv\Scripts\python -m pytest tests/test_gui_basic.py tests/test_gui_teardown.py tests/test_gui_init.py -v
 
   coverage:
     name: coverage

--- a/src/qiskit_metal/_gui/_init_trace.py
+++ b/src/qiskit_metal/_gui/_init_trace.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Opt-in init-tracing for MetalGUI (issues #1048 / #1109).
+
+Several reporters see ``MetalGUI.__init__`` silently abort mid-init on
+Windows 11 with no Python traceback. ``QISKIT_METAL_DEBUG_INIT=1`` makes
+each init step print to stderr with an explicit flush, so the last
+printed line identifies the failing call without needing a custom
+branch or screenshare.
+
+Lives in its own module so both ``main_window`` and ``main_window_base``
+can import it without a circular dependency. No Qt or metal imports
+here -- just os + sys -- so this stays usable from anywhere.
+"""
+
+import os
+import sys
+
+
+def trace_init(step: str) -> None:
+    """Print ``step`` to stderr when QISKIT_METAL_DEBUG_INIT is truthy.
+
+    Truthy = any value other than the empty string, ``0``, ``false``,
+    ``no``, or ``off`` (case-insensitive). Always flushes so a
+    subsequent crash doesn't swallow the marker. No-op when unset.
+
+    Args:
+        step: Short label for the init step about to be executed. Free
+            text. Use the function/method name that follows for clarity.
+    """
+    val = os.environ.get("QISKIT_METAL_DEBUG_INIT", "")
+    if not val or val.lower() in ("0", "false", "no", "off"):
+        return
+    print(f"[metal-init] {step}", file=sys.stderr, flush=True)

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -75,6 +75,13 @@ if TYPE_CHECKING:
     from ..renderers.renderer_mpl.mpl_canvas import PlotCanvas
 
 
+# Issues #1048 / #1109: opt-in init-tracing for reporters whose MetalGUI
+# silently aborts mid-init on Windows. When QISKIT_METAL_DEBUG_INIT is
+# set, each init step prints to stderr with an explicit flush -- the
+# last printed line identifies the failing call. No-op when unset.
+from qiskit_metal._gui._init_trace import trace_init as _trace_init
+
+
 def _teardown_qt_widgets():
     """Delete every top-level Qt widget before the interpreter finalizes.
 
@@ -363,19 +370,30 @@ class MetalGUI(QMainWindowBaseHandler):
                 also call ``set_design`` after constructing the GUI. When passed,
                 the GUI will immediately populate docks and the canvas from this
                 design. Defaults to None.
+
+        Diagnostic switch (issues #1048 / #1109):
+            Set ``QISKIT_METAL_DEBUG_INIT=1`` to trace each init step to
+            stderr with explicit flushes. Useful for users seeing the GUI
+            silently abort mid-init on Windows -- the last printed step
+            identifies the failing call without needing a custom branch.
         """
+
+        _trace_init("MetalGUI.__init__ entered")
 
         # Qt backend setup used to run at ``import qiskit_metal`` time;
         # it's now lazy, called the first time MetalGUI is instantiated.
         # Idempotent — second and later calls are no-ops.
         from qiskit_metal import setup_qt_backend
 
+        _trace_init("setup_qt_backend()")
         setup_qt_backend()
 
         from .utility._handle_qt_messages import QtCore, _qt_message_handler
 
+        _trace_init("qInstallMessageHandler")
         QtCore.qInstallMessageHandler(_qt_message_handler)
 
+        _trace_init("kick_start_qApp()")
         self.qApp = kick_start_qApp()
         if not self.qApp:
             logging.error("Could not start Qt event loop using QApplication.")
@@ -388,6 +406,7 @@ class MetalGUI(QMainWindowBaseHandler):
         atexit.unregister(_teardown_qt_widgets)
         atexit.register(_teardown_qt_widgets)
 
+        _trace_init("super().__init__() -> QMainWindowBaseHandler")
         super().__init__()
 
         # use set_design
@@ -397,22 +416,39 @@ class MetalGUI(QMainWindowBaseHandler):
         self.plot_win = None  # type: QMainWindowPlot
         self.elements_win = None  # type: ElementsWindow
         self.net_list_win = None  # type: NetListWindow
+        _trace_init("ComponentWidget()")
         self.component_window = ComponentWidget(self, self.ui.dockComponent)
+        _trace_init("PropertyTableWidget()")
         self.variables_window = PropertyTableWidget(self, gui=self)
 
         self.build_log_window = None
 
+        # All widget construction happens before show(). Calling show()
+        # mid-setup (as earlier code did) left the QMainWindow visible as
+        # bare scaffolding while filesystem-scanning widgets (library,
+        # netlist) dispatched events through partially-constructed docks;
+        # on Windows 11 / Qt 6.11 that path could abort silently, leaving
+        # only Qt's default object-inspector window briefly visible before
+        # the kernel returned (issue #1048).
+        _trace_init("_setup_component_widget")
         self._setup_component_widget()
+        _trace_init("_setup_plot_widget")
         self._setup_plot_widget()
+        _trace_init("_setup_design_components_widget")
         self._setup_design_components_widget()
+        _trace_init("_setup_elements_widget")
         self._setup_elements_widget()
-        self.main_window.show()
+        _trace_init("_setup_variables_widget")
         self._setup_variables_widget()
+        _trace_init("_ui_adjustments_final")
         self._ui_adjustments_final()
+        _trace_init("_setup_library_widget")
         self._setup_library_widget()
+        _trace_init("_setup_net_list_widget")
         self._setup_net_list_widget()
 
-        # Show and raise
+        # Show and raise — single call after all docks are wired.
+        _trace_init("main_window.show()")
         self.main_window.show()
 
         # self.qApp.processEvents(QEventLoop.AllEvents, 1)
@@ -421,9 +457,12 @@ class MetalGUI(QMainWindowBaseHandler):
         QTimer.singleShot(150, self._raise)
 
         if design:
+            _trace_init("set_design(design)")
             self.set_design(design)
         else:
             self._set_enabled_design_widgets(False)
+
+        _trace_init("MetalGUI.__init__ complete")
 
     def _raise(self):
         """Raises the window to the top."""

--- a/src/qiskit_metal/_gui/main_window_base.py
+++ b/src/qiskit_metal/_gui/main_window_base.py
@@ -33,6 +33,7 @@ from PySide6.QtWidgets import (
 from qiskit_metal import config
 from qiskit_metal.toolbox_python._logging import setup_logger
 from qiskit_metal import __version__
+from qiskit_metal._gui._init_trace import trace_init as _trace_init
 from qiskit_metal._gui.utility._handle_qt_messages import slot_catch_error
 from qiskit_metal._gui.widgets.log_widget.log_metal import LogHandler_for_QTextLog
 
@@ -317,26 +318,35 @@ class QMainWindowBaseHandler:
             self.logger.error(text)
 
         # Main Window and App level
+        _trace_init("base: _QMainWindowClass()")
         self.main_window = self._QMainWindowClass()
         self.main_window.handler = self
+        _trace_init("base: _setup_qApp")
         self.qApp = self._setup_qApp()
+        _trace_init("base: _setup_main_window_tray")
         self._setup_main_window_tray()
 
         # Style and window
         self._style_sheet_path = None
+        _trace_init("base: style_window")
         self.style_window()
 
         # UI
+        _trace_init("base: __UI__().setupUi")
         self.ui = self.__UI__()
         self.ui.setupUi(self.main_window)
         self.main_window.ui = self.ui
 
         self.ui.log_text.dock_window = self.ui.dockLog
+        _trace_init("base: _setup_logger")
         self._setup_logger()
+        _trace_init("base: _setup_window_size")
         self._setup_window_size()
 
+        _trace_init("base: _ui_adjustments (subclass)")
         self._ui_adjustments()  # overwrite
 
+        _trace_init("base: restore_window_settings")
         self.main_window.restore_window_settings()
 
     @property
@@ -416,16 +426,31 @@ class QMainWindowBaseHandler:
         return self.qApp
 
     def _setup_main_window_tray(self):
-        """Sets up the main window tray."""
+        """Sets up the main window tray icon.
 
-        if self.path_imgs.is_dir():
-            icon = QIcon(str(self.path_imgs / self._img_logo_name))
-            self.main_window.setWindowIcon(icon)
+        Only attaches a ``QSystemTrayIcon`` when one is actually available
+        per ``QSystemTrayIcon.isSystemTrayAvailable()`` — Qt's docs state
+        that constructing/showing a tray icon without a tray present is
+        undefined behavior, and on Windows 11 with a hidden notification
+        area / VDI / "compact" taskbar that path can abort silently.
+        Task/window icons are always set; only the tray is gated.
+        """
+        if not self.path_imgs.is_dir():
+            return
 
-            # not sure if this works, but let's try
-            self._icon_tray = QtWidgets.QSystemTrayIcon(icon, self.main_window)
-            self._icon_tray.show()
+        icon = QIcon(str(self.path_imgs / self._img_logo_name))
+        self.main_window.setWindowIcon(icon)
+        if self.qApp is not None:
             self.qApp.setWindowIcon(icon)
+
+        if not QtWidgets.QSystemTrayIcon.isSystemTrayAvailable():
+            self.logger.debug(
+                "No system tray available; skipping QSystemTrayIcon setup."
+            )
+            return
+
+        self._icon_tray = QtWidgets.QSystemTrayIcon(icon, self.main_window)
+        self._icon_tray.show()
 
     def create_log_handler(self, name_toshow: str, logger: logging.Logger):
         """Creates a log handler.

--- a/tests/test_gui_init.py
+++ b/tests/test_gui_init.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""On-screen MetalGUI initialization regression (issues #1048 / #1109).
+
+Distinct from ``test_gui_teardown.py`` (which only covers the exit-time
+segfault that PR #1104 / v0.7.4 fixed). This test guards the *init* path:
+multiple reporters on Windows 11 (and at least one on macOS) see
+``MetalGUI(design)`` render the QMainWindow briefly as bare scaffolding
+("variable table / object inspector" per #1109), then either silently
+abandon the GUI or take the kernel down — no Python traceback either way.
+
+The MARKER_INIT_OK assertion catches the silent-abandonment case;
+non-zero return code catches the segfault case. Combined, they fail
+loudly on either failure mode.
+
+Skips when PySide6 is absent (lite install) or when no display is
+available (a desktop session on Windows/macOS, ``$DISPLAY`` or
+``$WAYLAND_DISPLAY`` on Linux).
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+
+def _display_available() -> bool:
+    """True when a usable display is reachable from this process.
+
+    GHA windows-2025 / macos-15 runners and any normal desktop session
+    always have a usable display. Linux needs ``$DISPLAY`` (X11) or
+    ``$WAYLAND_DISPLAY`` (Wayland) -- or ``xvfb-run`` wrapping the
+    invocation.
+    """
+    if sys.platform.startswith("win") or sys.platform == "darwin":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+# Minimal init reproducer from the issue.  Prints MARKER_INIT_OK only if
+# MetalGUI.__init__ actually returned; immediate sys.exit(0) keeps the
+# subprocess scope to "init only" (teardown is test_gui_teardown.py's job).
+_SNIPPET = (
+    "import faulthandler, sys\n"
+    "faulthandler.enable()\n"
+    "from qiskit_metal import designs, MetalGUI\n"
+    "design = designs.DesignPlanar()\n"
+    "gui = MetalGUI(design)\n"
+    "print('MARKER_INIT_OK', flush=True)\n"
+    "sys.exit(0)\n"
+)
+
+
+class TestGUIInitOnScreen(unittest.TestCase):
+    """Issues #1048 / #1109 — MetalGUI.__init__ must complete without
+    hanging or crashing on a real display."""
+
+    def test_metalgui_init_completes(self):
+        """MetalGUI(design) must build cleanly on a real display."""
+        if not _display_available():
+            self.skipTest("no display available (needs desktop session or Xvfb)")
+
+        proc = subprocess.run(
+            [sys.executable, "-X", "faulthandler", "-c", _SNIPPET],
+            capture_output=True,
+            text=True,
+            timeout=240,
+        )
+
+        self.assertIn(
+            "MARKER_INIT_OK",
+            proc.stdout,
+            msg=(
+                f"MetalGUI.__init__ did not complete (wedged or silently "
+                f"abandoned -- issue #1109).\n"
+                f"stdout:\n{proc.stdout}\n"
+                f"stderr tail:\n{proc.stderr[-2000:]}"
+            ),
+        )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=(
+                f"MetalGUI init subprocess exited {proc.returncode} "
+                f"(non-zero / segfault -- issue #1048 init-branch regression).\n"
+                f"stderr tail:\n{proc.stderr[-2000:]}"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Three independent changes that together both reduce the surface area for the still-open Windows on-screen init crash (#1048 second branch / #1109) and give us a deterministic way to find it. PR #1104 / v0.7.4 fixed the **exit-teardown** segfault; this PR targets the **on-screen init** crash that several Windows 11 reporters still hit on 0.7.4.

### 1. Defensive — gate `QSystemTrayIcon` on `isSystemTrayAvailable()`

`main_window_base.py::_setup_main_window_tray` previously constructed and showed a `QSystemTrayIcon` unconditionally. Qt's own docs require checking `QSystemTrayIcon.isSystemTrayAvailable()` first — behavior is **undefined** when no tray is present. On Windows 11 with the notification area hidden, group-policy-restricted, or in VDI / "compact" taskbar configurations, this matches the silent-abort symptom reporters describe almost exactly: the QMainWindow flickers as bare scaffolding, then the kernel returns control with no traceback.

Task/window icons are still set unconditionally; only the tray construction is gated.

### 2. Defensive — stop calling `main_window.show()` mid-setup

`main_window.py::MetalGUI.__init__` showed the QMainWindow after only **four of eight** widget-setup calls, then continued wiring the variables / library / netlist widgets. `QFileSystemModel.setRootPath()` inside `_setup_library_widget` is async and dispatches events during its scan; on Qt 6.11 those events can land on a partially-constructed dock tree. The new order constructs everything first, then does a single `show()` at the end.

Compatible with the existing `tests-gui-display` job (PR #1104) — verified with the new init test under Xvfb.

### 3. Diagnostic — `QISKIT_METAL_DEBUG_INIT=1`

Opt-in init tracing. When the env var is truthy, each step of `MetalGUI.__init__` + `QMainWindowBaseHandler.__init__` prints `[metal-init] <step>` to stderr with an explicit flush. Reporters whose GUI silently aborts can set the env var, re-run their normal script, and paste the last printed line — that's the failing call, no custom branch / screenshare required.

Implementation lives in a tiny new module `_gui/_init_trace.py` (no Qt or metal imports) so both `main_window` and `main_window_base` can use it without a circular import. No-op when the env var is unset, so production users pay zero cost.

## CI / Coverage additions

- **`tests/test_gui_init.py`** — new on-screen init regression test. Distinct from `test_gui_teardown.py` (which only guards the exit segfault). Faulthandler-instrumented, marker-based assertion catches the silent-abandonment case, non-zero return code catches the segfault case. Cross-platform display detection.
- **`tests-gui-display-windows`** — new CI job on `windows-2025` that runs the GUI tests against a real Windows console session. The on-screen Windows crash does not reproduce under Linux Xvfb, so this is the first job that could catch it. `continue-on-error: true` while the bug is still being chased — signal without gating unrelated PRs.
- Existing `tests-gui-display` (Linux Xvfb) job also picks up `test_gui_init.py`.

## What this PR is *not*

- **Not a confirmed fix** for #1048 / #1109. The two defensive changes (#1, #2) match the silent-abort symptom mechanistically and are textbook Qt safety, but I cannot reproduce on Linux+Xvfb, so I cannot prove they fix it. The hope is the new Windows CI job + reporter `QISKIT_METAL_DEBUG_INIT=1` traces converge on whether they did.
- **Not a free-threaded fix.** Side-finding while investigating: PySide6 6.11.1 has no `cp313t` wheel, so no reporter can be running free-threaded Python today. Rules that hypothesis out entirely.

## Test plan

- [x] `uvx ruff check` clean on the five touched files
- [x] `uvx ruff format --check` clean
- [x] AST + YAML parse clean
- [x] `tests-gui-display` (Linux Xvfb) — extended to include `test_gui_init.py`
- [ ] `tests-gui-display-windows` (Windows 2025) — **brand new; will run on this PR**. If green → cannot reproduce on a GHA Windows runner, points at env-specific factors (DPI, AV, conda Qt). If red → we own a deterministic reproducer for the first time.
- [ ] Manual: ask one #1048 reporter to install this PR's branch, run with `QISKIT_METAL_DEBUG_INIT=1`, paste output

## Related

- Fixes (potentially) — #1048 (on-screen init branch), #1109 (duplicate, already closed)
- Builds on PR #1104 / v0.7.4 (the at-exit Qt teardown fix)
- See `CLAUDE.md` — `_gui/` is a hard-touch zone, hence `continue-on-error` on the new Windows job and the deliberate decision to ship the diagnostic switch *with* the defensive fixes (so reporters can verify the fixes worked on their box)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_