### PR TITLE
Fix RouteAnchors.unobstructed for segments contained in a bounding box (closes #1036)

### DIFF
--- a/src/qiskit_metal/qlibrary/tlines/anchored_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/anchored_path.py
@@ -209,11 +209,28 @@ class RouteAnchors(QRoute):
                 np.array([xmax, ymin]),
                 np.array([xmax, ymax]),
             ]
-            if any(
-                intersecting(segment[0], segment[1], k, l)
-                for k, l in [(p, q), (p, r), (r, s), (q, s)]
+            # A segment whose endpoints both lie inside the bounding box does
+            # not cross any box edge, so the edge-intersection test below would
+            # miss it. Detect that case explicitly and still run the contour
+            # check; otherwise a path passing through a (non-rectangular)
+            # component is wrongly reported as unobstructed. See issue #1036.
+            x0, y0 = segment[0][0], segment[0][1]
+            x1, y1 = segment[1][0], segment[1][1]
+            segment_in_box = (
+                xmin <= x0 <= xmax
+                and ymin <= y0 <= ymax
+                and xmin <= x1 <= xmax
+                and ymin <= y1 <= ymax
+            )
+            if (
+                any(
+                    intersecting(segment[0], segment[1], k, l)
+                    for k, l in [(p, q), (p, r), (r, s), (q, s)]
+                )
+                or segment_in_box
             ):
-                # At least 1 intersection with the component bounding box. Check the actual contour.
+                # At least 1 intersection with the component bounding box (or the
+                # segment lies entirely within it). Check the actual contour.
                 if not self.unobstructed_close_up(segment, component):
                     # At least 1 intersection with the actual component contour; do not proceed!
                     return False

--- a/tests/test_route_anchors_unobstructed.py
+++ b/tests/test_route_anchors_unobstructed.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Regression tests for RouteAnchors.unobstructed (issue #1036).
+
+A segment whose endpoints both lie inside a component's bounding box does not
+cross any bounding-box edge. The original obstacle check only tested for edge
+crossings, so such a segment skipped the contour check and was wrongly reported
+as unobstructed even when it cut through a (non-rectangular) component.
+"""
+
+import unittest
+
+import numpy as np
+
+from qiskit_metal import designs
+from qiskit_metal.qlibrary.sample_shapes.n_gon import NGon
+from qiskit_metal.qlibrary.tlines.anchored_path import RouteAnchors
+
+
+class TestRouteAnchorsUnobstructed(unittest.TestCase):
+    """Check obstacle detection for segments contained in a bounding box."""
+
+    @staticmethod
+    def _design_with_circle_obstacle():
+        """A ~circular obstacle (24-gon, radius 0.5 mm) at the origin, whose
+        bounding box ([-0.5, 0.5] in x and y) is strictly larger than its
+        contour. Returns (design, route)."""
+        design = designs.DesignPlanar()
+        design.overwrite_enabled = True
+        NGon(
+            design,
+            "obstacle",
+            options=dict(n="24", radius="0.5mm", pos_x="0mm", pos_y="0mm"),
+        )
+        # make=False: we only need the unobstructed() helper, not a routed path.
+        route = RouteAnchors(design, "r", options=dict(), make=False)
+        return design, route
+
+    def test_contained_segment_crossing_contour_is_obstructed(self):
+        """Both endpoints inside the bbox but outside the circle, with the chord
+        cutting through the circle -> obstructed (regression for #1036)."""
+        _, route = self._design_with_circle_obstacle()
+        segment = [np.array([-0.45, 0.45]), np.array([0.45, 0.45])]
+        self.assertFalse(route.unobstructed(segment))
+
+    def test_segment_clear_of_obstacle_is_unobstructed(self):
+        """A segment well outside the bounding box stays unobstructed."""
+        _, route = self._design_with_circle_obstacle()
+        segment = [np.array([2.0, 2.0]), np.array([3.0, 2.0])]
+        self.assertTrue(route.unobstructed(segment))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the obstacle-collision gap reported in #1036, and reimplements PR #1038 by @Jinyuan426 with proper formatting and a regression test.

`RouteAnchors.unobstructed()` only tested whether a segment **crossed an edge** of each component's bounding box. A segment whose **endpoints both lie inside** the box crosses no edge, so it skipped the actual-contour check and was wrongly reported as *unobstructed* — even when it cut straight through a non-rectangular component whose bbox is larger than its contour.

The fix detects the fully-contained case explicitly and still runs the contour (`unobstructed_close_up`) check in that case.

## Verification

Confirmed with a concrete reproduction (now committed as a regression test). Obstacle = a ~circle (24-gon, radius 0.5 mm); bbox is `[-0.5, 0.5]²`:

| Segment | endpoints in bbox? | crosses circle? | `unobstructed()` before | after |
|---|---|---|---|---|
| `(-0.45, 0.45) → (0.45, 0.45)` | yes | yes | `True` ❌ (clear) | **`False`** ✅ (obstructed) |
| `(2, 2) → (3, 2)` | no | no | `True` | `True` (unchanged) |

`tests/test_route_anchors_unobstructed.py` covers both cases.

- New test passes; `ruff format --check` and `ruff check` clean on both changed files.
- Behavior for segments that cross a bbox edge (the existing path) is unchanged.

## Attribution

The fix logic is from #1038 by @Jinyuan426; this PR adds the missing formatting + regression test so it can land on current `main`. Credited via `Co-authored-by`. #1038 can be closed in favour of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk)_