### PR TITLE
TransmonCross: optional non-uniform claw width / ground spacing (closes #957 intent)

### DIFF
--- a/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
@@ -62,7 +62,9 @@ class TransmonCross(BaseQubit):
             * connector_type: '0' -- 0 = Claw type, 1 = gap type
             * claw_length: '30um' -- Length of the claw 'arms', measured from the connector center trace
             * ground_spacing: '5um' -- Amount of ground plane between the connector and Crossmon arm (minimum should be based on fabrication capabilities)
+            * ground_spacing_back: None -- Ground plane between the cpw-side (back) of the connector and the Crossmon arm. Defaults to ground_spacing when None
             * claw_width: '10um' -- The width of the CPW center trace making up the claw/gap connector
+            * claw_width_back: None -- The width of the back (towards the incoming CPW) of the claw connector. Defaults to claw_width when None
             * claw_gap: '6um' -- The gap of the CPW center trace making up the claw/gap connector
             * connector_location: '0' -- 0 => 'west' arm, 90 => 'north' arm, 180 => 'east' arm
     """
@@ -76,7 +78,9 @@ class TransmonCross(BaseQubit):
             connector_type="0",  # 0 = Claw type, 1 = gap type
             claw_length="30um",
             ground_spacing="5um",
+            ground_spacing_back=None,  # Defaults to `ground_spacing` when None
             claw_width="10um",
+            claw_width_back=None,  # Defaults to `claw_width` when None
             claw_gap="6um",
             claw_cpw_length="40um",
             claw_cpw_width="10um",
@@ -181,14 +185,23 @@ class TransmonCross(BaseQubit):
         g_s = pc.ground_spacing
         con_loc = pc.connector_location
 
-        claw_cpw = draw.box(-c_w, -c_c_w / 2, -c_c_l - c_w, c_c_w / 2)
+        # claw_width_back / ground_spacing_back default to claw_width /
+        # ground_spacing when unset, so the default geometry is unchanged.
+        c_w_b = pc.claw_width_back
+        if c_w_b is None:
+            c_w_b = c_w
+        g_s_b = pc.ground_spacing_back
+        if g_s_b is None:
+            g_s_b = g_s
+
+        claw_cpw = draw.box(-c_w_b, -c_c_w / 2, -c_c_l - c_w_b, c_c_w / 2)
 
         if pc.connector_type == 0:  # Claw connector
             t_claw_height = (
                 2 * c_g + 2 * c_w + 2 * g_s + 2 * cross_gap + cross_width
             )  # temp value
 
-            claw_base = draw.box(-c_w, -(t_claw_height) / 2, c_l, t_claw_height / 2)
+            claw_base = draw.box(-c_w_b, -(t_claw_height) / 2, c_l, t_claw_height / 2)
             claw_subtract = draw.box(
                 0, -t_claw_height / 2 + c_w, c_l, t_claw_height / 2 - c_w
             )
@@ -205,7 +218,7 @@ class TransmonCross(BaseQubit):
         # extract from the connector later, but since allowing different connector types,
         # this seems more straightforward.
         port_line = draw.LineString(
-            [(-c_c_l - c_w, -c_c_w / 2), (-c_c_l - c_w, c_c_w / 2)]
+            [(-c_c_l - c_w_b, -c_c_w / 2), (-c_c_l - c_w_b, c_c_w / 2)]
         )
 
         claw_rotate = 0
@@ -216,7 +229,7 @@ class TransmonCross(BaseQubit):
 
         # Rotates and translates the connector polygons (and temporary port_line)
         polys = [connector_arm, connector_etcher, port_line]
-        polys = draw.translate(polys, -(cross_length + cross_gap + g_s + c_g), 0)
+        polys = draw.translate(polys, -(cross_length + cross_gap + g_s_b + c_g), 0)
         polys = draw.rotate(polys, claw_rotate, origin=(0, 0))
         polys = draw.rotate(polys, p.orientation, origin=(0, 0))
         polys = draw.translate(polys, p.pos_x, p.pos_y)

--- a/tests/test_qlibrary_2_options.py
+++ b/tests/test_qlibrary_2_options.py
@@ -502,11 +502,15 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         self.assertEqual(_options["cross_length"], "200um")
         self.assertEqual(_options["cross_gap"], "20um")
 
-        self.assertEqual(len(_options["_default_connection_pads"]), 8)
+        self.assertEqual(len(_options["_default_connection_pads"]), 10)
         self.assertEqual(_options["_default_connection_pads"]["connector_type"], "0")
         self.assertEqual(_options["_default_connection_pads"]["claw_length"], "30um")
         self.assertEqual(_options["_default_connection_pads"]["ground_spacing"], "5um")
+        self.assertEqual(
+            _options["_default_connection_pads"]["ground_spacing_back"], None
+        )
         self.assertEqual(_options["_default_connection_pads"]["claw_width"], "10um")
+        self.assertEqual(_options["_default_connection_pads"]["claw_width_back"], None)
         self.assertEqual(_options["_default_connection_pads"]["claw_gap"], "6um")
         self.assertEqual(
             _options["_default_connection_pads"]["claw_cpw_length"], "40um"

--- a/tests/test_qlibrary_3_options.py
+++ b/tests/test_qlibrary_3_options.py
@@ -470,11 +470,15 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
         self.assertEqual(_options["cross_length"], "200um")
         self.assertEqual(_options["cross_gap"], "20um")
 
-        self.assertEqual(len(_options["_default_connection_pads"]), 8)
+        self.assertEqual(len(_options["_default_connection_pads"]), 10)
         self.assertEqual(_options["_default_connection_pads"]["connector_type"], "0")
         self.assertEqual(_options["_default_connection_pads"]["claw_length"], "30um")
         self.assertEqual(_options["_default_connection_pads"]["ground_spacing"], "5um")
+        self.assertEqual(
+            _options["_default_connection_pads"]["ground_spacing_back"], None
+        )
         self.assertEqual(_options["_default_connection_pads"]["claw_width"], "10um")
+        self.assertEqual(_options["_default_connection_pads"]["claw_width_back"], None)
         self.assertEqual(
             _options["_default_connection_pads"]["claw_cpw_length"], "40um"
         )

--- a/tests/test_transmon_cross_claw_back.py
+++ b/tests/test_transmon_cross_claw_back.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the non-uniform claw options of TransmonCross.
+
+``claw_width_back`` and ``ground_spacing_back`` let the back of a claw
+connector (the side facing the incoming CPW) use a different width / ground
+spacing than the sides. Both default to ``None``, in which case they fall back
+to ``claw_width`` / ``ground_spacing`` so existing designs are unchanged.
+"""
+
+import unittest
+
+from qiskit_metal import designs
+from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
+
+
+def _arm_area(component, pad="a"):
+    """Area of the named claw connector_arm polygon."""
+    table = component.qgeometry_table("poly")
+    row = table[table["name"] == f"{pad}_connector_arm"]
+    return float(row.iloc[0].geometry.area)
+
+
+class TestTransmonCrossClawBack(unittest.TestCase):
+    """Backward-compatibility and effect of the *_back claw options."""
+
+    @staticmethod
+    def _make(**pad_overrides):
+        design = designs.DesignPlanar()
+        design.overwrite_enabled = True
+        return TransmonCross(
+            design, "Q", options=dict(connection_pads=dict(a=dict(**pad_overrides)))
+        )
+
+    def test_defaults_unchanged_when_back_options_none(self):
+        """A claw built with the defaults must be identical to one that sets
+        the *_back options equal to their front counterparts."""
+        default_arm = _arm_area(self._make())
+        explicit_arm = _arm_area(
+            self._make(claw_width_back="10um", ground_spacing_back="5um")
+        )
+        self.assertAlmostEqual(default_arm, explicit_arm, places=12)
+
+    def test_claw_width_back_changes_geometry(self):
+        """Setting a different back width must change the connector geometry."""
+        default_arm = _arm_area(self._make())
+        wide_back_arm = _arm_area(self._make(claw_width_back="30um"))
+        self.assertNotAlmostEqual(default_arm, wide_back_arm, places=12)
+
+    def test_rectangle_connector_still_builds(self):
+        """connector_type='1' (rectangle) must still build without error."""
+        comp = self._make(connector_type="1")
+        self.assertIn("a_connector_arm", set(comp.qgeometry_table("poly")["name"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reimplements PR #957 by @clarkmiyamoto on current `main` — lets the **back** of a `TransmonCross` claw connector (the side facing the incoming CPW) use a different width and ground spacing than the sides, for designs like the MIT-LL "candle" qubit.

Two new connection-pad options:

| Option | Meaning | Default |
|---|---|---|
| `claw_width_back` | width of the back of the claw | `None` → falls back to `claw_width` |
| `ground_spacing_back` | ground spacing on the back side | `None` → falls back to `ground_spacing` |

## Per the maintainer decision: **defaults unchanged**

Unlike the original PR, this keeps `claw_gap = "6um"` and `claw_cpw_width = "10um"` as-is — so **existing `TransmonCross` designs render byte-for-byte identically**. The new options only change geometry when explicitly set.

It also fixes a bug in the original: it referenced `pc.claw_spacing_back` (no such option) instead of `ground_spacing_back`, which would have raised `AttributeError` on every claw connector.

## Tests (`tests/test_transmon_cross_claw_back.py`)

- **Backward compatibility**: default claw geometry is identical to one that sets `claw_width_back`/`ground_spacing_back` equal to their front counterparts.
- **Effect**: a different `claw_width_back` changes the connector geometry.
- **Rectangle connector** (`connector_type='1'`) still builds.
- Updated the two default-option guards (pad count 8 → 10, new `None` keys); `claw_gap`/`claw_cpw_width` assertions left at `6um`/`10um`.

All four changed files pass `ruff check` and `ruff format --check`; the new test plus both option-guard suites pass locally.

## Attribution

Feature and original implementation by @clarkmiyamoto (#957); credited via `Co-authored-by`. #957 can be closed in favour of this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk)_