### PR TITLE
roadmap: add GDS airbridge support (PR #962)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -363,6 +363,22 @@ or their employer.*
   strength of the class-based qlibrary and is currently
   under-used. Pairs with the "When to use Metal" page
   above as the visual half of the answer.
+- **GDS airbridge support** `[planned, PR #962]`
+  Add airbridges to `QGDSRenderer.export_to_gds` so fab-grade
+  GDS files include the bridges that CPW crossings need without
+  a manual post-processing step in KLayout. Most SC qubit
+  chips with multi-crossing CPW routing need this; today
+  users hand-place bridges downstream.
+  The structural work landed in @clarkmiyamoto's PR #962
+  (`_populate_airbridge` + `make_airbridge.py`, mirroring the
+  cheesing flow), but the PR has bit-rotted relative to
+  current main — needs rebase + the v0.7-era housekeeping
+  (lazy `gdstk`, ruff/format pass, headless test). The
+  limitations the original PR called out (uniform-only
+  bridges, single bridge per turn, no overlap warning) can
+  ship as follow-ups; landing the basic path is the unblock.
+  Pairs with the `.lyp` + Metal → KLayout work above for a
+  clean GDS-handoff story.
 
 ### High impact, high effort
 


### PR DESCRIPTION
## Summary

Adds **"GDS airbridge support"** under the *High impact, medium effort* bucket of `ROADMAP.md`. The entry points at @clarkmiyamoto's PR #962, which already has the structural work (`_populate_airbridge` + `make_airbridge.py`, mirroring the cheesing flow) but has bit-rotted relative to current main.

### Why this fits the bucket

- **Real fab need** — most SC qubit chips with multi-crossing CPW routing need airbridges; today users hand-place them in KLayout downstream.
- **High impact** — closes a meaningful gap in the GDS-handoff story; pairs naturally with the `.lyp` and "Metal → KLayout" items already in this bucket.
- **Medium effort, not high** — design exists in PR #962; the work is rebase + v0.7-era housekeeping (lazy `gdstk`, ruff/format, headless test), not a from-scratch build.

The PR also notes the limitations the original called out (uniform-only bridges, single bridge per turn, no overlap warning) can ship as follow-ups — landing the basic path is the unblock.

## Validation

Pure roadmap doc change — single file, +16 lines.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_