### PR TITLE
docs: render ROADMAP.md inline on the docs site via myst-parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,6 +183,11 @@ extensions = [
     # in nbsphinx-rendered notebooks. Used for the architecture and
     # design-flow diagrams in contributor-guide.rst and tutorial 1.1.
     "sphinxcontrib.mermaid",
+    # Parses Markdown so RST pages can ``.. include::`` ``.md`` files
+    # via ``:parser: myst_parser.sphinx_``. Currently used by
+    # ``docs/roadmap.rst`` to render the repo-root ``ROADMAP.md`` inline
+    # without duplicating it.
+    "myst_parser",
 ]
 
 # --- Mermaid --------------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -203,6 +203,7 @@ in a simple, open, community-driven framework.
     :caption: Concepts
     :hidden:
 
+    Roadmap<roadmap>
     Quantum Metal Workflow<workflow>
     Frequently Asked Questions<faq>
 

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,10 @@
+.. _roadmap:
+
+.. The Sphinx Roadmap page is rendered from the repo-root ``ROADMAP.md``
+   so the docs site and GitHub stay in lockstep -- no hand-curated
+   teaser to drift. Requires ``myst-parser`` (in the ``docs`` extra).
+   The included file's ``# Quantum Metal -- Roadmap`` H1 becomes the
+   page title; everything below is parsed as MyST Markdown.
+
+.. include:: ../ROADMAP.md
+   :parser: myst_parser.sphinx_

--- a/docs/workflow.rst
+++ b/docs/workflow.rst
@@ -1,54 +1,5 @@
 .. _workflow:
 
-*********************
-Roadmap
-*********************
-
-
-.. note::
-
-   **From IBM to a Community-Maintained Project**
-
-   Originally developed at IBM by **Dr. Zlatko K. Minev**, Quantum Metal has transitioned into a
-   **community-driven project** supported by universities, research groups, laboratories, and
-   individual contributors worldwide. Ongoing work is carried out by the
-   **Quantum Device Consortium (QDC)** and active maintainers.
-
-   Current release: **v0.7.0** (lite-by-default install — see :doc:`migration-to-v0.7.0`).
-   The project follows `EffVer <https://jacobtomlinson.dev/effver/>`_ and will switch to
-   `SemVer <https://semver.org>`_ after v1.0 (date TBD).
-
-   - QDC website & governance: https://qdc-qcsa.org — Discord: `discord.gg/kaZ3UFuq <https://discord.gg/kaZ3UFuq>`_
-   - QDW (annual workshop): https://qdw-ucla.squarespace.com/ — sign for 2026: https://qdw-ucla.squarespace.com/qdw2026
-   - Slack (`#metal <https://qiskit.slack.com/archives/C01R8KP5WP7>`_) remains available but is being phased out in favour of Discord.
-
-The full, up-to-date roadmap lives in
-`ROADMAP.md <https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_
-in the repository root. It is the canonical source of truth — items there are
-linked to open PRs and issues so you can track progress or jump in.
-
-**Current priorities (v0.7.x — v0.8.0):**
-
-- **Lite-by-default** ``[shipped in v0.7.0]`` — ``pip install quantum-metal``
-  is now small and fast; heavy backends (GUI, Ansys, gmsh) are opt-in extras.
-- **pyaedt renderer** ``[active]`` — the ``renderer_ansys_pyaedt/`` path is the
-  modern replacement for the legacy COM-based HFSS/Q3D bridge. Ongoing validation
-  and feature parity work.
-- **Jupyter widget viewer** ``[research]`` — exploring a Jupyter-widgets-based
-  interactive viewer (pan, zoom, click-to-select) as a lighter alternative to the
-  PySide6 desktop GUI. Goal: full interactivity in JupyterLab and VS Code notebooks
-  without requiring Qt.
-- **Open FEM stack** ``[research]`` — gmsh mesher (``renderer_gmsh/``) +
-  Elmer solver (``renderer_elmer/``) + AWS Palace renderer (planned). Unblocks
-  HFSS-free full-field analysis for users without an Ansys license.
-- **AI-orchestration profile** ``[planned, v0.7.x]`` — stable programmatic API
-  contract, determinism guarantees, and renderer dispatch by name so that
-  agent-driven design loops can use Quantum Metal predictably.
-
-Have a feature request or want to help? Open an issue or join the conversation
-on `Discord <https://discord.gg/kaZ3UFuq>`_.
-
-
 **********************
 Quantum Metal Workflow
 **********************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,12 @@
         # GitHub so they don't need any extension; the Sphinx side
         # picks up the same syntax through this package.
         "sphinxcontrib-mermaid>=1.0.0",
+        # Parses Markdown into Sphinx's docutils tree so we can
+        # ``.. include::`` files like ``ROADMAP.md`` directly into RST
+        # pages (see ``docs/roadmap.rst``). Single source of truth: the
+        # repo-root ``ROADMAP.md`` renders on GitHub AND on the docs
+        # site with no hand-curated teaser to drift.
+        "myst-parser>=4.0",
 ]
     lint = [ "ruff>=0.14.2" ]
     test = [

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,8 @@ name = "jupytext"
 version = "1.19.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mdit-py-plugins" },
     { name = "nbformat" },
     { name = "packaging" },
@@ -1455,14 +1456,36 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+dependencies = [
+    { name = "mdurl", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -1569,7 +1592,8 @@ name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
@@ -1622,6 +1646,50 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/b6/5f922792be93b82ec6b5f270bbb1ef031fd0622847070bbcf9da816502cc/multiprocess-0.70.18-py312-none-any.whl", hash = "sha256:9b78f8e5024b573730bfb654783a13800c2c0f2dfc0c25e70b40d184d64adaa2", size = 150287, upload-time = "2025-04-17T03:11:22.69Z" },
     { url = "https://files.pythonhosted.org/packages/3b/c3/ca84c19bd14cdfc21c388fdcebf08b86a7a470ebc9f5c3c084fc2dbc50f7/multiprocess-0.70.18-py38-none-any.whl", hash = "sha256:dbf705e52a154fe5e90fb17b38f02556169557c2dd8bb084f2e06c2784d8279b", size = 132636, upload-time = "2025-04-17T03:11:24.936Z" },
     { url = "https://files.pythonhosted.org/packages/6c/28/dd72947e59a6a8c856448a5e74da6201cb5502ddff644fbc790e4bd40b9a/multiprocess-0.70.18-py39-none-any.whl", hash = "sha256:e78ca805a72b1b810c690b6b4cc32579eba34f403094bbbae962b7b5bf9dfcb8", size = 133478, upload-time = "2025-04-17T03:11:26.253Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
+    "python_full_version < '3.11' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.11'" },
+    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
 ]
 
 [[package]]
@@ -2683,6 +2751,8 @@ docs = [
     { name = "ipywidgets" },
     { name = "jupyterlite-pyodide-kernel" },
     { name = "jupyterlite-sphinx" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nbsphinx" },
     { name = "numpydoc" },
     { name = "qiskit-sphinx-theme" },
@@ -2744,6 +2814,7 @@ docs = [
     { name = "ipywidgets", specifier = ">=8.1" },
     { name = "jupyterlite-pyodide-kernel", specifier = ">=0.4.0" },
     { name = "jupyterlite-sphinx", specifier = ">=0.16.0" },
+    { name = "myst-parser", specifier = ">=4.0" },
     { name = "nbsphinx", specifier = ">=0.9.8" },
     { name = "numpydoc", specifier = ">=1.5.0" },
     { name = "qiskit-sphinx-theme", specifier = ">=2.0.0" },
@@ -2859,7 +2930,8 @@ name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }


### PR DESCRIPTION
## Summary

Wires `myst-parser` into the Sphinx build so a new `docs/roadmap.rst` can include `ROADMAP.md` directly. Eliminates the hand-curated teaser in `workflow.rst` that was drifting (still claimed v0.7.0; airbridges entry I just added in #1116 wasn't visible from the docs).

Same pattern the project already uses for `tutorials/` ↔ `docs/tut/` sync — but here Sphinx parses the file *in place* rather than copying, so there's only one copy and no sync gate needed.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | + `myst-parser>=4.0` in the `docs` group |
| `docs/conf.py` | + `myst_parser` extension |
| `docs/roadmap.rst` | **new** — 3-line wrapper that includes `ROADMAP.md` via `:parser: myst_parser.sphinx_` |
| `docs/workflow.rst` | Drop the stale Roadmap section. Keep Workflow + Quantization Methods (what the filename always implied). `.. _workflow:` label preserved so any inbound `:ref:` still resolves. |
| `docs/index.rst` | + `Roadmap<roadmap>` to the Concepts toctree, ordered above Workflow. |

## Why now

Before this PR: `workflow.rst` carried a hand-curated 5-bullet teaser that said `Current release: **v0.7.0**` (we're on v0.7.4) and linked out to GitHub for the full list. Anything added to `ROADMAP.md` — like the airbridges item from #1116 — wouldn't show up on the docs site at all.

After this PR: `ROADMAP.md` is the single source of truth. The docs site renders it inline; GitHub renders it on the repo. No drift class possible.

## Verification

- `myst-parser 5.1.0` resolves cleanly under the `docs` group.
- Direct MyST parse of `ROADMAP.md` is clean: 1 root, 22 headings, first = `Quantum Metal — Roadmap`, last = `How to help`. No syntax issues.
- Local Sphinx build can't complete in this container (pandoc is missing — unrelated nbsphinx dep), but the docs CI job has pandoc and will exercise the include end-to-end.

## Follow-up (out of scope)

The five other docs files that already link to `ROADMAP.md` on GitHub (`faq.rst`, `migration-to-v0.7.0.rst`, `ecosystem.rst`, `headless-usage.rst`) are left as-is. They're useful as external references too; converting them to `:doc:\`roadmap\`` cross-refs is an easy follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_