### PR TITLE
docs(toc): move v0.7.0 migration guide from Get Started to Project

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,7 +180,6 @@ in a simple, open, community-driven framework.
 
     Installing Quantum Metal<installation>
     Quick Start<tut/1-Overview/1.1-Quick-start>
-    Migrating to v0.7.0<migration-to-v0.7.0>
     Built on / with Quantum Metal<ecosystem>
 
 .. toctree::
@@ -222,6 +221,7 @@ in a simple, open, community-driven framework.
 
     Roadmap<roadmap>
     Frequently Asked Questions<faq>
+    Migrating to v0.7.0<migration-to-v0.7.0>
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
## Summary

Moves the **"Migrating to v0.7.0"** guide out of the **Get Started** sidebar section and into **Project** (alongside Roadmap / FAQ).

`docs/migration-to-v0.7.0.rst` has two top-level (`===`) sections — the migration guide and the *"v0.7.2 follow-on: prefer `qm.gui(design)` over `MetalGUI(design)`"* note — so under the Get Started toctree's `:maxdepth: 2` it rendered as **two** entries cluttering the new-user landing nav. Relocating the single `migration-to-v0.7.0` toctree entry to the Project section (which is `:maxdepth: 1`) tidies the Get Started nav and puts this transitional reference material where it belongs.

## Change
- `docs/index.rst`: one toctree entry moved (Get Started → Project). No content change; the doc is still referenced exactly once, so no orphan/duplicate-toctree warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk)_