### PR TITLE
gui(windows): default to software OpenGL + bisection toggles (#1048)

### DIFF
--- a/src/qiskit_metal/__init__.py
+++ b/src/qiskit_metal/__init__.py
@@ -32,6 +32,19 @@ __status__ = "Development"
 import os
 
 if os.name == "nt":
+    # Issue #1048: Qt 6.11 + integrated Intel GPU + WDDM 3.2 + touchscreen-
+    # capable Windows 11 hardware (e.g. Dell Latitude 9440 2-in-1) hits a
+    # native CRT __fastfail(7) inside Qt's accelerated D3D/RHI render path
+    # at QMainWindow.show(). Forcing Qt's bundled Mesa software OpenGL
+    # (opengl32sw.dll) bypasses the failure. The env var must be set
+    # BEFORE any PySide6 module is imported -- the runtime Qt attribute
+    # (Qt.AA_UseSoftwareOpenGL) is only a hint and is silently ignored on
+    # the affected drivers. Power users on healthy GPUs can opt back into
+    # accelerated GL by exporting QISKIT_METAL_QT_HARDWARE_GL=1 before
+    # ``import qiskit_metal``.
+    if not os.environ.get("QISKIT_METAL_QT_HARDWARE_GL"):
+        os.environ.setdefault("QT_OPENGL", "software")
+
     try:
         import geopandas
     except ImportError:

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -433,7 +433,18 @@ class MetalGUI(QMainWindowBaseHandler):
         _trace_init("_setup_component_widget")
         self._setup_component_widget()
         _trace_init("_setup_plot_widget")
-        self._setup_plot_widget()
+        # Issue #1048 bisection toggle: the embedded matplotlib
+        # ``FigureCanvasQTAgg`` is the heaviest QWidget in MetalGUI's tree
+        # and a prime suspect for the Qt 6.11 + Intel Iris Xe + WDDM 3.2
+        # crash at ``show()``. ``QISKIT_METAL_GUI_NO_PLOT=1`` skips the
+        # canvas embed so reporters can isolate whether it's the trigger.
+        # The GUI loses its main view -- this is a diagnostic-only flag.
+        if os.environ.get("QISKIT_METAL_GUI_NO_PLOT"):
+            self.logger.warning(
+                "QISKIT_METAL_GUI_NO_PLOT set; skipping plot canvas embed."
+            )
+        else:
+            self._setup_plot_widget()
         _trace_init("_setup_design_components_widget")
         self._setup_design_components_widget()
         _trace_init("_setup_elements_widget")
@@ -518,7 +529,11 @@ class MetalGUI(QMainWindowBaseHandler):
 
         self._set_enabled_design_widgets(True)
 
-        self.plot_win.set_design(design)
+        # ``plot_win`` is None when the QISKIT_METAL_GUI_NO_PLOT bisection
+        # toggle is set (issue #1048). Tolerate that gracefully so the GUI
+        # still builds; the user just won't see the chip canvas.
+        if self.plot_win is not None:
+            self.plot_win.set_design(design)
         self.elements_win.force_refresh()
         self.net_list_win.force_refresh()
 
@@ -995,7 +1010,8 @@ class MetalGUI(QMainWindowBaseHandler):
 
     def refresh_plot(self):
         """Redraw only the plot window contents."""
-        self.plot_win.replot()
+        if self.plot_win is not None:
+            self.plot_win.replot()
 
     def autoscale(self):
         """Shortcut to autoscale all views."""

--- a/src/qiskit_metal/_gui/main_window_base.py
+++ b/src/qiskit_metal/_gui/main_window_base.py
@@ -120,6 +120,17 @@ class QMainWindowExtensionBase(QMainWindow):
                 window_state = window_state.encode("ascii")
             self.restoreState(window_state)
 
+            # Issue #1048 bisection toggle: if the stylesheet (which affects
+            # every paint operation) is the trigger for the Qt 6.11 + Intel
+            # Iris Xe crash, ``QISKIT_METAL_GUI_NO_STYLESHEET=1`` skips it.
+            # Falls back to the default Qt-system style (lighter UX cost
+            # than disabling the plot widget).
+            if os.environ.get("QISKIT_METAL_GUI_NO_STYLESHEET"):
+                self.logger.warning(
+                    "QISKIT_METAL_GUI_NO_STYLESHEET set; skipping stylesheet load."
+                )
+                return
+
             self.handler.load_stylesheet(
                 self.settings.value("stylesheet", self.handler._stylesheet_default)
             )

--- a/src/qiskit_metal/_gui/main_window_base.py
+++ b/src/qiskit_metal/_gui/main_window_base.py
@@ -89,6 +89,12 @@ class QMainWindowExtensionBase(QMainWindow):
         self.logger.info("Saving window state")
         # get the current size and position of the window as a byte array.
         self.settings.setValue("metal_version", __version__)
+        # Persist the Qt version too. If the user upgrades PySide6 the
+        # binary QMainWindow-state blob may no longer be compatible;
+        # restore_window_settings uses this to invalidate stale state
+        # instead of feeding an incompatible blob to restoreState() and
+        # ending up with an inconsistent QMainWindow (issue #1048).
+        self.settings.setValue("qt_version", QtCore.qVersion())
         self.settings.setValue("geometry", self.saveGeometry())
         self.settings.setValue("windowState", self.saveState())
         self.settings.setValue("stylesheet", self.handler._stylesheet)
@@ -99,12 +105,55 @@ class QMainWindowExtensionBase(QMainWindow):
 
         Raises:
             Exception: Error in restoration
+
+        Issue #1048 hypothesis: on some Windows 11 hardware (Intel Iris Xe
+        + WDDM 3.2 + touchscreen 2-in-1 laptops in particular), display
+        config changes between sessions (tablet mode toggle, DPI change on
+        undock, monitor hot-swap) can leave the persisted geometry /
+        window-state referencing coordinates or widget layouts that no
+        longer make sense. ``restoreState()`` doesn't reject those blobs
+        outright -- it happily builds a QMainWindow in an inconsistent
+        state which then hits a native CRT ``__fastfail(7)`` at the first
+        paint from ``show()``. This method now:
+
+        1. Honours ``QISKIT_METAL_RESET_UI_SETTINGS=1`` -- users can force
+           a clean slate without touching the registry.
+        2. Auto-invalidates if the persisted state was written by a
+           different Qt version than the one loaded now.
+        3. Treats *any* exception during restoration as terminal for the
+           persisted state: clear it and continue with defaults, so the
+           next launch doesn't hit the same trap.
         """
+
+        # Escape hatch: users hitting the persisted-state crash can
+        # ``$env:QISKIT_METAL_RESET_UI_SETTINGS = "1"`` to clean the slate
+        # without going through the registry themselves.
+        if os.environ.get("QISKIT_METAL_RESET_UI_SETTINGS"):
+            self.logger.warning(
+                "QISKIT_METAL_RESET_UI_SETTINGS set; clearing persisted "
+                "MetalGUI window state before restore."
+            )
+            self.settings.clear()
+            return
 
         version_settings = self.settings.value("metal_version", defaultValue="0")
         if __version__ > version_settings:
             self.logger.debug(f"Clearing window settings [{version_settings}]...")
             self.settings.clear()
+            return
+
+        # Cross-version Qt invalidation: state saved under one Qt version
+        # may not restore cleanly under another. Qt has no version tag on
+        # the state blob itself so we compare our own.
+        saved_qt = self.settings.value("qt_version", defaultValue="")
+        current_qt = QtCore.qVersion()
+        if saved_qt and saved_qt != current_qt:
+            self.logger.info(
+                f"Clearing window settings: saved under Qt {saved_qt}, "
+                f"now running Qt {current_qt}."
+            )
+            self.settings.clear()
+            return
 
         try:
             self.logger.debug("Restoring window settings...")
@@ -137,7 +186,15 @@ class QMainWindowExtensionBase(QMainWindow):
 
             # TODO: Recent files
         except Exception as e:
-            self.logger.error(f"ERROR [restore_window_settings]: {e}")
+            # Persisted state that raised on restore is the failure mode
+            # #1048 is chasing. Blow it away so subsequent launches don't
+            # relive the poisoning -- one bad exit shouldn't brick the GUI
+            # for every future session.
+            self.logger.error(
+                f"ERROR [restore_window_settings]: {e}. "
+                "Clearing persisted state to prevent recurrence."
+            )
+            self.settings.clear()
 
     def bring_to_top(self):
         """Bring window to top.


### PR DESCRIPTION
## Summary

Two-pronged defensive fix for the still-open Windows `MetalGUI` crash (#1048), targeting two distinct hypotheses in one install. **This PR does not claim a proven cure** — @RhinoHand's 5-of-5 failure in [this comment](https://github.com/qiskit-community/qiskit-metal/issues/1048#issuecomment-4834597854) after tutorial use falsified the simpler "GL backend is the fix" version we started with. The updated PR now tests both the GL-backend and the persisted-state hypotheses simultaneously.

## The two hypotheses

### A. GL backend (harm reduction)

Qt 6.11's accelerated D3D/RHI path is fragile on integrated Intel Iris Xe + WDDM 3.2 + touchscreen-enabled Win 11 hardware. Software OpenGL is more forgiving. Verified as harm-reduction (worked 1× for RhinoHand before state pollution), *not* deterministic (0/5 after tutorial usage).

### B. Persisted state corruption (sharper hypothesis)

RhinoHand's data fits this pattern better:
- First-ever launch: `QSettings` empty → `restoreGeometry`/`restoreState` no-op → `show()` succeeds.
- User uses the GUI. On close, `save_window_settings` writes geometry + windowState + stylesheet to registry.
- Display config changes between sessions (tablet toggle, DPI change on undock, monitor hot-swap on 2-in-1 laptops with WDDM 3.2).
- Next launch: `restoreState()` feeds a now-inconsistent widget-layout blob to QMainWindow. Qt happily builds an inconsistent widget tree.
- `show()` → first paint → Qt hits a native invariant → CRT `__fastfail(7)` → process dies.

Explains everything the GL-backend hypothesis couldn't:
- 5/5 env-var failures after RhinoHand's tutorial use (state got poisoned during usage).
- Software GL only helps *sometimes* (raster path tolerates some corruption).
- @gulapjamun's "works on first run, crashes on subsequent runs" pattern is exactly this.
- CI Windows job passes every time (GHA runners start with empty registry).

## Changes

### 1. Default to Qt software OpenGL on Windows

`qiskit_metal/__init__.py` sets `QT_OPENGL=software` before any PySide6 import, on Windows only, unless `QISKIT_METAL_QT_HARDWARE_GL=1` is set. Harm-reduction, not a cure.

### 2. Defensive persisted-state handling *(this iteration's core change)*

`main_window_base.py::restore_window_settings`:

- **`QISKIT_METAL_RESET_UI_SETTINGS=1`** — clear-slate escape hatch that doesn't require registry surgery.
- **Cross-Qt-version invalidation** — `save_window_settings` now persists `QtCore.qVersion()` alongside `metal_version`; `restore_window_settings` clears state if the current Qt differs from the saved one. A state blob saved under one Qt version was never contractually valid to restore under another.
- **Terminal exception handling** — the existing try/except only *logged*. Now it also clears the persisted state so the next launch doesn't relive the poisoning. One bad shutdown shouldn't brick every future session on the same account.

### 3. Bisection toggles (unchanged from earlier iteration)

For reporters if A and B both come up short:
- `QISKIT_METAL_GUI_NO_STYLESHEET=1` — skip the dark stylesheet
- `QISKIT_METAL_GUI_NO_PLOT=1` — skip the embedded matplotlib canvas (leaves `plot_win` as `None`; `set_design`/`refresh_plot` are defensive against that)

## What we're waiting on before merge

@RhinoHand testing this branch. Two data points he can give us:

1. Just install and run his normal repro (both defensives active). If it works → likely persisted-state was the real driver, ship it.
2. If it still crashes on the patched branch, one clean command distinguishes the hypotheses:
   ```powershell
   reg delete "HKCU\Software\QiskitMetal\MainWindow" /f
   python -X faulthandler -c "from qiskit_metal import designs, MetalGUI; MetalGUI(designs.DesignPlanar()); print('built')"
   ```
   - Works once, breaks on second run → confirms B (persisted state)
   - Still crashes on the first run after registry clear → falsifies B, we're chasing something deeper

## Verification

- Imports cleanly on Linux (Windows-specific block gated on `os.name == 'nt'`).
- Opt-out mechanics tested locally.
- `ruff check` clean.
- Terminal exception handling preserves the existing log line and adds the clear — no lost signal.

## Related

- Issue: #1048
- Builds on: #1104 (v0.7.4 atexit fix), #1110 (init-order + diagnostic switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj