### PR TITLE
chore: bump version to 0.7.5

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,37 @@ For the offical user-facing changelog for a particular release can be found in t
 
 The changelog for all releases can be found in the release page: [![Releases](https://img.shields.io/github/release/Qiskit/qiskit-metal.svg?style=popout-square)](https://github.com/Qiskit/qiskit-metal/releases)
 
+## Quantum Metal v0.7.5 (Windows GUI crash fix + routing/qubit fixes; no breaking changes)
+
+Patch release. Additive — no breaking changes.
+
+### Fixed (v0.7.5-only)
+
+- **`MetalGUI` no longer crashes at `show()` on Windows** (the on-screen crash, distinct from the exit-teardown segfault fixed in v0.7.4). Root cause was **persisted-state corruption**: Metal saves window geometry / dock layout to the registry (`HKCU\Software\QiskitMetal\MainWindow`) on close, and after a display-configuration change (tablet-mode toggle, undock, DPI change on 2-in-1 laptops with WDDM 3.2) Qt's `restoreState()` handed `show()` an inconsistent widget tree that fast-failed (`__fastfail(7)`) at first paint — the "works on the first run, crashes after" pattern several Windows 11 users reported. Fix: persisted UI state is invalidated when the saved Qt version differs from the running one, and is **cleared** (not just logged) if restoration raises, so one bad shutdown can't brick every future session. Reporter-validated (6/6 clean runs). One-shot escape hatch: `QISKIT_METAL_RESET_UI_SETTINGS=1`. (#1122, closes #1048; builds on #1104 / #1110)
+- **Auto-routing no longer passes straight through a component.** `RouteAnchors.unobstructed()` returned `True` when both segment endpoints lay inside a component's bounding box even though the segment crossed the actual (non-rectangular) contour, so routed paths could penetrate e.g. a circular pad. The contour is now checked in that case too. (#1113, closes #1036; reimplements the community fix #1038 by @Jinyuan426, with a regression test)
+- **`design.to_python_script()` output is runnable again.** Exported `.metal.py` scripts that use numpy arrays now include `from numpy import array` in the header. (#1043 by @saschabuehrle, closes #1042)
+
+### Added (v0.7.5-only)
+
+- **`TransmonCross` non-uniform claw options.** New per-connection-pad `claw_width_back` / `ground_spacing_back` let the back of a claw connector (facing the incoming CPW) use a different width / ground spacing than the sides — e.g. MIT-LL "candle" qubits. Both default to `None` (fall back to `claw_width` / `ground_spacing`), so existing designs render byte-for-byte identically. (#1115; reimplements #957 by @clarkmiyamoto)
+- **Windows Qt software-OpenGL default.** On Windows, `import qiskit_metal` sets `QT_OPENGL=software` before PySide6 imports (opt out with `QISKIT_METAL_QT_HARDWARE_GL=1`) — harm-reduction for fragile integrated-GPU / WDDM 3.2 driver stacks. (#1122)
+- **Reference full-chip design tutorials.** Three executed, headless-rendered end-to-end examples — single transmon + readout resonator, two coupled transmons, and 4-qubit multiplexed readout — under *Tutorials → Full-Chip Design Examples* on the docs site. (#1108)
+
+### Docs (v0.7.5-only)
+
+- Component-gallery cards now deep-link to each component's own API page with real descriptions (registry-aware, so new components self-link). (#1108)
+- `ROADMAP.md` now renders inline on the docs site as a single source of truth; site TOC restructured for clarity. (#1118–#1121)
+
+### Security / CI (v0.7.5-only)
+
+- Cleared 10 Dependabot advisories in the dev/docs toolchain (`starlette`, `bleach`, `jupyter-server`, `jupyterlab`, `tornado`) — lockfile-only, no runtime impact for installed users. (#1111)
+- Hardened the CI `apt` setup against flaky third-party runner sources (azure-cli / Microsoft repos) that were failing jobs before any test ran. (#1112)
+- Windows on-screen GUI init hardening + `QISKIT_METAL_DEBUG_INIT` diagnostic + a `tests-gui-display-windows` CI job. (#1110)
+
+### Upgrade notes
+
+No API changes; drop-in upgrade from 0.7.4. Windows users hitting the GUI crash: just upgrade — the fix is automatic. If a machine is already in a poisoned state, `QISKIT_METAL_RESET_UI_SETTINGS=1` (or deleting `HKCU\Software\QiskitMetal\MainWindow`) clears it once.
+
 ## Quantum Metal v0.7.4 (new SNAIL component + crash fixes; no breaking changes)
 
 Patch release. Additive — no breaking changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
     readme = { file = "README.md", content-type = "text/markdown" }
     requires-python = ">=3.10,<3.13"
     urls = { bugtracker = "https://github.com/qiskit-community/qiskit-metal/issues", documentation = "https://qiskit-community.github.io/qiskit-metal/", source = "https://github.com/qiskit-community/qiskit-metal" }
-    version = "0.7.4"
+    version = "0.7.5"
     # ────────────────────────────────────────────────────────────────
     # v0.7.0: LITE-BY-DEFAULT. Core deps only — what's needed to
     # ``import qiskit_metal``, build designs, run ``qm.view()``,

--- a/uv.lock
+++ b/uv.lock
@@ -2700,7 +2700,7 @@ wheels = [
 
 [[package]]
 name = "quantum-metal"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "addict" },


### PR DESCRIPTION
Version bump for the **v0.7.5** patch release. Bumps `pyproject.toml` + `uv.lock` in lockstep and adds the `changelog.md` section. No API changes.

After merge, on your go: `git tag v0.7.5 origin/main && git push origin v0.7.5` (fires `release.yml` → PyPI), then create the GitHub Release with the notes below.

---

## Draft GitHub Release notes — Quantum Metal v0.7.5

Patch release — **additive, no breaking changes.** Headline: the Windows `MetalGUI` on-screen crash (#1048) is fixed.

```bash
pip install --upgrade quantum-metal          # headless / lite
pip install --upgrade "quantum-metal[gui]"   # desktop GUI
```

### 🐛 Fixes

- **`MetalGUI` no longer crashes at `.show()` on Windows** (#1122, closes #1048). Distinct from the exit-teardown segfault fixed in v0.7.4 — this is the *on-screen* crash several Windows 11 users hit. Root cause: **persisted-state corruption**. Metal saves window geometry/dock layout to the registry on close; after a display-config change (tablet-mode toggle, undock, DPI change on 2-in-1 laptops with WDDM 3.2) Qt's `restoreState()` fed `show()` an inconsistent widget tree that fast-failed at first paint — the "works on the first run, crashes after" pattern. Persisted state is now invalidated on a Qt-version change and cleared if restoration raises, so one bad shutdown can't brick future sessions. **Reporter-validated (6/6).** Escape hatch: `QISKIT_METAL_RESET_UI_SETTINGS=1`.
- **Auto-routing no longer passes through a component** (#1113, closes #1036). `RouteAnchors.unobstructed()` missed the case where both segment endpoints sit inside a component's bounding box but the segment crosses its actual (non-rectangular) contour. Reimplements the community fix #1038 by @Jinyuan426, with a regression test.
- **`design.to_python_script()` output runs again** (#1043 by @saschabuehrle, closes #1042) — exported `.metal.py` now includes `from numpy import array`.

### ✨ Added

- **`TransmonCross` non-uniform claws** (#1115) — new `claw_width_back` / `ground_spacing_back` per-pad options (default `None` → unchanged geometry). Reimplements #957 by @clarkmiyamoto.
- **Windows Qt software-OpenGL default** (#1122) — `QT_OPENGL=software` on Windows (opt out with `QISKIT_METAL_QT_HARDWARE_GL=1`); harm-reduction for fragile integrated-GPU driver stacks.
- **Reference full-chip design tutorials** (#1108) — single transmon + readout, two coupled transmons, 4-qubit multiplexed readout, under *Tutorials → Full-Chip Design Examples*.

### 📚 Docs

- Component-gallery cards deep-link to each component's API page with real descriptions (#1108).
- `ROADMAP.md` renders inline on the docs site; TOC restructured (#1118–#1121).

### 🔒 Security / CI

- Cleared 10 Dependabot advisories in the dev/docs toolchain (lockfile-only, no runtime impact) (#1111).
- Hardened CI `apt` setup against flaky third-party runner sources (#1112).
- Windows on-screen GUI init hardening + `QISKIT_METAL_DEBUG_INIT` diagnostic + `tests-gui-display-windows` CI job (#1110).

### Upgrade notes

Drop-in from 0.7.4. Windows users hitting the GUI crash: just upgrade. If a machine is already in a poisoned state, `QISKIT_METAL_RESET_UI_SETTINGS=1` (or delete `HKCU\Software\QiskitMetal\MainWindow`) clears it once.

**Full changelog:** https://github.com/qiskit-community/qiskit-metal/compare/v0.7.4...v0.7.5

---
_Generated by [Claude Code](https://claude.ai/code/session_01UavmC8ioMDbJarbRquffkk)_