### PR TITLE
renderer_ansys: catch Ansys COM / pyEPR failures instead of crashing (#1130, #1127)

### DIFF
--- a/src/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
@@ -764,7 +764,8 @@ class QAnsysRenderer(QRendererAnalysis):
             show (bool, optional): Whether or not to display the screenshot.  Defaults to True.
 
         Returns:
-            pathlib.WindowsPath: path to png formatted screenshot.
+            pathlib.WindowsPath: path to png formatted screenshot. ``None`` if the
+                Ansys COM call failed (see issues #1046, #1130).
         """
         self.modeler._modeler.ShowWindow()
         try:
@@ -773,6 +774,24 @@ class QAnsysRenderer(QRendererAnalysis):
             self.logger.error(
                 "Please install a more recent version of pyEPR (>=0.8.4.3)"
             )
+        except Exception as e:
+            # Ansys's COM automation for ExportModelImageToFile can
+            # intermittently fail with a native RPC error (issues #1046,
+            # #1130) -- e.g. ``com_error: (-2147023170, 'The remote
+            # procedure call failed.', None, None)``. This is an
+            # Ansys/COM reliability issue, not something Python can
+            # prevent, but an uncaught COM error here previously crashed
+            # the caller's whole script/kernel with a cryptic native
+            # traceback. Surface it as an actionable message instead.
+            self.logger.error(
+                "save_screenshot() failed talking to the Ansys COM "
+                f"interface: {e}. This is a known Ansys/pyEPR COM "
+                "reliability issue, not a Qiskit Metal bug (see "
+                "qiskit-metal#1046, #1130). It is often transient -- try "
+                "again, or make sure the AEDT window has focus and no "
+                "other automation is attached to the same session."
+            )
+            return None
 
     def execute_design(
         self,

--- a/src/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -639,9 +639,33 @@ class QQ3DRenderer(QAnsysRenderer):
 
         Args:
             RES (pd.DataFrame): Dictionary of capacitance matrices versus pass number, organized as pandas table.
+
+        Returns:
+            The convergence plot, or ``None`` if constructing pyEPR's
+            ``DistributedAnalysis`` failed (see issue #1127).
         """
         if self._pinfo:
-            eprd = epr.DistributedAnalysis(self._pinfo)
+            try:
+                eprd = epr.DistributedAnalysis(self._pinfo)
+            except Exception as e:
+                # pyEPR's DistributedAnalysis construction can raise
+                # ``TypeError: tuple indices must be integers or slices,
+                # not Quantity`` from an internal bug in its own
+                # variation-key handling -- ``core_distributed_analysis.py``
+                # calls ``self._list_variations[ureg(variation)]``, which
+                # units-parses the variation label via pint instead of
+                # treating it as a plain index (issue #1127). This is a
+                # pyEPR-internal bug that Metal's call site cannot work
+                # around, but an uncaught exception here previously
+                # crashed with a confusing traceback deep in pyEPR
+                # internals rather than a clear, attributable message.
+                self.logger.error(
+                    "plot_convergence_main() failed constructing pyEPR's "
+                    f"DistributedAnalysis: {e}. This is a known pyEPR "
+                    "internal bug in its variation-key handling, not a "
+                    "Qiskit Metal bug (see qiskit-metal#1127)."
+                )
+                return None
             epr.toolbox.plotting.mpl_dpi(110)
             return _plot_q3d_convergence_main(eprd, RES)
 

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -16,7 +16,7 @@
 """Qiskit Metal unit tests analyses functionality."""
 
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import matplotlib.pyplot as _plt
 
 from qiskit_metal import designs
@@ -670,6 +670,81 @@ class TestRenderers(unittest.TestCase):
         renderer._pinfo.setup.get_convergence = MagicMock()
         renderer._pinfo.setup.get_convergence.return_value = (None, convergence_txt)
         self.assertFalse(renderer.get_convergence())
+
+    def test_save_screenshot_survives_ansys_com_error(self):
+        """Issues #1046 / #1130 -- QAnsysRenderer.save_screenshot() must not
+        propagate an Ansys COM RPC failure. Before this fix, only
+        AttributeError was caught; any other exception from pyEPR's
+        ``ExportModelImageToFile`` (e.g. a native ``com_error``) crashed
+        the caller's script/kernel with a cryptic traceback instead of a
+        clear, attributable message."""
+        design = designs.DesignPlanar()
+        renderer = QAnsysRenderer(design, initiate=False)
+        renderer._pinfo = MagicMock()
+        renderer._pinfo.design.save_screenshot = MagicMock(
+            side_effect=RuntimeError(
+                "(-2147023170, 'The remote procedure call failed.', None, None)"
+            )
+        )
+        # ``modeler`` is a read-only property derived from ``pinfo.design.modeler``;
+        # since ``_pinfo`` is already a MagicMock, ``self.modeler._modeler.ShowWindow()``
+        # resolves automatically without needing an explicit assignment.
+
+        try:
+            result = renderer.save_screenshot()
+        except Exception as e:  # noqa: BLE001 -- this is exactly what must NOT happen
+            self.fail(
+                "save_screenshot() propagated the Ansys COM error instead "
+                f"of catching it: {e!r}"
+            )
+        self.assertIsNone(
+            result, "save_screenshot() should return None after a caught COM failure"
+        )
+
+    def test_save_screenshot_still_handles_old_pyepr_attributeerror(self):
+        """Regression guard: the pre-existing AttributeError branch (old
+        pyEPR versions missing save_screenshot) must still work after
+        adding the broader Exception handler alongside it."""
+        design = designs.DesignPlanar()
+        renderer = QAnsysRenderer(design, initiate=False)
+        renderer._pinfo = MagicMock()
+        renderer._pinfo.design.save_screenshot = MagicMock(
+            side_effect=AttributeError("no save_screenshot on this pyEPR version")
+        )
+
+        try:
+            result = renderer.save_screenshot()
+        except Exception as e:  # noqa: BLE001
+            self.fail(f"save_screenshot() should catch AttributeError too: {e!r}")
+        self.assertIsNone(result)
+
+    def test_plot_convergence_main_survives_pyepr_distributedanalysis_bug(self):
+        """Issue #1127 -- QQ3DRenderer.plot_convergence_main() must not
+        propagate the TypeError that pyEPR's ``DistributedAnalysis``
+        construction can raise from its own internal variation-key
+        handling (``core_distributed_analysis.py`` indexing
+        ``self._list_variations`` with a ``ureg()``-parsed Quantity
+        instead of a plain index). This is a pyEPR-internal bug Metal's
+        call site cannot work around, but it must degrade gracefully
+        instead of crashing with a confusing traceback."""
+        design = designs.DesignPlanar()
+        renderer = QQ3DRenderer(design, initiate=False)
+        renderer._pinfo = MagicMock()
+
+        with patch(
+            "qiskit_metal.renderers.renderer_ansys.q3d_renderer.epr.DistributedAnalysis",
+            side_effect=TypeError(
+                "tuple indices must be integers or slices, not Quantity"
+            ),
+        ):
+            try:
+                result = renderer.plot_convergence_main(RES=MagicMock())
+            except Exception as e:  # noqa: BLE001
+                self.fail(
+                    "plot_convergence_main() propagated pyEPR's "
+                    f"DistributedAnalysis TypeError instead of catching it: {e!r}"
+                )
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two reports from @RhinoHand (#1130, #1127), both the same class of bug: Metal's call sites into pyEPR/Ansys COM automation only caught the one exception type they were originally written for, letting any other failure — including two upstream-flaky code paths — propagate raw and crash the caller's script/kernel.

**These do not fix Ansys's or pyEPR's own reliability issues** (can't, from Metal). They convert a script-ending crash into a recoverable, diagnosable failure with an actionable message.

## #1130 (and #1046 — same root cause, different reporter)

`QAnsysRenderer.save_screenshot()` wraps pyEPR's `design.save_screenshot() → ExportModelImageToFile()` COM call in `try/except AttributeError` (added only to detect old pyEPR versions missing the method). The actual reported failure — `com_error: (-2147023170, 'The remote procedure call failed.', None, None)` — is a different exception class entirely and was never caught.

**#1046 (April, different reporter, identical traceback) confirms this isn't a one-off** — Ansys's COM automation for image export is a known-flaky path, and Metal had zero defense against it.

Added a second `except Exception` branch (after the existing `AttributeError` branch, so that regression path is untouched) that logs a clear, attributable message and returns `None` instead of propagating.

## #1127

`QQ3DRenderer.plot_convergence_main()` (called from `LumpedOscillatorModel.plot_convergence()`, per the issue title) constructs `epr.DistributedAnalysis(self._pinfo)` as its first line. @RhinoHand's traceback and diagnosis are correct — I confirmed by reading the actually-installed pyEPR 0.9.5 source: `core_distributed_analysis.py` line 370 indexes `self._list_variations[ureg(variation)]`, passing the variation label through pint's unit registry instead of using it as a plain index, which raises `TypeError: tuple indices must be integers or slices, not Quantity` for certain variation label formats. **This is entirely inside pyEPR** — Metal's call site doesn't control it.

Wrapped the `DistributedAnalysis` construction in `try/except` that logs a clear message pointing at the pyEPR-internal root cause and returns `None`.

## Tests

Added to `tests/test_renderers.py`, reusing the file's existing `QAnsysRenderer(design, initiate=False)` / `_pinfo = MagicMock()` pattern (no live AEDT connection needed):

- `test_save_screenshot_survives_ansys_com_error` — mocks `_pinfo.design.save_screenshot` to raise the exact reported COM error text; asserts no propagation, returns `None`.
- `test_save_screenshot_still_handles_old_pyepr_attributeerror` — regression guard confirming the new broader `except` doesn't shadow the pre-existing `AttributeError` branch.
- `test_plot_convergence_main_survives_pyepr_distributedanalysis_bug` — patches `q3d_renderer.epr.DistributedAnalysis` to raise the exact reported `TypeError`; asserts no propagation.

**Verified the tests actually test the fix**: reverted the two source changes locally, confirmed the COM-error and DistributedAnalysis tests fail with the exception propagating uncaught (the `AttributeError` regression-guard test correctly still passes, since that path was untouched). Restored the fix afterward.

`tests/test_renderers.py`: 36/41 passed locally (installed the `ansys` extra). The 5 failures are pre-existing `renderer_gmsh`/`renderer_elmer` tests requiring the separate `mesh` extra + system `libGLU` (this sandbox has no network path to fetch it) — confirmed unrelated by reverting this PR's diff and observing the identical 5 failures. CI's `tests-extras-mesh` job covers that combination.

`ruff check` + `ruff format --check` clean on all three touched files.

## Hard-touch zone note

Per `CLAUDE.md`, `renderer_ansys/` requires careful validation. This follows the same pattern as PR #1078 (whose AEDT validation is tracked in #1079) — both changes here are purely additive (new `except` branches only; success-path behavior is completely unchanged) and covered by mocked unit tests, but real-AEDT confirmation that "Ansys is flaky in exactly this way and the message is helpful" would benefit from someone with a live AEDT license, same ask as #1079.

## Related

- Fixes (defensively) #1130, #1127
- Same root cause as #1046 (COM RPC failure) — cross-referenced
- Follows the established pattern from #1078 / #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFSp55LrdMsUyRexqbFoJj)_