### PR TITLE
Recent-issue fixes: pyEPR 1.0.1 floor + LOM composite-model docs (#1127, #1135)

### DIFF
--- a/docs/quantization.rst
+++ b/docs/quantization.rst
@@ -60,6 +60,42 @@ References:
 
 |
 
+.. _lom-composite-api:
+
+Composite-system API: ``Cell`` / ``Subsystem`` / ``CompositeSystem``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The lumped-oscillator model is assembled from three classes in
+:mod:`qiskit_metal.analyses.quantization.lom_core_analysis`. A **Cell** holds
+an extracted capacitance matrix plus any inductors and junctions; a
+**Subsystem** maps a set of circuit nodes to a quantum model (transmon,
+fluxonium, transmission-line or lumped resonator, ...); and a
+**CompositeSystem** reduces and quantizes the combined network. These are the
+classes used in tutorials ``4.04`` and ``4.05``.
+
+The accepted ``q_opts`` for every built-in subsystem ``sys_type``
+(``TRANSMON``, ``FLUXONIUM``, ``TL_RESONATOR``, ``LUMPED_RESONATOR``) — which
+values you supply and which are computed from the extracted L and C matrices —
+are listed on :class:`Subsystem` below. Call
+:meth:`QuantumSystemRegistry.registry` to enumerate every registered type,
+including any custom builder you add.
+
+.. currentmodule:: qiskit_metal.analyses.quantization.lom_core_analysis
+
+.. autoclass:: Cell
+   :members:
+
+.. autoclass:: Subsystem
+   :members:
+
+.. autoclass:: CompositeSystem
+   :members:
+
+.. autoclass:: QuantumSystemRegistry
+   :members:
+
+|
+
 ---------------------------------------------------
 Energy: The energy-participation-ratio (EPR) method
 ---------------------------------------------------

--- a/docs/quantization.rst
+++ b/docs/quantization.rst
@@ -65,7 +65,7 @@ References:
 
    A reliable red flag is the **EPR junction participation ratio**
    :math:`p_{mj}`. By definition it is the fraction of the mode's inductive
-   energy in junction *j*, so :math:`0 \\le p_{mj} \\le 1`. If EPR reports
+   energy in junction *j*, so :math:`0 \le p_{mj} \le 1`. If EPR reports
    :math:`p_{mj} > 1` (often together with energy-normalization warnings),
    the lumped-junction picture is invalid for that geometry and the extracted
    Hamiltonian parameters for the mode should not be trusted. Fixes: keep the

--- a/docs/quantization.rst
+++ b/docs/quantization.rst
@@ -50,6 +50,30 @@ References:
 * Zlatko K. Minev, Thomas G. McConkey, Maika Takita, Antonio Corcoles, Jay M. Gambetta,
   Circuit quantum electrodynamics (cQED) with modular quasi-lumped models. (2021)
 
+.. admonition:: Validity: the junction must be *lumped*
+   :class: warning
+
+   Both the lumped-oscillator reduction and the single-mode EPR extraction
+   assume each nonlinear element (Josephson junction) is a compact, lumped
+   inductor sitting directly across the capacitive gap it shunts — i.e. that
+   essentially all of the mode's inductive energy is stored in ``Lj``. That
+   assumption breaks when the junction is displaced away from the pads and
+   reached through long, narrow leads/arms: those leads add series geometric
+   inductance in the current path, so the eigenmode is no longer a clean
+   ``Lj``–``C`` oscillator and a capacitance extracted by fitting
+   ``1/ω² = C·Lj + b`` is contaminated (it can be off by a factor of ~2).
+
+   A reliable red flag is the **EPR junction participation ratio**
+   :math:`p_{mj}`. By definition it is the fraction of the mode's inductive
+   energy in junction *j*, so :math:`0 \\le p_{mj} \\le 1`. If EPR reports
+   :math:`p_{mj} > 1` (often together with energy-normalization warnings),
+   the lumped-junction picture is invalid for that geometry and the extracted
+   Hamiltonian parameters for the mode should not be trusted. Fixes: keep the
+   junction compact and centered between its pads, or model the leads
+   explicitly as their own inductor in the LOM :class:`Cell` ``ind_dict``
+   (between the pad node and the junction node) rather than folding them into
+   ``Lj``.
+
 .. image:: images/lump.png
    :alt: Missing Image
    :width: 388

--- a/docs/quantization.rst
+++ b/docs/quantization.rst
@@ -50,30 +50,6 @@ References:
 * Zlatko K. Minev, Thomas G. McConkey, Maika Takita, Antonio Corcoles, Jay M. Gambetta,
   Circuit quantum electrodynamics (cQED) with modular quasi-lumped models. (2021)
 
-.. admonition:: Validity: the junction must be *lumped*
-   :class: warning
-
-   Both the lumped-oscillator reduction and the single-mode EPR extraction
-   assume each nonlinear element (Josephson junction) is a compact, lumped
-   inductor sitting directly across the capacitive gap it shunts — i.e. that
-   essentially all of the mode's inductive energy is stored in ``Lj``. That
-   assumption breaks when the junction is displaced away from the pads and
-   reached through long, narrow leads/arms: those leads add series geometric
-   inductance in the current path, so the eigenmode is no longer a clean
-   ``Lj``–``C`` oscillator and a capacitance extracted by fitting
-   ``1/ω² = C·Lj + b`` is contaminated (it can be off by a factor of ~2).
-
-   A reliable red flag is the **EPR junction participation ratio**
-   :math:`p_{mj}`. By definition it is the fraction of the mode's inductive
-   energy in junction *j*, so :math:`0 \le p_{mj} \le 1`. If EPR reports
-   :math:`p_{mj} > 1` (often together with energy-normalization warnings),
-   the lumped-junction picture is invalid for that geometry and the extracted
-   Hamiltonian parameters for the mode should not be trusted. Fixes: keep the
-   junction compact and centered between its pads, or model the leads
-   explicitly as their own inductor in the LOM :class:`Cell` ``ind_dict``
-   (between the pad node and the junction node) rather than folding them into
-   ``Lj``.
-
 .. image:: images/lump.png
    :alt: Missing Image
    :width: 388

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1.24.2,<2
   - pandas>=2.1.1 # Synced with pyproject.toml floor.
   - pint>=0.21.0 # Synced with pyproject.toml floor.
-  - pyEPR-quantum~=0.9.5
+  - pyEPR-quantum>=1.0.1 # Synced with pyproject.toml floor.
   - pygments~=2.14
   - qdarkstyle~=3.1
   - qutip>=5.0.0 # Synced with pyproject.toml floor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
     readme = { file = "README.md", content-type = "text/markdown" }
     requires-python = ">=3.10,<3.13"
     urls = { bugtracker = "https://github.com/qiskit-community/qiskit-metal/issues", documentation = "https://qiskit-community.github.io/qiskit-metal/", source = "https://github.com/qiskit-community/qiskit-metal" }
-    version = "0.7.5"
+    version = "0.7.6"
     # ────────────────────────────────────────────────────────────────
     # v0.7.0: LITE-BY-DEFAULT. Core deps only — what's needed to
     # ``import qiskit_metal``, build designs, run ``qm.view()``,
@@ -71,7 +71,7 @@
         ]
         ansys = [
             "pyaedt>=0.21,<0.24",
-            "pyEPR-quantum>=0.9.5",
+            "pyEPR-quantum>=1.0.1",
         ]
         # gmsh — the universal mesher. Used by Elmer (today), Palace
         # (future), and any other open FEM backend. The mesher itself is
@@ -91,7 +91,7 @@
             "pyside6>=6.8",
             "qdarkstyle>=3.1",
             "pyaedt>=0.21,<0.24",
-            "pyEPR-quantum>=0.9.5",
+            "pyEPR-quantum>=1.0.1",
             "gmsh>=4.15.0,<5",
         ]
 

--- a/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
+++ b/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
@@ -800,9 +800,68 @@ class QuantumSystemRegistry:
 
 class Subsystem:
     """Class representing a subsystem that can typically be mapped to a quantum system with known
-    solution, such as a transmon, a fluxonium or a quantum harmonic osccilator
+    solution, such as a transmon, a fluxonium or a quantum harmonic oscillator.
 
-    frequencies if entered in q_opts need to be in GHz
+    A subsystem is defined by three things: a ``name``, a ``sys_type`` (which
+    built-in or custom quantum model it maps to), and the list of circuit
+    ``nodes`` it occupies. Type-specific numbers — offset charge, external
+    flux, resonator frequency, scQubits truncation, etc. — are passed through
+    the ``q_opts`` dict.
+
+    **Any frequency-like value in** ``q_opts`` **must be given in GHz.**
+
+    Built-in ``sys_type`` values and their ``q_opts``
+    -------------------------------------------------
+
+    The list below is the accepted-parameter reference for the four models
+    shipped with quantum-metal. Call
+    :meth:`QuantumSystemRegistry.registry` at runtime to list every
+    registered type, including any you have added yourself. Parameters marked
+    *(computed)* are extracted from the reduced L and C matrices during the
+    LOM solve and must **not** be supplied; the rest are optional and fall
+    back to the defaults shown.
+
+    ``"TRANSMON"`` — maps to ``scqubits.Transmon``.
+        - ``EJ``, ``EC`` — *(computed)* from the extracted L and C matrices.
+        - ``ng`` — offset charge (default ``0.001``).
+        - ``ncut`` — charge-basis cutoff (default ``22``).
+        - ``truncated_dim`` — retained levels (default ``10``).
+        - ``nodes`` — a single junction node.
+
+    ``"FLUXONIUM"`` — maps to ``scqubits.Fluxonium``.
+        - ``EC`` — *(computed)* from the extracted C matrix.
+        - ``EJ`` — Josephson energy in GHz **(required)**.
+        - ``EL`` — inductive energy in GHz **(required)**.
+        - ``flux`` — external flux in units of the flux quantum
+          :math:`\\Phi_0` **(required)**.
+        - ``cutoff`` — basis cutoff (default ``110``).
+        - ``truncated_dim`` — retained levels (default ``10``).
+        - ``nodes`` — a single junction node.
+
+    ``"TL_RESONATOR"`` — distributed transmission-line resonator, maps to
+    ``scqubits.Oscillator``.
+        - ``f_res`` — resonator frequency in GHz **(required)**.
+        - ``Z0`` — characteristic impedance in ohms (default ``50``).
+        - ``vp`` — phase velocity in m/s, or the string ``"use_design"``
+          (default) to derive it from the ``design`` stack below.
+        - ``design`` — dict of the physical stack used when
+          ``vp="use_design"``: ``line_width``, ``line_gap``,
+          ``substrate_thickness``, ``film_thickness``, all in **meters**
+          (defaults ``10e-6``, ``6e-6``, ``750e-6``, ``200e-9``).
+        - ``truncated_dim`` — retained levels (default ``3``).
+        - ``other_end_shorted`` — ``True`` if the far end is shorted to
+          ground (default ``False``). A shorted resonator must be given a
+          single node.
+        - ``nodes`` — one node (open- or shorted-end) or two nodes.
+
+    ``"LUMPED_RESONATOR"`` — lumped LC resonator, maps to
+    ``scqubits.Oscillator``.
+        - ``f_res`` — *(computed)* from the extracted L and C matrices.
+        - ``truncated_dim`` — retained levels (default ``3``).
+        - ``nodes`` — a single node.
+
+    See tutorials ``4.04`` and ``4.05`` for worked transmon / fluxonium /
+    coupled-transmon examples.
     """
 
     def __init__(self, name: str, sys_type: str, nodes: List[str], q_opts: dict = None):
@@ -1242,7 +1301,41 @@ class Cell:
 
 
 class CompositeSystem:
-    """Class representing the composite system which may consist of multiple subsystems and cells"""
+    """Class representing the composite system which may consist of multiple subsystems and cells.
+
+    A composite system stitches one or more :class:`Cell` objects (each
+    carrying an extracted capacitance matrix, and optionally inductors and
+    junctions) together with the :class:`Subsystem` objects that describe
+    which quantum model each set of nodes maps to. Calling
+    :meth:`circuitGraph` reduces the combined L and C matrices;
+    :meth:`create_hilbertspace` and :meth:`hamiltonian_results` then build and
+    diagonalize the coupled Hamiltonian.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        from qiskit_metal.analyses.quantization.lom_core_analysis import (
+            Cell, Subsystem, CompositeSystem)
+
+        # A cell holds the extracted capacitance matrix plus the junction
+        cell = Cell(dict(node_rename={},
+                         cap_mat=cap_df,               # pandas DataFrame
+                         ind_dict={('pad_top', 'pad_bot'): 12.0},   # nH
+                         jj_dict={('pad_top', 'pad_bot'): 'j1'}))
+
+        transmon = Subsystem(name='Q1', sys_type='TRANSMON', nodes=['j1'])
+
+        composite = CompositeSystem(
+            subsystems=[transmon],
+            cells=[cell],
+            grd_node='ground',
+            nodes_force_keep=None,
+        )
+        hilbertspace = composite.create_hilbertspace()
+        results = composite.hamiltonian_results(hilbertspace, evals_count=10)
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Bundles the recent follow-up work (developed on one branch this session):
- **#1127 / #1130** — raise the `pyEPR-quantum` floor to the release that fixes the variation-indexing crash; companion pyEPR PR: zlatko-minev/pyEPR#212.
- **#1135** — document the LOM composite-model classes (`Cell` / `Subsystem` / `CompositeSystem`), which had no API-reference coverage.

### Did you add tests to cover your changes (yes/no)?

No — dependency-floor/version bump and docstring/docs only, no code behavior change. `scripts/check_env_consistency.py` covers the pin change and passes locally.

### Did you update the documentation accordingly (yes/no)?

Yes — new API-reference section for the LOM composite model (#1135).

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

1. **Dependency sync (#1127):** require `pyEPR-quantum>=1.0.1` in the `[ansys]` and `[full]` extras and `environment.yml` so Ansys installs pull the pyEPR release that fixes the `plot_convergence()` variation-indexing crash. Also removes the latent `environment.yml` pin (`~=0.9.5`) that excluded pyEPR 1.0.x entirely. Bump quantum-metal `0.7.5` → `0.7.6`.
2. **LOM docs (#1135):** `Cell` / `Subsystem` / `CompositeSystem` were neither exported from `qiskit_metal.analyses` nor autodoc'd, and the accepted per-`sys_type` `q_opts` were undocumented. Added:
   - a `Subsystem` reference for the four built-in `sys_type` values (`TRANSMON`, `FLUXONIUM`, `TL_RESONATOR`, `LUMPED_RESONATOR`) — each type's `q_opts`, defaults, units, node semantics, and which values are user-supplied vs computed from the extracted L/C matrices;
   - a worked `CompositeSystem` example;
   - a "Composite-system API" section in `docs/quantization.rst` that autodocuments the classes so they appear in the rendered API Reference.

### Details and comments

**Release ordering (for the dependency part):** publish pyEPR 1.0.1 to PyPI (zlatko-minev/pyEPR#212) before releasing quantum-metal 0.7.6, or the `pyEPR-quantum>=1.0.1` floor is unsatisfiable — this is why the `[ansys]`-extra CI checks are currently red.

_Note: #1127 (dependency) and #1135 (docs) were combined here because both were developed on the same session branch. Happy to split into two PRs if preferred._
