### PR TITLE
ci: guard uv.lock ↔ pyproject.toml consistency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,26 @@ jobs:
       - name: Check environment.yml against pyproject.toml
         run: uv run --quiet scripts/check_env_consistency.py
 
+  lockfile-check:
+    name: uv.lock ↔ pyproject.toml consistency
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_COLOR: "1"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.9.24"
+          enable-cache: true
+      # Fails if pyproject.toml deps/version changed without regenerating
+      # uv.lock. A stale lock ships the wrong version to PyPI at release
+      # time — see the v0.6.0 post-mortem in
+      # .claude/context/lessons-learned.md and PR #1136.
+      - name: Assert uv.lock is in sync with pyproject.toml
+        run: uv lock --check
+
   tutorials-sync:
     name: docs/tut/ ↔ tutorials/ sync
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Preventive follow-up to #1133 / #1136 (the stale-lockfile release blocker).

### Did you add tests to cover your changes (yes/no)?

The change *is* a CI check. `uv lock --check` passes on current `main`.

### Did you update the documentation accordingly (yes/no)?

N/A — the job comment cites the relevant lessons-learned entry.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Adds a `lockfile-check` CI job that runs `uv lock --check`, failing any PR that changes `pyproject.toml` dependencies or the package version without regenerating `uv.lock`.

### Details and comments

A stale `uv.lock` ships the wrong version to PyPI at release time — this is the v0.6.0 post-mortem in `.claude/context/lessons-learned.md`, and it recurred in #1133 (pyproject bumped to 0.7.6 + `pyEPR-quantum>=1.0.1`, lock left at 0.7.5 / 0.9.5), fixed in #1136. This guard catches that class of drift at PR time instead of at release. Mirrors the existing `env-consistency` job's setup (`astral-sh/setup-uv`, pinned `0.9.24`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_