### PR TITLE
GDS short-segment export fix (#1141) + bridge_at_corners airbridge option

### DIFF
--- a/.claude/context/lessons-learned.md
+++ b/.claude/context/lessons-learned.md
@@ -103,6 +103,31 @@ label-based.
 (`render_junction`). Surfaced when the lite venv pulled a newer
 pandas than the dev env.
 
+### pandas 2.0: `DataFrame.append` removed + gdstk positional-indexing a Series
+
+**Symptom** (#1141): exporting a `RouteMeander` to GDS raised — first
+`AttributeError: 'GeoDataFrame' object has no attribute 'append'`, then,
+once that was fixed, `gdstk.boolean(...)` failed with
+`Unable to retrieve item N from sequence operand2`. Only triggered when a
+route had a lead segment shorter than the fillet radius, so it reached
+`_fix_short_segments_within_table`.
+
+**Cause**: two independent pandas-2 traps in the GDS renderer.
+1. `df.append(row, ignore_index=False)` — `DataFrame.append` was removed in
+   pandas 2.0. Replace with `pd.concat([df, row.to_frame().T])` (re-wrap in
+   `geopandas.GeoDataFrame` to keep the geometry accessor).
+2. `gdstk.boolean` iterates its operands by **position** (`operand[i]`), but
+   `q_subtract_true` / `q_subtract_false` are pandas `Series` whose labels are
+   not `0..n-1` (the short-segment path leaves duplicate/gapped index labels).
+   `series[i]` is label-based, so gdstk's positional access raised `KeyError`.
+   Fix: pass `list(series)` so gdstk sees a plain positional sequence.
+
+**Fix**: `src/qiskit_metal/renderers/renderer_gds/gds_renderer.py` —
+`_fix_short_segments_within_table` (concat instead of append) and
+`_negative_mask` / `_positive_mask` (`list(...)` around the boolean operands).
+Regression test: `tests/test_gds_short_segments.py` (exports a short-lead
+meander and checks the area matches a low-fillet control).
+
 ### qutip 5: `np.array([Qobj, ...])` no longer stacks
 
 **Symptom**: Code that worked under qutip 4 returns an object-dtype

--- a/_dev/sync_two_folders.py
+++ b/_dev/sync_two_folders.py
@@ -77,7 +77,7 @@ PAIRS = {
         "docs/tut/2-From-components-to-chip/2.14-Get-them-all-with-MixedRoute.ipynb",
         "tutorials/2 From components to chip/B. Routing between QComponents/2.14 Get them all with MixedRoute.ipynb",
     ),
-    (
+    "2.15": (
         "docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb",
         "tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb",
     ),

--- a/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
+++ b/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
@@ -172,6 +172,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "83219e61",
+   "source": "### Guaranteeing a bridge on every bend\n\nUniform spacing already covers bends wherever a `pitch` sample happens to land\non a fillet arc, but with a coarse `pitch` a corner can fall between samples.\nSet `bridge_at_corners=True` to force one bridge centered on every rounded\nbend, in addition to the uniform-pitch bridges. A uniform bridge that would\nland within half a pitch of a corner bridge is dropped so the two do not bunch\nup.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "12e6dacc",
+   "source": "bridges = route_airbridges(\n    design, cpw, pitch=\"0.6mm\", min_spacing=\"30um\", bridge_at_corners=True\n)\ndesign.rebuild()\nprint(f\"placed {len(bridges)} airbridges (one on every bend)\")\nqm.view(design)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab-gds-h",
    "metadata": {},
    "source": [

--- a/src/qiskit_metal/qlibrary/tlines/airbridge.py
+++ b/src/qiskit_metal/qlibrary/tlines/airbridge.py
@@ -149,26 +149,73 @@ def _fillet_corner(vertex_start, vertex_corner, vertex_end, radius, points):
     )
 
 
-def _fillet_centerline(pts, radius, resolution=16):
+def _fillet_centerline(pts, radius, resolution=16, return_corners=False):
     """Return the rounded (filleted) centerline of a route as an ``Nx2`` array.
 
     Rounds every interior corner that the fillet radius fits; corners that are
     too tight stay sharp. Mirrors ``QMplRenderer.fillet_path`` so placement
     matches the rendered trace.
+
+    If ``return_corners`` is true, also return a list of the arc-length
+    positions (measured along the returned centerline) of the midpoint of each
+    rounded bend — used to guarantee an airbridge sits on every corner.
     """
     pts = np.asarray(pts, dtype=float)
     if len(pts) <= 2 or radius <= 0:
-        return pts
+        return (pts, []) if return_corners else pts
 
     out = [pts[0]]
+    corner_idx = []  # index into `out` of each rounded bend's arc midpoint
     for start, corner, end in zip(pts, pts[1:], pts[2:]):
         arc = _fillet_corner(start, corner, end, radius, resolution)
         if arc is None:
             out.append(corner)
         else:
+            corner_idx.append(len(out) + len(arc) // 2)
             out.extend(arc)
     out.append(pts[-1])
-    return np.asarray(out, dtype=float)
+    out = np.asarray(out, dtype=float)
+
+    if not return_corners:
+        return out
+    _, _, _, cum = _arclength_frame(out)
+    corners = [float(cum[i]) for i in corner_idx]
+    return out, corners
+
+
+def _arclength_frame(coords):
+    """Cumulative arc-length bookkeeping ``(coords, seg, seg_len, cum)`` for a
+    polyline, shared by every arc-length sampler below."""
+    coords = np.asarray(coords, dtype=float)
+    seg = np.diff(coords, axis=0)
+    seg_len = np.hypot(seg[:, 0], seg[:, 1])
+    cum = np.concatenate([[0.0], np.cumsum(seg_len)])
+    return coords, seg, seg_len, cum
+
+
+def _sample_at(frame, s):
+    """``(x, y, orientation_deg)`` at arc-length ``s`` along a polyline.
+
+    Orientation is perpendicular to the local tangent so a bridge span placed
+    here crosses the trace.
+    """
+    coords, seg, seg_len, cum = frame
+    k = int(np.searchsorted(cum, s) - 1)
+    k = min(max(k, 0), len(seg_len) - 1)
+    seg_frac = (s - cum[k]) / seg_len[k] if seg_len[k] else 0.0
+    point = coords[k] + seg_frac * seg[k]
+    theta = np.arctan2(seg[k][1], seg[k][0])
+    return (float(point[0]), float(point[1]), float(np.degrees(theta) + 90.0))
+
+
+def _uniform_arclengths(total, pitch, margin):
+    """Evenly-spaced, path-centered arc-length positions kept ``margin`` clear
+    of both ends. Empty if the usable span is shorter than needed."""
+    usable = total - 2.0 * margin
+    if total <= 0 or usable < 0:
+        return []
+    n = int(np.floor(usable / pitch)) + 1
+    return list(total / 2.0 + (np.arange(n) - (n - 1) / 2.0) * pitch)
 
 
 def _placements_along(coords, pitch, margin):
@@ -179,30 +226,9 @@ def _placements_along(coords, pitch, margin):
     ``margin`` clear of both ends, and each is oriented perpendicular to the
     local tangent so its span crosses the trace.
     """
-    coords = np.asarray(coords, dtype=float)
-    seg = np.diff(coords, axis=0)
-    seg_len = np.hypot(seg[:, 0], seg[:, 1])
-    cum = np.concatenate([[0.0], np.cumsum(seg_len)])
-    total = float(cum[-1])
-
-    usable = total - 2.0 * margin
-    if total <= 0 or usable < 0:
-        return []
-
-    n = int(np.floor(usable / pitch)) + 1
-    centers = total / 2.0 + (np.arange(n) - (n - 1) / 2.0) * pitch
-
-    placements = []
-    for s in centers:
-        k = int(np.searchsorted(cum, s) - 1)
-        k = min(max(k, 0), len(seg_len) - 1)
-        seg_frac = (s - cum[k]) / seg_len[k] if seg_len[k] else 0.0
-        point = coords[k] + seg_frac * seg[k]
-        theta = np.arctan2(seg[k][1], seg[k][0])
-        placements.append(
-            (float(point[0]), float(point[1]), float(np.degrees(theta) + 90.0))
-        )
-    return placements
+    frame = _arclength_frame(coords)
+    total = float(frame[3][-1])
+    return [_sample_at(frame, s) for s in _uniform_arclengths(total, pitch, margin)]
 
 
 def route_airbridges(
@@ -211,6 +237,7 @@ def route_airbridges(
     pitch="100um",
     min_spacing="5um",
     crossover_length=None,
+    bridge_at_corners=False,
     name=None,
     ab_options=None,
 ):
@@ -234,6 +261,13 @@ def route_airbridges(
         min_spacing (str): minimum clearance from the end pins.
         crossover_length (str, optional): bridge span. Defaults to the route's
             ``trace_width + 2*trace_gap`` so the span crosses trace and gaps.
+        bridge_at_corners (bool): if true, guarantee one bridge centered on
+            every rounded bend (in addition to the uniform-pitch bridges). A
+            uniform bridge that would land within half a pitch of a corner
+            bridge is dropped so the two do not bunch up. Corners within
+            ``min_spacing`` of an end are skipped. Defaults to false (uniform
+            pitch only — bends are still covered wherever a pitch sample lands
+            on the fillet arc).
         name (str, optional): prefix for the created components. Defaults to
             ``f"{route.name}_ab"``.
         ab_options (dict, optional): extra options forwarded to each
@@ -256,8 +290,24 @@ def route_airbridges(
         trace_gap = design.parse_value(route.options.get("trace_gap", "6um"))
         crossover_length = trace_width + 2.0 * trace_gap
 
-    centerline = _fillet_centerline(route.get_points(), fillet)
-    placements = _placements_along(centerline, pitch, min_spacing)
+    centerline, corners = _fillet_centerline(
+        route.get_points(), fillet, return_corners=True
+    )
+    frame = _arclength_frame(centerline)
+    total = float(frame[3][-1])
+    s_values = _uniform_arclengths(total, pitch, min_spacing)
+
+    if bridge_at_corners:
+        # Corner bridges are mandatory; add them first, then keep only the
+        # uniform samples that are at least half a pitch (in arc length) from
+        # every corner bridge so bridges do not overlap at bends.
+        kept = [s for s in corners if min_spacing <= s <= total - min_spacing]
+        for s in s_values:
+            if all(abs(s - cs) >= 0.5 * pitch for cs in kept):
+                kept.append(s)
+        s_values = sorted(kept)
+
+    placements = [_sample_at(frame, s) for s in s_values]
 
     # Idempotent re-runs: clear airbridges this helper previously placed under
     # ``name`` before re-placing (so re-executing a cell / re-routing doesn't

--- a/src/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -773,7 +773,11 @@ class QGDSRenderer(QRenderer):
                     orig_row["fillet"] = short_shape["fillet"]
                     # Keep ignore_index=False, otherwise,
                     # the other del_key will not be found.
-                    df_copy = df_copy.append(orig_row, ignore_index=False)
+                    # (pandas 2.0 removed DataFrame.append; concat a one-row
+                    # frame that preserves the del_key index label.)
+                    df_copy = geopandas.GeoDataFrame(
+                        pd.concat([df_copy, orig_row.to_frame().T], ignore_index=False)
+                    )
 
             self.chip_info[chip_name][chip_layer][all_sub_true_or_false] = df_copy.copy(
                 deep=True
@@ -1656,8 +1660,8 @@ class QGDSRenderer(QRenderer):
         if len(self.chip_info[chip_name][chip_layer]["q_subtract_true"]) != 0:
             # Difference for True-False.
             diff_geometry = gdstk.boolean(
-                self.chip_info[chip_name][chip_layer]["q_subtract_true"],
-                self.chip_info[chip_name][chip_layer]["q_subtract_false"],
+                list(self.chip_info[chip_name][chip_layer]["q_subtract_true"]),
+                list(self.chip_info[chip_name][chip_layer]["q_subtract_false"]),
                 "not",
                 layer=chip_layer,
                 precision=precision,
@@ -1694,7 +1698,7 @@ class QGDSRenderer(QRenderer):
         if len(self.chip_info[chip_name][chip_layer]["q_subtract_true"]) != 0:
             diff_geometry = gdstk.boolean(
                 [self.chip_info[chip_name]["subtract_poly"]],
-                self.chip_info[chip_name][chip_layer]["q_subtract_true"],
+                list(self.chip_info[chip_name][chip_layer]["q_subtract_true"]),
                 "not",
                 layer=chip_layer,
                 datatype=0,

--- a/tests/test_airbridge.py
+++ b/tests/test_airbridge.py
@@ -135,6 +135,85 @@ class TestRouteAirbridges(unittest.TestCase):
         # the filleted trace does NOT pass through the sharp corner vertex
         self.assertGreater(line.distance(Point(1.0, 0.0)), 0.05)
 
+    def test_fillet_centerline_reports_corner_arclengths(self):
+        """return_corners yields one arc-length per rounded bend, located near
+        the bend's projection onto the filleted centerline."""
+        import numpy as np
+        from qiskit_metal.qlibrary.tlines.airbridge import _fillet_centerline
+
+        pts = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]  # single 90-degree bend
+        coords, corners = _fillet_centerline(pts, radius=0.2, return_corners=True)
+        self.assertEqual(len(corners), 1)
+        # the reported arc length indexes a point that is actually on the arc
+        # (near the (1,0) corner, at roughly radius distance from it)
+        seg = np.diff(coords, axis=0)
+        cum = np.concatenate([[0.0], np.cumsum(np.hypot(seg[:, 0], seg[:, 1]))])
+        k = int(np.searchsorted(cum, corners[0]))
+        d = np.hypot(*(coords[k] - np.array([1.0, 0.0])))
+        self.assertLess(d, 0.3)
+
+    def test_bridge_at_corners_places_one_bridge_per_bend(self):
+        """bridge_at_corners guarantees a bridge centered on each rounded bend
+        even when the uniform pitch would otherwise skip it."""
+        from shapely.geometry import LineString, Point
+        from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+        from qiskit_metal.qlibrary.tlines.meandered import RouteMeander
+        from qiskit_metal.qlibrary.tlines.airbridge import (
+            route_airbridges,
+            _fillet_centerline,
+        )
+
+        OpenToGround(self.design, "A", options=dict(pos_x="-1mm", orientation="0"))
+        OpenToGround(self.design, "B", options=dict(pos_x="1mm", orientation="180"))
+        cpw = RouteMeander(
+            self.design,
+            "cpw",
+            options=Dict(
+                pin_inputs=Dict(
+                    start_pin=Dict(component="A", pin="open"),
+                    end_pin=Dict(component="B", pin="open"),
+                ),
+                total_length="8mm",
+                fillet="90um",
+                trace_width="10um",
+                trace_gap="6um",
+                meander=Dict(spacing="300um"),
+            ),
+        )
+        self.design.rebuild()
+
+        fillet = self.design.parse_value(cpw.options.fillet)
+        coords, corners = _fillet_centerline(
+            cpw.get_points(), fillet, return_corners=True
+        )
+        centerline = LineString(coords)
+        trace = centerline.buffer(self.design.parse_value(cpw.options.trace_width) / 2)
+
+        # A coarse pitch (larger than the corner spacing) would skip bends
+        # without the option.
+        bridges = route_airbridges(
+            self.design, cpw, pitch="600um", min_spacing="30um", bridge_at_corners=True
+        )
+        self.design.rebuild()
+
+        centers = [
+            Point(float(b.options["pos_x"][:-2]), float(b.options["pos_y"][:-2]))
+            for b in bridges
+        ]
+        total = centerline.length
+        interior = [s for s in corners if 0.03 < s < total - 0.03]
+        # every interior bend has a bridge center within a bridge-pitch of it
+        for s in interior:
+            cp = centerline.interpolate(s)
+            self.assertTrue(
+                any(cp.distance(c) < 1e-6 or c.distance(cp) < 0.05 for c in centers),
+                f"no bridge near corner at arc length {s}",
+            )
+        # and every span still crosses the trace
+        poly = self.design.qgeometry.tables["poly"]
+        for g in poly[poly["name"] == "bridge"]["geometry"]:
+            self.assertTrue(g.intersects(trace))
+
     def test_route_airbridges_cross_the_filleted_trace(self):
         """Regression: every bridge lands on the *filleted* trace and its span
         actually crosses the CPW — including at corners and near the ends."""

--- a/tests/test_gds_short_segments.py
+++ b/tests/test_gds_short_segments.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Regression tests for GDS export of routes with short segments (#1141)."""
+
+import os
+import tempfile
+import unittest
+
+import gdstk
+
+from qiskit_metal import designs, Dict
+from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+from qiskit_metal.qlibrary.tlines.meandered import RouteMeander
+
+
+class TestGdsShortSegments(unittest.TestCase):
+    """A meander whose lead segments are shorter than the fillet exercises
+    `_fix_short_segments_within_table`. Before #1141 this raised — first a
+    pandas-2 `DataFrame.append` AttributeError, then a `gdstk.boolean` error
+    from positional indexing of a duplicate-labelled pandas Series."""
+
+    def _meander_design(self, fillet):
+        design = designs.DesignPlanar()
+        OpenToGround(design, "A", options=dict(pos_x="-1mm", orientation="0"))
+        OpenToGround(design, "B", options=dict(pos_x="1mm", orientation="180"))
+        RouteMeander(
+            design,
+            "cpw",
+            options=Dict(
+                pin_inputs=Dict(
+                    start_pin=Dict(component="A", pin="open"),
+                    end_pin=Dict(component="B", pin="open"),
+                ),
+                total_length="8mm",
+                fillet=fillet,
+                trace_width="10um",
+                trace_gap="6um",
+                meander=Dict(spacing="0.3mm"),
+            ),
+        )
+        design.rebuild()
+        return design
+
+    def test_meander_with_short_segments_exports(self):
+        design = self._meander_design("90um")
+        path = os.path.join(tempfile.mkdtemp(), "m.gds")
+        design.renderers.gds.export_to_gds(path)  # raised before #1141
+        self.assertTrue(os.path.exists(path))
+        self.assertGreater(os.path.getsize(path), 0)
+
+        lib = gdstk.read_gds(path)
+        polys = sum(len(c.polygons) for c in lib.cells)
+        self.assertGreater(polys, 0)
+
+    def test_area_matches_low_fillet_control(self):
+        """The short-segment path must produce the same geometry (to within
+        the fillet's small area change) as a design that avoids it."""
+
+        def total_area(design):
+            path = os.path.join(tempfile.mkdtemp(), "x.gds")
+            design.renderers.gds.export_to_gds(path)
+            lib = gdstk.read_gds(path)
+            return sum(abs(p.area()) for c in lib.cells for p in c.polygons)
+
+        a_short = total_area(self._meander_design("90um"))
+        a_ctrl = total_area(self._meander_design("30um"))
+        self.assertGreater(a_short, 0)
+        self.assertAlmostEqual(a_short, a_ctrl, delta=0.01 * a_ctrl)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
@@ -172,6 +172,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "83219e61",
+   "source": "### Guaranteeing a bridge on every bend\n\nUniform spacing already covers bends wherever a `pitch` sample happens to land\non a fillet arc, but with a coarse `pitch` a corner can fall between samples.\nSet `bridge_at_corners=True` to force one bridge centered on every rounded\nbend, in addition to the uniform-pitch bridges. A uniform bridge that would\nland within half a pitch of a corner bridge is dropped so the two do not bunch\nup.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "12e6dacc",
+   "source": "bridges = route_airbridges(\n    design, cpw, pitch=\"0.6mm\", min_spacing=\"30um\", bridge_at_corners=True\n)\ndesign.rebuild()\nprint(f\"placed {len(bridges)} airbridges (one on every bend)\")\nqm.view(design)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab-gds-h",
    "metadata": {},
    "source": [


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Fixes #1141. Also adds a follow-up airbridge placement option (continues the airbridge work from #1138 / #1140).

### Did you add tests to cover your changes (yes/no)?

Yes — `tests/test_gds_short_segments.py` (GDS fix) and new cases in `tests/test_airbridge.py` (corner option).

### Did you update the documentation accordingly (yes/no)?

Yes — tutorial 2.15 documents `bridge_at_corners` (both folder copies in sync). Added an agent-notes entry in `.claude/context/lessons-learned.md` for the pandas-2 GDS traps.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Two independent, self-contained changes on the shared development branch:

1. **Fix GDS export of routes with short lead segments (#1141).**
2. **Add `bridge_at_corners=True` to `route_airbridges`.**

### Details and comments

**1. GDS short-segment export (#1141).** Exporting a `RouteMeander` (or any route with a lead segment shorter than the fillet radius) raised, because the short-segment repair path in `_fix_short_segments_within_table` hit two pandas-2 incompatibilities:
- `DataFrame.append` was removed in pandas 2.0 → replaced with `pd.concat` of a one-row frame, re-wrapped as a `GeoDataFrame` to keep the geometry accessor and the `del_key` index label.
- `gdstk.boolean` indexes its operands positionally, but `q_subtract_true` / `q_subtract_false` are pandas `Series` with gapped/duplicate index labels after the short-segment path, so `series[i]` (label-based) raised `Unable to retrieve item N from sequence`. Passing `list(series)` gives `gdstk` a positional sequence. Validation: a short-lead meander now exports and its total polygon area matches a low-fillet control.

**2. `bridge_at_corners` option.** `route_airbridges` spaces bridges by uniform arc-length pitch along the filleted centerline; with a coarse `pitch` a rounded bend can fall between samples. `bridge_at_corners=True` forces one bridge centered on every rounded bend (arc midpoint, perpendicular to the local tangent) in addition to the uniform bridges; a uniform bridge within half a pitch of a corner bridge is dropped so they don't bunch up. Default stays `False`, so existing behaviour is unchanged. The placement helpers were refactored around a shared arc-length sampler (`_arclength_frame` / `_sample_at` / `_uniform_arclengths`); `_fillet_centerline(..., return_corners=True)` now also reports each bend's arc-length. Also fixes a missing dict key (`"2.15":`) in the dev helper `_dev/sync_two_folders.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)