### PR TITLE
Experimental: 3D airbridges via layer-stack elevation (#1144)

### DIFF
--- a/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
+++ b/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
@@ -712,6 +712,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e3453f40",
+   "source": "## Experimental: 3D airbridges\n\nIn a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\nspan should be *elevated* above the base metal. Metal's 3D renderers extrude\neach layer by the `thickness` / `z_coord` in the design's **layer stack**, so\nlifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\nthe ecosystem matures) AWS Palace or Ansys.\n\n```python\nfrom qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack\n\n# design must be a DesignMultiPlanar (it carries a layer stack)\napply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", bridge_thickness=\"0.3um\")\n# then render 3D with the airbridge layers marked metal, e.g.\n#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31], dielectric=[3]))\n```\n\n> ⚠️ **Experimental.** The elevated geometry renders in gmsh, but the 3D mesh\n> has **not** been validated against a live FEM solve, and rendering a full\n> CPW *route* in 3D currently hits a separate gmsh path-fillet limitation.\n> Follow / help validate in\n> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab-closing",
    "metadata": {},
    "source": [

--- a/src/qiskit_metal/qlibrary/tlines/airbridge.py
+++ b/src/qiskit_metal/qlibrary/tlines/airbridge.py
@@ -13,10 +13,14 @@
 # that they have been altered from the originals.
 """Airbridge — a ground-plane crossover that hops over a CPW trace."""
 
+import logging
+
 import numpy as np
 
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core import QComponent
+
+logger = logging.getLogger(__name__)
 
 
 class Airbridge(QComponent):
@@ -331,3 +335,141 @@ def route_airbridges(
         )
         made.append(Airbridge(design, f"{name}_{k}", options=opts))
     return made
+
+
+# ---------------------------------------------------------------------------
+# EXPERIMENTAL — 3D airbridges via layer-stack elevation
+#
+# See issue #1144. The 2D crossover above renders flat (z=0). Metal's 3D FEM
+# renderers (``renderer_gmsh`` today; AWS Palace / Ansys as follow-ons) extrude
+# every filled ``(layer, datatype)`` in the design's layer stack by its
+# ``thickness`` at its ``z_coord`` (see ``toolbox_metal/layer_stack_handler.py``
+# and ``renderer_gmsh/gmsh_renderer.py``). Elevating the ``bridge_layer`` in the
+# layer stack is therefore all it takes to lift the flat span into a real 3D
+# bridge — no renderer code, and the same rows feed whichever 3D backend runs.
+# ---------------------------------------------------------------------------
+
+
+def airbridge_layer_stack_rows(
+    bridge_layer=30,
+    pad_layer=31,
+    bridge_z_coord="3um",
+    bridge_thickness="0.3um",
+    pad_thickness="0.2um",
+    material="pec",
+    chip_name="main",
+    datatype=0,
+):
+    """[EXPERIMENTAL] Layer-stack rows giving an :class:`Airbridge` a 3D form.
+
+    Returns the two :class:`~qiskit_metal.toolbox_metal.layer_stack_handler.LayerStackHandler`
+    rows that make the airbridge stand up for FEM meshing: the landing pads sit
+    on the base plane (``z_coord="0um"``) and the span sits ``bridge_z_coord``
+    above it, each extruded by its ``thickness``.
+
+    .. warning::
+
+        **Experimental and only partially validated.** The rows are constructed
+        and unit-tested in pure Python. The resulting 3D *mesh* renders through
+        ``renderer_gmsh`` but has **not** been validated against a live FEM
+        solve, and the pad↔span connection in 3D is not guaranteed. Treat the
+        geometry as a starting point, not a fabrication- or simulation-ready
+        result. Tracking: https://github.com/qiskit-community/qiskit-metal/issues/1144
+
+    Args:
+        bridge_layer (int): layer the elevated span lives on (matches the
+            ``Airbridge`` ``bridge_layer`` option). Defaults to 30.
+        pad_layer (int): layer the base landing pads live on. Defaults to 31.
+        bridge_z_coord (str): elevation of the span above the base plane.
+        bridge_thickness (str): thickness of the elevated span metal.
+        pad_thickness (str): thickness of the base landing-pad metal.
+        material (str): layer-stack material name. Defaults to ``"pec"``.
+        chip_name (str): chip the layers belong to. Defaults to ``"main"``.
+        datatype (int): datatype for both rows. Defaults to 0.
+
+    Returns:
+        list[dict]: two rows keyed by ``LayerStackHandler.Col_Names`` — the
+        pads at the base plane and the span elevated.
+    """
+    return [
+        dict(
+            chip_name=chip_name,
+            layer=int(pad_layer),
+            datatype=int(datatype),
+            material=material,
+            thickness=pad_thickness,
+            z_coord="0um",
+            fill="true",
+        ),
+        dict(
+            chip_name=chip_name,
+            layer=int(bridge_layer),
+            datatype=int(datatype),
+            material=material,
+            thickness=bridge_thickness,
+            z_coord=bridge_z_coord,
+            fill="true",
+        ),
+    ]
+
+
+def apply_airbridge_layer_stack(design, replace=True, **kwargs):
+    """[EXPERIMENTAL] Register the 3D airbridge layer rows on a design's stack.
+
+    Appends the rows from :func:`airbridge_layer_stack_rows` to a
+    ``DesignMultiPlanar`` layer stack (``design.ls.ls_df``) so the gmsh (and
+    future Palace / Ansys) mesh renders the span elevated. This is the
+    renderer-agnostic seam: no renderer code changes, the same rows feed any 3D
+    backend.
+
+    .. note::
+
+        The gmsh renderer also classifies layers as metal vs dielectric via its
+        ``layer_types`` argument. Register the airbridge layers as metal, e.g.
+        ``QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31],
+        dielectric=[3]))``, or ``assign_physical_groups`` raises. (Rendering a
+        full CPW route in 3D separately hits a known gmsh path-fillet fragility
+        with short lead segments — see #1144.)
+
+    .. warning::
+
+        Experimental — see :func:`airbridge_layer_stack_rows`. The elevated
+        geometry renders in gmsh, but no live FEM solve has validated it.
+        Tracking: https://github.com/qiskit-community/qiskit-metal/issues/1144
+
+    Args:
+        design (DesignMultiPlanar): a design exposing a layer stack at
+            ``design.ls`` (i.e. ``DesignMultiPlanar``).
+        replace (bool): if True (default), drop any existing rows for the
+            ``bridge_layer`` / ``pad_layer`` before appending, so re-running is
+            idempotent.
+        **kwargs: forwarded to :func:`airbridge_layer_stack_rows`.
+
+    Returns:
+        pandas.DataFrame: the updated ``design.ls.ls_df``.
+
+    Raises:
+        AttributeError: if ``design`` has no layer stack (``design.ls``), e.g.
+            a plain ``DesignPlanar``.
+    """
+    import pandas as pd
+
+    logger.warning(
+        "apply_airbridge_layer_stack is EXPERIMENTAL: the 3D airbridge mesh has "
+        "not been validated against a live FEM solve (see issue #1144)."
+    )
+
+    ls = getattr(design, "ls", None)
+    if ls is None or getattr(ls, "ls_df", None) is None:
+        raise AttributeError(
+            "3D airbridges need a design with a layer stack (DesignMultiPlanar); "
+            f"{type(design).__name__} exposes none."
+        )
+
+    rows = airbridge_layer_stack_rows(**kwargs)
+    df = ls.ls_df
+    if replace:
+        drop_layers = {r["layer"] for r in rows}
+        df = df[~df["layer"].isin(drop_layers)]
+    ls.ls_df = pd.concat([df, pd.DataFrame(rows)], ignore_index=True)
+    return ls.ls_df

--- a/tests/test_airbridge.py
+++ b/tests/test_airbridge.py
@@ -265,5 +265,111 @@ class TestRouteAirbridges(unittest.TestCase):
             self.assertLess(centerline.distance(Point(x, y)), 1e-6)
 
 
+class TestAirbridge3DLayerStack(unittest.TestCase):
+    """[EXPERIMENTAL] The layer-stack elevation seam for 3D airbridges (#1144).
+
+    Pure-Python coverage of the row construction and the layer-stack mutation;
+    the actual 3D mesh is validated in a gmsh-gated test below."""
+
+    def test_rows_elevate_the_bridge_layer(self):
+        from qiskit_metal.qlibrary.tlines.airbridge import airbridge_layer_stack_rows
+
+        rows = airbridge_layer_stack_rows(
+            bridge_layer=30, pad_layer=31, bridge_z_coord="3um"
+        )
+        self.assertEqual(len(rows), 2)
+        by_layer = {r["layer"]: r for r in rows}
+        # pads on the base plane, span elevated
+        self.assertEqual(by_layer[31]["z_coord"], "0um")
+        self.assertEqual(by_layer[30]["z_coord"], "3um")
+        # every row carries the columns the LayerStackHandler expects
+        from qiskit_metal.toolbox_metal.layer_stack_handler import LayerStackHandler
+
+        for r in rows:
+            self.assertEqual(set(r), set(LayerStackHandler.Col_Names))
+
+    def test_apply_mutates_multiplanar_stack_idempotently(self):
+        from qiskit_metal.designs.design_multiplanar import MultiPlanar
+        from qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack
+
+        design = MultiPlanar()
+        df = apply_airbridge_layer_stack(design, bridge_layer=30, pad_layer=31)
+        self.assertIn(30, set(df["layer"]))
+        self.assertIn(31, set(df["layer"]))
+        n_after_first = len(df)
+        # re-running replaces, not duplicates
+        df2 = apply_airbridge_layer_stack(design, bridge_layer=30, pad_layer=31)
+        self.assertEqual(len(df2), n_after_first)
+        elevated = df2[df2["layer"] == 30]["z_coord"].iloc[0]
+        self.assertEqual(elevated, "3um")
+
+    def test_apply_requires_a_layer_stack(self):
+        from qiskit_metal import designs
+        from qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack
+
+        # DesignPlanar has no layer stack -> clear, early error.
+        with self.assertRaises(AttributeError):
+            apply_airbridge_layer_stack(designs.DesignPlanar())
+
+
+def _gmsh_importable():
+    try:
+        import gmsh  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(
+    _gmsh_importable(), "gmsh not installed (optional [mesh] extra); 3D mesh check"
+)
+class TestAirbridge3DMesh(unittest.TestCase):
+    """[EXPERIMENTAL] Validate the actual 3D extrusion via the gmsh renderer.
+
+    Skipped in the lite CI (no gmsh). Standalone Airbridge polys are used so
+    the check exercises the elevation seam without the gmsh CPW-path fragility
+    (short fillet segments, #1144)."""
+
+    def test_bridge_span_extrudes_elevated(self):
+        import gmsh
+        from qiskit_metal.designs.design_multiplanar import MultiPlanar
+        from qiskit_metal.qlibrary.tlines.airbridge import (
+            Airbridge,
+            apply_airbridge_layer_stack,
+        )
+        from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
+
+        design = MultiPlanar()
+        design.overwrite_enabled = True
+        Airbridge(design, "ab", options=dict(crossover_length="24um"))
+        design.rebuild()
+        apply_airbridge_layer_stack(
+            design,
+            bridge_z_coord="3um",
+            bridge_thickness="0.3um",
+            pad_thickness="0.2um",
+        )
+
+        r = QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31], dielectric=[3]))
+        try:
+            r.render_design(
+                draw_sample_holder=False, mesh_geoms=False, box_plus_buffer=False
+            )
+            zbands = [
+                (gmsh.model.getBoundingBox(d, t)[2], gmsh.model.getBoundingBox(d, t)[5])
+                for d, t in gmsh.model.getEntities(3)
+            ]
+        finally:
+            r.close()
+
+        # bridge span elevated near z=3um (0.003mm); pads on the base plane
+        self.assertTrue(any(zmin >= 0.0029 for zmin, _ in zbands), zbands)
+        self.assertTrue(
+            any(abs(zmin) < 1e-6 and 0.0 < zmax <= 0.00051 for zmin, zmax in zbands),
+            zbands,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
@@ -712,6 +712,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e3453f40",
+   "source": "## Experimental: 3D airbridges\n\nIn a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\nspan should be *elevated* above the base metal. Metal's 3D renderers extrude\neach layer by the `thickness` / `z_coord` in the design's **layer stack**, so\nlifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\nthe ecosystem matures) AWS Palace or Ansys.\n\n```python\nfrom qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack\n\n# design must be a DesignMultiPlanar (it carries a layer stack)\napply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", bridge_thickness=\"0.3um\")\n# then render 3D with the airbridge layers marked metal, e.g.\n#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31], dielectric=[3]))\n```\n\n> ⚠️ **Experimental.** The elevated geometry renders in gmsh, but the 3D mesh\n> has **not** been validated against a live FEM solve, and rendering a full\n> CPW *route* in 3D currently hits a separate gmsh path-fillet limitation.\n> Follow / help validate in\n> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab-closing",
    "metadata": {},
    "source": [


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Implements the first increment of #1144 (Phase 4 of the airbridge work, #1138). Stays on the open-source FEM path; does not touch `renderer_ansys*`.

### Did you add tests to cover your changes (yes/no)?

Yes — `tests/test_airbridge.py`: pure-Python row/stack tests plus a gmsh-gated 3D-mesh test (skipped in the lite CI, which has no gmsh).

### Did you update the documentation accordingly (yes/no)?

Yes — tutorial 2.15 gains an "Experimental: 3D airbridges" section (both folder copies in sync). Docstrings carry `.. warning::` experimental notes.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

The `Airbridge` crossover renders flat (z=0) in `qm.view` and GDS. For 3D FEM the span should be *elevated*. Metal's 3D renderers already extrude each `(layer, datatype)` by its `thickness` at its `z_coord` from the design's `LayerStackHandler`, so **elevating the `bridge_layer` in the layer stack is all it takes** — no renderer code, and the same rows feed gmsh today and AWS Palace / Ansys later. This keeps both directions open while picking the easier (open-source) one now.

### Details and comments

Two pure-Python helpers in `qlibrary/tlines/airbridge.py`:

- `airbridge_layer_stack_rows(...)` — the two `LayerStackHandler` rows: pads at the base plane, span elevated by `bridge_z_coord`, each with a `thickness`.
- `apply_airbridge_layer_stack(design, ...)` — registers them on a `DesignMultiPlanar` layer stack (`design.ls.ls_df`), idempotently.

Both are marked **experimental** (docstring `.. warning::` + a runtime log warning).

**Validated:** row construction, the layer-stack mutation, and — via a gmsh-gated test — that the span actually extrudes elevated (span volume at z≈3.0–3.3 µm, pads at 0–0.2 µm) through the real `QGmshRenderer`.

**Not validated (tracked in #1144):** any live FEM solve, and whether the elevated span + base pads form one connected conductor in 3D. Two integration findings are recorded in the issue: the airbridge layers must be added to the gmsh renderer's `layer_types["metal"]`, and the gmsh CPW *path* renderer fails on short fillet segments (same class as #1141), so full routes don't yet render in 3D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_