### PR TITLE
Fix gmsh 3D render of routes with sub-width lead segments (#1144)

### DIFF
--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -23,6 +23,7 @@ from qiskit_metal.renderers.renderer_gmsh.gmsh_utils import (
     Vec3D,
     Vec3DArray,
     line_width_offset_pts,
+    remove_degenerate_segments,
     render_path_curves,
 )
 from qiskit_metal.toolbox_metal.bounds_for_path_and_poly_tables import (
@@ -529,15 +530,18 @@ class QGmshRenderer(QRenderer):
             layer_num=path.layer
         )
 
-        vecs = Vec3DArray.make_vec3DArray(
-            self.parse_units_gmsh(list(qc_shapely.coords)), qc_z
-        )
+        # Drop sub-width lead stubs (e.g. a route's short pin segments): they
+        # collapse the width-offset geometry and make Gmsh reject a zero-length
+        # line. Endpoints are preserved. See remove_degenerate_segments.
+        coords = remove_degenerate_segments(list(qc_shapely.coords), qc_width)
+
+        vecs = Vec3DArray.make_vec3DArray(self.parse_units_gmsh(coords), qc_z)
         qc_name = (
             self.design._components[path["component"]].name
             + "_"
             + clean_name(path["name"])
         )
-        bad_fillets = bad_fillet_idxs(qc_shapely.coords, qc_fillet)
+        bad_fillets = bad_fillet_idxs(coords, qc_fillet)
         curves = render_path_curves(vecs, qc_z, qc_fillet, qc_width, bad_fillets)
         surface = self.make_general_surface(curves)
 

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
@@ -272,6 +272,47 @@ def transform_arc_points(pts: list, translate: np.ndarray, path_vecs: list) -> l
     return new_pts
 
 
+def remove_degenerate_segments(coords: list, min_len: float) -> list:
+    """Drop interior vertices that would create a segment shorter than
+    ``min_len``, always preserving the two endpoints.
+
+    A CPW path segment shorter than the conductor's own width collapses the
+    width-offset geometry in :func:`render_path_curves`: the two offset points
+    of adjacent vertices coincide, and Gmsh rejects the resulting zero-length
+    line (``Could not create line``). Routes routinely add such sub-width lead
+    stubs at their pins (e.g. a 5 um stub on a 10 um trace), so a plain
+    ``RouteMeander`` fails to render in 3D. Dropping those vertices keeps both
+    endpoints and changes the trace length only negligibly — the same
+    short-segment cleanup the GDS and matplotlib paths already do.
+
+    Args:
+        coords (list): ordered ``(x, y[, z])`` path vertices (design units).
+        min_len (float): minimum allowed segment length (same units). Typically
+            the conductor width; segments shorter than this are degenerate for
+            meshing.
+
+    Returns:
+        list: the cleaned vertex list (endpoints preserved).
+    """
+    pts = [tuple(c) for c in coords]
+    if len(pts) <= 2 or min_len <= 0:
+        return pts
+
+    out = [pts[0]]
+    for p in pts[1:-1]:
+        if np.hypot(p[0] - out[-1][0], p[1] - out[-1][1]) >= min_len:
+            out.append(p)
+    # Never drop the final endpoint: if the last kept interior vertex sits
+    # within min_len of it, drop that interior vertex instead.
+    end = pts[-1]
+    while (
+        len(out) >= 2 and np.hypot(end[0] - out[-1][0], end[1] - out[-1][1]) < min_len
+    ):
+        out.pop()
+    out.append(end)
+    return out
+
+
 def draw_curves(
     recent_pts: list, curves1: list, curves2: list
 ) -> Tuple[list, list, list]:

--- a/tests/test_gmsh_path_short_segments.py
+++ b/tests/test_gmsh_path_short_segments.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Gmsh path renderer: short (sub-width) lead segments (#1144).
+
+A route's short pin stubs (e.g. a 5um segment on a 10um trace) collapse the
+width-offset geometry and made Gmsh reject a zero-length line. The
+``remove_degenerate_segments`` cleanup fixes it; endpoints are preserved."""
+
+import unittest
+
+from qiskit_metal.renderers.renderer_gmsh.gmsh_utils import remove_degenerate_segments
+
+
+class TestRemoveDegenerateSegments(unittest.TestCase):
+    """Pure-Python coverage (no gmsh needed)."""
+
+    def test_drops_short_lead_and_trailing_stubs(self):
+        # 5-unit stubs at both ends of a 10-unit-wide conductor.
+        coords = [(0.0, 0.0), (0.005, 0.0), (1.0, 0.0), (1.0, 1.0), (1.0, 1.005)]
+        out = remove_degenerate_segments(coords, min_len=0.01)
+        # endpoints preserved
+        self.assertEqual(out[0], (0.0, 0.0))
+        self.assertEqual(out[-1], (1.0, 1.005))
+        # the two sub-min_len stub vertices are gone
+        self.assertNotIn((0.005, 0.0), out)
+        self.assertEqual(len(out), 3)
+
+    def test_noop_when_all_segments_long_enough(self):
+        coords = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0)]
+        out = remove_degenerate_segments(coords, min_len=0.01)
+        self.assertEqual([tuple(p) for p in out], coords)
+
+    def test_preserves_final_endpoint_even_if_last_segment_short(self):
+        # last real vertex sits within min_len of the endpoint -> drop the
+        # interior vertex, never the endpoint.
+        coords = [(0.0, 0.0), (1.0, 0.0), (1.001, 0.0)]
+        out = remove_degenerate_segments(coords, min_len=0.01)
+        self.assertEqual(out[0], (0.0, 0.0))
+        self.assertEqual(out[-1], (1.001, 0.0))
+        self.assertEqual(len(out), 2)
+
+    def test_degenerate_inputs(self):
+        self.assertEqual(remove_degenerate_segments([(0, 0)], 0.01), [(0, 0)])
+        self.assertEqual(
+            remove_degenerate_segments([(0, 0), (1, 0)], 0.0), [(0, 0), (1, 0)]
+        )
+
+
+def _gmsh_importable():
+    try:
+        import gmsh  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(
+    _gmsh_importable(), "gmsh not installed (optional [mesh] extra); 3D render check"
+)
+class TestMeanderRendersIn3D(unittest.TestCase):
+    """A RouteMeander adds short pin stubs; before #1144 it crashed the gmsh
+    path renderer with 'Could not create line'. Skipped in the lite CI."""
+
+    def test_meander_with_short_stubs_renders(self):
+        import gmsh
+        from qiskit_metal.designs.design_multiplanar import MultiPlanar
+        from qiskit_metal import Dict
+        from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+        from qiskit_metal.qlibrary.tlines.meandered import RouteMeander
+        from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
+
+        design = MultiPlanar()
+        design.overwrite_enabled = True
+        OpenToGround(design, "A", options=dict(pos_x="-0.6mm", orientation="0"))
+        OpenToGround(design, "B", options=dict(pos_x="0.6mm", orientation="180"))
+        RouteMeander(
+            design,
+            "cpw",
+            options=Dict(
+                pin_inputs=Dict(
+                    start_pin=Dict(component="A", pin="open"),
+                    end_pin=Dict(component="B", pin="open"),
+                ),
+                total_length="4mm",
+                fillet="90um",
+                trace_width="10um",
+                trace_gap="6um",
+                meander=Dict(spacing="0.3mm"),
+            ),
+        )
+        design.rebuild()
+
+        r = QGmshRenderer(design, layer_types=dict(metal=[1], dielectric=[3]))
+        try:
+            r.render_design(
+                draw_sample_holder=False, mesh_geoms=False, box_plus_buffer=False
+            )
+            n_volumes = len(gmsh.model.getEntities(3))
+        finally:
+            r.close()
+        self.assertGreater(n_volumes, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Resolves finding #2 in #1144 (the gmsh CPW-path short-segment failure).

### Did you add tests to cover your changes (yes/no)?

Yes — `tests/test_gmsh_path_short_segments.py`: pure-Python coverage of the cleanup plus a gmsh-gated 3D-render test (skipped in the lite CI, which has no gmsh).

### Did you update the documentation accordingly (yes/no)?

N/A — bug fix; the behavior is documented in the new helper's docstring.

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

Rendering a `RouteMeander` (or any route whose pin lead stubs are shorter than the trace width) through `QGmshRenderer` raised `Could not create line`. A route's short lead segment (e.g. 5 µm on a 10 µm trace — exactly half-width) collapses the width-offset geometry in `render_path_curves`: the two offset points of adjacent vertices coincide, and Gmsh rejects the resulting zero-length line.

### Details and comments

`remove_degenerate_segments()` (new, in `gmsh_utils.py`) drops interior path vertices that would create a segment shorter than the conductor width, always preserving the two endpoints. `render_element_path` applies it before building the curve geometry. This mirrors the short-segment cleanup the GDS/matplotlib paths already do; it only ever removes sub-width (degenerate-for-meshing) segments and changes the trace length negligibly (~0.2 % on the meander tested, endpoints unchanged).

Validated with gmsh installed locally: the previously-failing meander now renders in 3D (the fix is a no-op for routes without short stubs). Full test suite shows no new failures (the pre-existing Ansys/pyEPR failures in a gmsh-less lite venv are unrelated).

**Scope note:** a *full* route + airbridge 3D scene still fails later, in `fragment_interfaces`, because the elevated span is unsupported (no posts tying it to the base plane) — that's the separate 3D-connectivity item tracked in #1144, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_