### PR TITLE
Airbridge support posts: connect the elevated span for 3D (#1144)

### DIFF
--- a/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
+++ b/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
@@ -836,30 +836,7 @@
    "cell_type": "markdown",
    "id": "e3453f40",
    "metadata": {},
-   "source": [
-    "## Experimental: 3D airbridges\n",
-    "\n",
-    "In a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\n",
-    "span should be *elevated* above the base metal. Metal's 3D renderers extrude\n",
-    "each layer by the `thickness` / `z_coord` in the design's **layer stack**, so\n",
-    "lifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\n",
-    "the ecosystem matures) AWS Palace or Ansys.\n",
-    "\n",
-    "```python\n",
-    "from qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack\n",
-    "\n",
-    "# design must be a DesignMultiPlanar (it carries a layer stack)\n",
-    "apply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", bridge_thickness=\"0.3um\")\n",
-    "# then render 3D with the airbridge layers marked metal, e.g.\n",
-    "#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31], dielectric=[3]))\n",
-    "```\n",
-    "\n",
-    "> ⚠️ **Experimental.** The elevated geometry renders in gmsh, but the 3D mesh\n",
-    "> has **not** been validated against a live FEM solve, and rendering a full\n",
-    "> CPW *route* in 3D currently hits a separate gmsh path-fillet limitation.\n",
-    "> Follow / help validate in\n",
-    "> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144)."
-   ]
+   "source": "## Experimental: 3D airbridges\n\nIn a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\nspan should be *elevated* above the base metal. Metal's 3D renderers extrude\neach layer by the `thickness` / `z_coord` in the design's **layer stack**, so\nlifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\nthe ecosystem matures) AWS Palace or Ansys.\n\nTo keep the elevated span connected to the base metal (so the design meshes as\none conductor rather than a floating bar), the airbridges also grow **support\nposts** that rise from the pads to the span — enabled with `enable_posts`, and\ngiven a height by the matching layer-stack row:\n\n```python\nfrom qiskit_metal.qlibrary.tlines.airbridge import (\n    route_airbridges,\n    apply_airbridge_layer_stack,\n)\n\n# design must be a DesignMultiPlanar (it carries a layer stack)\nroute_airbridges(design, cpw, pitch=\"0.3mm\", enable_posts=True)\napply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", include_posts=True)\n# then render 3D with the airbridge layers marked metal, e.g.\n#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31, 32], dielectric=[3]))\n```\n\nThe schematic below (drawn to scale) shows the resulting shape: the elevated\nspan on two posts, hopping over the CPW.\n\n> ⚠️ **Experimental.** A full CPW + airbridges (with posts) renders and meshes\n> in gmsh as a connected 3D solid, but the mesh has **not** been validated\n> against a live FEM solve. Follow / help validate in\n> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144)."
   },
   {
    "cell_type": "code",

--- a/src/qiskit_metal/qlibrary/tlines/airbridge.py
+++ b/src/qiskit_metal/qlibrary/tlines/airbridge.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from qiskit_metal import draw, Dict
 from qiskit_metal.qlibrary.core import QComponent
+from qiskit_metal.toolbox_metal.parsing import is_true
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,13 @@ class Airbridge(QComponent):
         * pad_length: '11um' -- Length of each base landing pad (along the CPW).
         * bridge_layer: '30' -- Layer of the elevated bridge span.
         * pad_layer: '31' -- Layer of the two base landing pads.
+        * enable_posts: 'False' -- Emit two support-post feet on ``post_layer``
+          where the span meets each pad. In a planar view these coincide with
+          the pad/span overlap; their purpose is the 3D mesh, where the posts
+          (on a layer stacked between pad and span heights) join the elevated
+          span to the base metal into one connected conductor.
+        * post_layer: '32' -- Layer of the support posts (used only when
+          ``enable_posts``).
     """
 
     default_options = Dict(
@@ -59,6 +67,8 @@ class Airbridge(QComponent):
         pad_length="11um",
         bridge_layer="30",
         pad_layer="31",
+        enable_posts="False",
+        post_layer="32",
     )
     """Default drawing options"""
 
@@ -88,16 +98,32 @@ class Airbridge(QComponent):
         # feet and forms a single connected conductor once fabricated.
         span = draw.rectangle(crossover_length + pad_length, bridge_width, 0, 0)
 
+        # Optional support posts: the span-over-pad overlap, emitted on their
+        # own layer so a 3D layer stack can bridge the z-gap between the base
+        # pads and the elevated span (see route_airbridges / the 3D helpers).
+        posts = None
+        if is_true(p.enable_posts):
+            left_post = draw.rectangle(pad_length, bridge_width, -pad_offset, 0)
+            right_post = draw.rectangle(pad_length, bridge_width, +pad_offset, 0)
+            posts = draw.union(left_post, right_post)
+
         # Reposition the whole crossover.
-        geom = [span, pads]
+        geom = [span, pads] + ([posts] if posts is not None else [])
         geom = draw.rotate(geom, p.orientation, origin=(0, 0))
         geom = draw.translate(geom, p.pos_x, p.pos_y)
-        span, pads = geom
+        if posts is not None:
+            span, pads, posts = geom
+        else:
+            span, pads = geom
 
         self.add_qgeometry(
             "poly", {"bridge": span}, layer=p.bridge_layer, subtract=False
         )
         self.add_qgeometry("poly", {"pads": pads}, layer=p.pad_layer, subtract=False)
+        if posts is not None:
+            self.add_qgeometry(
+                "poly", {"posts": posts}, layer=p.post_layer, subtract=False
+            )
 
 
 def _fillet_corner(vertex_start, vertex_corner, vertex_end, radius, points):
@@ -242,6 +268,7 @@ def route_airbridges(
     min_spacing="5um",
     crossover_length=None,
     bridge_at_corners=False,
+    enable_posts=False,
     name=None,
     ab_options=None,
 ):
@@ -272,6 +299,10 @@ def route_airbridges(
             ``min_spacing`` of an end are skipped. Defaults to false (uniform
             pitch only — bends are still covered wherever a pitch sample lands
             on the fillet arc).
+        enable_posts (bool): emit support posts on each airbridge (the
+            ``Airbridge`` ``enable_posts`` option) so a 3D layer stack can join
+            the elevated span to the base metal. Defaults to false. Pair with
+            :func:`apply_airbridge_layer_stack` ``include_posts=True``.
         name (str, optional): prefix for the created components. Defaults to
             ``f"{route.name}_ab"``.
         ab_options (dict, optional): extra options forwarded to each
@@ -283,6 +314,8 @@ def route_airbridges(
     pitch = design.parse_value(pitch)
     min_spacing = design.parse_value(min_spacing)
     ab_options = dict(ab_options or {})
+    if enable_posts:
+        ab_options.setdefault("enable_posts", "True")
     name = name or f"{route.name}_ab"
 
     fillet = 0.0
@@ -359,22 +392,30 @@ def airbridge_layer_stack_rows(
     material="pec",
     chip_name="main",
     datatype=0,
+    include_posts=False,
+    post_layer=32,
 ):
     """[EXPERIMENTAL] Layer-stack rows giving an :class:`Airbridge` a 3D form.
 
-    Returns the two :class:`~qiskit_metal.toolbox_metal.layer_stack_handler.LayerStackHandler`
+    Returns the :class:`~qiskit_metal.toolbox_metal.layer_stack_handler.LayerStackHandler`
     rows that make the airbridge stand up for FEM meshing: the landing pads sit
     on the base plane (``z_coord="0um"``) and the span sits ``bridge_z_coord``
     above it, each extruded by its ``thickness``.
 
+    With ``include_posts`` a third row is added for the support posts, extruded
+    from the base plane up to the span (``thickness=bridge_z_coord``) so the
+    elevated span is joined to the base metal into one connected conductor —
+    required for the 3D mesh of a full CPW + airbridges to render (the span
+    otherwise floats and the boolean fragmentation fails). Pair it with
+    ``Airbridge(..., enable_posts=True)`` (or ``route_airbridges(...,
+    enable_posts=True)``) so post *geometry* exists on ``post_layer``.
+
     .. warning::
 
-        **Experimental and only partially validated.** The rows are constructed
-        and unit-tested in pure Python. The resulting 3D *mesh* renders through
-        ``renderer_gmsh`` but has **not** been validated against a live FEM
-        solve, and the pad↔span connection in 3D is not guaranteed. Treat the
-        geometry as a starting point, not a fabrication- or simulation-ready
-        result. Tracking: https://github.com/qiskit-community/qiskit-metal/issues/1144
+        **Experimental.** The elevated + connected geometry renders and meshes
+        through ``renderer_gmsh``, but has **not** been validated against a live
+        FEM solve. Treat it as a starting point, not a simulation-ready result.
+        Tracking: https://github.com/qiskit-community/qiskit-metal/issues/1144
 
     Args:
         bridge_layer (int): layer the elevated span lives on (matches the
@@ -386,12 +427,15 @@ def airbridge_layer_stack_rows(
         material (str): layer-stack material name. Defaults to ``"pec"``.
         chip_name (str): chip the layers belong to. Defaults to ``"main"``.
         datatype (int): datatype for both rows. Defaults to 0.
+        include_posts (bool): also add a support-post row (see above).
+        post_layer (int): layer the posts live on (matches ``Airbridge``
+            ``post_layer``). Defaults to 32.
 
     Returns:
-        list[dict]: two rows keyed by ``LayerStackHandler.Col_Names`` — the
-        pads at the base plane and the span elevated.
+        list[dict]: rows keyed by ``LayerStackHandler.Col_Names`` — pads at the
+        base plane, the elevated span, and (if ``include_posts``) the posts.
     """
-    return [
+    rows = [
         dict(
             chip_name=chip_name,
             layer=int(pad_layer),
@@ -411,6 +455,20 @@ def airbridge_layer_stack_rows(
             fill="true",
         ),
     ]
+    if include_posts:
+        # Posts rise from the base plane to the span bottom, connecting them.
+        rows.append(
+            dict(
+                chip_name=chip_name,
+                layer=int(post_layer),
+                datatype=int(datatype),
+                material=material,
+                thickness=bridge_z_coord,
+                z_coord="0um",
+                fill="true",
+            )
+        )
+    return rows
 
 
 def apply_airbridge_layer_stack(design, replace=True, **kwargs):

--- a/tests/test_airbridge.py
+++ b/tests/test_airbridge.py
@@ -99,6 +99,30 @@ class TestAirbridge(unittest.TestCase):
         # airbridge layers (>1) render above the base layer's z-order of ~1.0
         self.assertGreater(max(zorders), 1.0)
 
+    def test_posts_are_opt_in(self):
+        """enable_posts defaults off (span + pads only); turning it on adds
+        support-post geometry on post_layer."""
+        Airbridge(self.design, "off", options=dict(bridge_layer="30", pad_layer="31"))
+        self.design.rebuild()
+        off_layers = set(self.design.qgeometry.tables["poly"]["layer"].tolist())
+        self.assertEqual(off_layers, {30, 31})
+
+        d2 = designs.DesignPlanar()
+        Airbridge(
+            d2,
+            "on",
+            options=dict(
+                bridge_layer="30", pad_layer="31", post_layer="32", enable_posts="True"
+            ),
+        )
+        d2.rebuild()
+        on = d2.qgeometry.tables["poly"]
+        self.assertIn(32, set(on["layer"].tolist()))
+        # the post geometry on post_layer is non-degenerate
+        posts = on[on["layer"] == 32]
+        self.assertGreater(len(posts), 0)
+        self.assertGreater(sum(g.area for g in posts["geometry"]), 0.0)
+
 
 class TestRouteAirbridges(unittest.TestCase):
     """Auto-placement of airbridges along a route (route_airbridges)."""
@@ -311,6 +335,19 @@ class TestAirbridge3DLayerStack(unittest.TestCase):
         with self.assertRaises(AttributeError):
             apply_airbridge_layer_stack(designs.DesignPlanar())
 
+    def test_include_posts_adds_a_connecting_row(self):
+        """include_posts adds a post row rising from the base plane
+        (z_coord=0) to the span (thickness=bridge_z_coord), joining them."""
+        from qiskit_metal.qlibrary.tlines.airbridge import airbridge_layer_stack_rows
+
+        rows = airbridge_layer_stack_rows(
+            bridge_z_coord="3um", include_posts=True, post_layer=32
+        )
+        self.assertEqual(len(rows), 3)
+        post = next(r for r in rows if r["layer"] == 32)
+        self.assertEqual(post["z_coord"], "0um")
+        self.assertEqual(post["thickness"], "3um")
+
 
 def _gmsh_importable():
     try:
@@ -369,6 +406,62 @@ class TestAirbridge3DMesh(unittest.TestCase):
             any(abs(zmin) < 1e-6 and 0.0 < zmax <= 0.00051 for zmin, zmax in zbands),
             zbands,
         )
+
+    def test_full_route_with_posts_renders_in_3d(self):
+        """A CPW route + airbridges with support posts renders in 3D: the posts
+        join the elevated span to the base metal so the design meshes (#1144).
+        Also checks a post volume spans the base-to-span z-gap."""
+        import gmsh
+        from qiskit_metal import Dict
+        from qiskit_metal.designs.design_multiplanar import MultiPlanar
+        from qiskit_metal.qlibrary.terminations.open_to_ground import OpenToGround
+        from qiskit_metal.qlibrary.tlines.straight_path import RouteStraight
+        from qiskit_metal.qlibrary.tlines.airbridge import (
+            route_airbridges,
+            apply_airbridge_layer_stack,
+        )
+        from qiskit_metal.renderers.renderer_gmsh.gmsh_renderer import QGmshRenderer
+
+        design = MultiPlanar()
+        design.overwrite_enabled = True
+        OpenToGround(design, "A", options=dict(pos_x="-0.4mm", orientation="0"))
+        OpenToGround(design, "B", options=dict(pos_x="0.4mm", orientation="180"))
+        cpw = RouteStraight(
+            design,
+            "cpw",
+            options=Dict(
+                pin_inputs=Dict(
+                    start_pin=Dict(component="A", pin="open"),
+                    end_pin=Dict(component="B", pin="open"),
+                ),
+                trace_width="10um",
+                trace_gap="6um",
+            ),
+        )
+        design.rebuild()
+        route_airbridges(
+            design, cpw, pitch="0.25mm", min_spacing="30um", enable_posts=True
+        )
+        design.rebuild()
+        apply_airbridge_layer_stack(design, bridge_z_coord="3um", include_posts=True)
+
+        r = QGmshRenderer(
+            design, layer_types=dict(metal=[1, 30, 31, 32], dielectric=[3])
+        )
+        try:
+            r.render_design(mesh_geoms=False)  # default sample-holder path
+            zbands = [
+                (gmsh.model.getBoundingBox(d, t)[2], gmsh.model.getBoundingBox(d, t)[5])
+                for d, t in gmsh.model.getEntities(3)
+            ]
+        finally:
+            r.close()
+
+        self.assertGreater(len(zbands), 0)
+        # the elevated span exists (a volume reaching ~3um) and the base plane
+        # exists — i.e. the full route + airbridges meshed as a 3D solid.
+        self.assertTrue(any(zmax >= 0.0029 for _, zmax in zbands), zbands)
+        self.assertTrue(any(abs(zmin) < 1e-6 for zmin, _ in zbands), zbands)
 
 
 if __name__ == "__main__":

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
@@ -836,30 +836,7 @@
    "cell_type": "markdown",
    "id": "e3453f40",
    "metadata": {},
-   "source": [
-    "## Experimental: 3D airbridges\n",
-    "\n",
-    "In a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\n",
-    "span should be *elevated* above the base metal. Metal's 3D renderers extrude\n",
-    "each layer by the `thickness` / `z_coord` in the design's **layer stack**, so\n",
-    "lifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\n",
-    "the ecosystem matures) AWS Palace or Ansys.\n",
-    "\n",
-    "```python\n",
-    "from qiskit_metal.qlibrary.tlines.airbridge import apply_airbridge_layer_stack\n",
-    "\n",
-    "# design must be a DesignMultiPlanar (it carries a layer stack)\n",
-    "apply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", bridge_thickness=\"0.3um\")\n",
-    "# then render 3D with the airbridge layers marked metal, e.g.\n",
-    "#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31], dielectric=[3]))\n",
-    "```\n",
-    "\n",
-    "> ⚠️ **Experimental.** The elevated geometry renders in gmsh, but the 3D mesh\n",
-    "> has **not** been validated against a live FEM solve, and rendering a full\n",
-    "> CPW *route* in 3D currently hits a separate gmsh path-fillet limitation.\n",
-    "> Follow / help validate in\n",
-    "> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144)."
-   ]
+   "source": "## Experimental: 3D airbridges\n\nIn a planar view and in GDS the crossover is flat (z = 0). For 3D FEM the\nspan should be *elevated* above the base metal. Metal's 3D renderers extrude\neach layer by the `thickness` / `z_coord` in the design's **layer stack**, so\nlifting the `bridge_layer` is all it takes — the same rows feed gmsh, and (as\nthe ecosystem matures) AWS Palace or Ansys.\n\nTo keep the elevated span connected to the base metal (so the design meshes as\none conductor rather than a floating bar), the airbridges also grow **support\nposts** that rise from the pads to the span — enabled with `enable_posts`, and\ngiven a height by the matching layer-stack row:\n\n```python\nfrom qiskit_metal.qlibrary.tlines.airbridge import (\n    route_airbridges,\n    apply_airbridge_layer_stack,\n)\n\n# design must be a DesignMultiPlanar (it carries a layer stack)\nroute_airbridges(design, cpw, pitch=\"0.3mm\", enable_posts=True)\napply_airbridge_layer_stack(design, bridge_z_coord=\"3um\", include_posts=True)\n# then render 3D with the airbridge layers marked metal, e.g.\n#   QGmshRenderer(design, layer_types=dict(metal=[1, 30, 31, 32], dielectric=[3]))\n```\n\nThe schematic below (drawn to scale) shows the resulting shape: the elevated\nspan on two posts, hopping over the CPW.\n\n> ⚠️ **Experimental.** A full CPW + airbridges (with posts) renders and meshes\n> in gmsh as a connected 3D solid, but the mesh has **not** been validated\n> against a live FEM solve. Follow / help validate in\n> [issue #1144](https://github.com/qiskit-community/qiskit-metal/issues/1144)."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
### What are the issues this pull addresses (issue numbers / links)?

Implements the 3D-connectivity step of #1144.

### Did you add tests to cover your changes (yes/no)?

Yes — `tests/test_airbridge.py`: opt-in post geometry, the layer-stack post row, and a gmsh-gated full-route 3D render (skipped in the lite CI).

### Did you update the documentation accordingly (yes/no)?

Yes — tutorial 2.15's experimental section documents the posts (the 3D schematic already shows them).

### Did you read the CONTRIBUTING document (yes/no)?

Yes.

### Summary

The experimental 3D airbridge (#1145) elevated the bridge span above the base metal but left it **floating** — disconnected from the landing pads — so the 3D mesh of a full CPW + airbridges was not one conductor. This adds **opt-in support posts** that join the span to the base.

### Details and comments

- `Airbridge` gains `enable_posts` (default `False`) + `post_layer` (default `32`). When enabled, `make()` emits the span-over-pad overlap on `post_layer`. **Default behaviour is unchanged** — a plain airbridge is still span + pads on two layers, and the 2D / GDS output is identical.
- `airbridge_layer_stack_rows(..., include_posts=True)` adds a post row rising from the base plane (`z_coord=0`) up to the span (`thickness=bridge_z_coord`), so the post volume overlaps both pad and span and ties them together.
- `route_airbridges(..., enable_posts=True)` forwards the option to each bridge.
- Fixed a boolean-parse bug along the way (`enable_posts="False"` is a truthy string) by gating on `is_true()`.

Validated with gmsh installed: a straight CPW + airbridges with posts now meshes as a **connected 3D solid** (a post volume spans the base-to-span z-gap; 54 volumes vs 21 floating without posts). Still experimental — no live FEM solve has validated the mesh (tracked in #1144).

Note: the earlier `(3,1) is not in list` crash was the renderer's `draw_sample_holder=False` path (an unrelated assumption at `fragment_interfaces`); the default sample-holder path renders fine. Left as a separate observation on #1144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_