### PR TITLE
Tutorial 2.15: add PyVista install note + %pip cell before 3D renders

### DIFF
--- a/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
+++ b/docs/tut/2-From-components-to-chip/2.15-Airbridges.ipynb
@@ -902,6 +902,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 3D pictures below are rendered with **PyVista** (a VTK-based renderer),\n",
+    "which — unlike matplotlib's `mplot3d` — does true depth-sorting, so elevated\n",
+    "and overlapping parts look right. It is an optional extra; install it into\n",
+    "the running kernel with the cell below. PyVista also needs an OpenGL backend:\n",
+    "a desktop session already has one; on a headless machine use `osmesa`/`egl`\n",
+    "VTK wheels or a virtual framebuffer (`xvfb`). The tutorial ships the rendered\n",
+    "images, so you can also just read on without installing anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Optional: install the 3D renderer used by the cells below (skip if you\n",
+    "# already have it). '%pip' installs into this notebook's kernel.\n",
+    "%pip install pyvista"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "989ceb1b",

--- a/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
+++ b/tutorials/2 From components to chip/B. Routing between QComponents/2.15 Airbridges.ipynb
@@ -902,6 +902,30 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The 3D pictures below are rendered with **PyVista** (a VTK-based renderer),\n",
+    "which — unlike matplotlib's `mplot3d` — does true depth-sorting, so elevated\n",
+    "and overlapping parts look right. It is an optional extra; install it into\n",
+    "the running kernel with the cell below. PyVista also needs an OpenGL backend:\n",
+    "a desktop session already has one; on a headless machine use `osmesa`/`egl`\n",
+    "VTK wheels or a virtual framebuffer (`xvfb`). The tutorial ships the rendered\n",
+    "images, so you can also just read on without installing anything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Optional: install the 3D renderer used by the cells below (skip if you\n",
+    "# already have it). '%pip' installs into this notebook's kernel.\n",
+    "%pip install pyvista"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "989ceb1b",


### PR DESCRIPTION
## What changed

The 3D figures in tutorial 2.15 are rendered with PyVista, which is an optional dependency. This adds, right before the first 3D render:

- a short **markdown note** explaining that the 3D renders use PyVista (real depth-sorting, unlike matplotlib's `mplot3d`), that it's optional, and that it needs an OpenGL backend (desktop session, `osmesa`/`egl` VTK wheels, or `xvfb` on a headless box);
- a runnable **`%pip install pyvista`** cell so the reader can install it into the notebook kernel.

The tutorial still ships the rendered images, so the section reads fine without installing anything — this only makes re-running the 3D cells self-service.

Both `tutorials/` and `docs/tut/` copies updated; `check_tutorials_sync.py` passes (56/56). No code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_