### PR TITLE
fix(designs): add Qt event loop to generated standalone scripts

### DIFF
--- a/src/qiskit_metal/designs/design_base.py
+++ b/src/qiskit_metal/designs/design_base.py
@@ -1168,6 +1168,7 @@ gui = MetalGUI(design)
         footer = """
 gui.rebuild()
 gui.autoscale()
+gui.qApp.exec_()
         """
         # all imports at front
         # option -- only the options of the component that are different from the default options are specified.


### PR DESCRIPTION
Scripts generated by `design.to_python_script()` did not include a call to start the Qt event loop. When the exported script was run standalone, the MetalGUI window would appear briefly and close immediately as the Python process exited.

Added `gui.qApp.exec_()` to the generated script footer so the Qt event loop keeps the GUI window open and responsive until the user closes it.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### What are the issues this pull addresses ?

Scripts exported via `design.to_python_script()` are missing the Qt event loop call. When the generated script is saved and run as a standalone `.py` file, the GUI window flashes open and immediately closes.

### Did you add tests to cover your changes ?

No — this is a one-line addition to a string template (the generated script footer). The change only affects the text output of `to_python_script()`, not runtime logic.

### Did you update the documentation accordingly ?

No update needed — the method signature and docstring are unchanged.

### Did you read the CONTRIBUTING document ?

Yes.

### Summary

Added `gui.qApp.exec_()` to the footer template in `QDesign.to_python_script()` so that generated standalone Python scripts start the Qt event loop and keep the MetalGUI window open.

### Details and comments

**Root cause:** The generated footer called `gui.rebuild()` and `gui.autoscale()` but never started the Qt event loop. Without `QApplication.exec_()`, the Python process exits immediately, destroying the GUI window.

**Fix:** Added `gui.qApp.exec_()` as the last line of the generated script footer — the standard Qt pattern for standalone applications.

**Changed file:** `src/qiskit_metal/designs/design_base.py` (1 line added)

```diff
 footer = """
 gui.rebuild()
 gui.autoscale()
+gui.qApp.exec_()
         """
