### PR TITLE
to_python_script: harden the Qt event loop across install variants, and import qiskit_metal (#1157)

### DIFF
--- a/src/qiskit_metal/designs/design_base.py
+++ b/src/qiskit_metal/designs/design_base.py
@@ -1152,6 +1152,15 @@ class QDesign:
     def to_python_script(self, thin=True, printout: bool = False):
         """
         Generates a python script from current chip
+
+        The script is self-contained: it imports ``qiskit_metal`` and every
+        component class it uses, rebuilds the design in a ``MetalGUI``, and --
+        when run standalone (``python my_chip_design.py``) -- starts the Qt
+        event loop so the window stays open. The event loop is guarded on
+        ``__name__ == "__main__"`` and on a live ``QApplication``, so importing
+        the script, or running it where a Qt loop already exists (Jupyter with
+        ``%gui qt``) or where no display is available, does not block or raise.
+
         Args:
             printout (bool): Whether to print the script
 
@@ -1159,6 +1168,7 @@ class QDesign:
             str: Python script for current chip
         """
         header = """
+import qiskit_metal
 from qiskit_metal import designs, MetalGUI
 
 design = designs.DesignPlanar()
@@ -1168,8 +1178,18 @@ gui = MetalGUI(design)
         footer = """
 gui.rebuild()
 gui.autoscale()
-gui.qApp.exec_()
-        """
+
+# Keep the MetalGUI window open when this file is run as a standalone script
+# (``python my_chip_design.py``). Without an event loop the process exits
+# immediately and the window disappears.
+#
+# Guarded on __main__ so that importing this file -- or executing it inside a
+# session that already runs a Qt loop (Jupyter/IPython with ``%gui qt``) --
+# does not block the caller. ``gui.qApp`` may be None if no QApplication could
+# be created (e.g. a headless machine), so check before calling into it.
+if __name__ == "__main__" and gui.qApp is not None:
+    gui.qApp.exec()
+"""
         # all imports at front
         # option -- only the options of the component that are different from the default options are specified.
         # vertically aligned dictionary (pretty print)

--- a/tests/test_to_python_script.py
+++ b/tests/test_to_python_script.py
@@ -66,13 +66,35 @@ def _make_design_with_numpy_array_option() -> "designs.DesignPlanar":
     return design
 
 
+class _StubQApp:
+    """Stand-in for the ``QApplication`` at ``MetalGUI.qApp``.
+
+    Records whether the exported script started the event loop instead of
+    actually blocking on one, so the exec-based tests stay non-blocking and
+    runnable on the lite install.
+    """
+
+    def __init__(self):
+        self.exec_calls = 0
+
+    def exec(self):
+        self.exec_calls += 1
+        return 0
+
+
 class _StubMetalGUI:
     """No-op stand-in for ``MetalGUI`` so the exported script's
     ``gui = MetalGUI(design); gui.rebuild(); gui.autoscale()`` calls
-    don't try to construct a Qt window in the test process."""
+    don't try to construct a Qt window in the test process.
 
-    def __init__(self, design):  # noqa: D401
+    ``qApp`` mirrors the real ``MetalGUI`` attribute (set in
+    ``main_window_base._setup_qApp``); pass ``qapp=None`` to emulate a
+    headless machine where no ``QApplication`` could be created.
+    """
+
+    def __init__(self, design, qapp: "_StubQApp | None" = None):  # noqa: D401
         self.design = design
+        self.qApp = _StubQApp() if qapp is None else qapp
 
     def rebuild(self):
         pass
@@ -81,7 +103,19 @@ class _StubMetalGUI:
         pass
 
 
-def _exec_exported_script(script: str) -> dict:
+class _StubMetalGUINoQApp(_StubMetalGUI):
+    """``MetalGUI`` whose ``qApp`` is None -- the headless case."""
+
+    def __init__(self, design):
+        super().__init__(design)
+        self.qApp = None
+
+
+def _exec_exported_script(
+    script: str,
+    run_name: str = "__exported__",
+    gui_cls: type = _StubMetalGUI,
+) -> dict:
     """Execute ``script`` in a clean namespace with ``MetalGUI`` stubbed.
 
     The patch must target the ``qiskit_metal`` MODULE attribute -- the
@@ -91,15 +125,20 @@ def _exec_exported_script(script: str) -> dict:
     than ``import qiskit_metal``) to avoid the dual ``import`` /
     ``from import`` style smell on the same package.
 
+    ``run_name`` sets the script's ``__name__``; pass ``"__main__"`` to
+    exercise the standalone-run path that starts the Qt event loop.
+    ``gui_cls`` swaps in a different ``MetalGUI`` stub (e.g. the headless
+    no-``qApp`` variant).
+
     Returns the resulting global namespace so tests can inspect what was
     bound (e.g. ``design``, ``gui``). Re-raises any exception so the
     failing test reports the actual error.
     """
     qm = sys.modules["qiskit_metal"]
     original = qm.__dict__.get("MetalGUI", None)
-    qm.MetalGUI = _StubMetalGUI
+    qm.MetalGUI = gui_cls
     try:
-        ns: dict = {"__name__": "__exported__"}
+        ns: dict = {"__name__": run_name}
         exec(compile(script, "<exported.metal.py>", "exec"), ns)
         return ns
     finally:
@@ -139,6 +178,99 @@ class TestToPythonScriptStructure(unittest.TestCase):
             self.fail(
                 f"to_python_script output is not valid Python:\n{e}\n\nScript:\n{script}"
             )
+
+
+class TestQiskitMetalImport(unittest.TestCase):
+    """Issue #1157 — the generated script must ``import qiskit_metal``.
+
+    When a component's ``name`` is not a valid Python identifier,
+    ``QComponent.to_script`` falls back to a variable name built from the
+    component's full module path (``qiskit_metal.qlibrary...<random>``). Without
+    a top-level ``import qiskit_metal`` the exported script then raises
+    ``NameError: name 'qiskit_metal' is not defined`` on that assignment.
+    """
+
+    @staticmethod
+    def _design_with_non_identifier_name() -> "designs.DesignPlanar":
+        # A name starting with a digit is not a valid identifier, so
+        # to_script uses the module-path fallback that references qiskit_metal.
+        design = designs.DesignPlanar()
+        TransmonPocket(design, "7q", options=dict(connection_pads=dict(a=dict())))
+        return design
+
+    def test_script_imports_qiskit_metal(self):
+        """The header must import ``qiskit_metal`` outright, not only
+        ``from qiskit_metal import ...`` (regression of issue #1157)."""
+        script = self._design_with_non_identifier_name().to_python_script()
+        self.assertIn("import qiskit_metal", script)
+
+    def test_non_identifier_name_executes_without_NameError(self):
+        """The reporter's failure was a NameError on a
+        ``qiskit_metal.qlibrary...`` assignment. Exec the script and assert it
+        completes."""
+        script = self._design_with_non_identifier_name().to_python_script()
+        # sanity: the fallback path that needs the import is actually taken
+        self.assertIn("qiskit_metal.qlibrary", script)
+        try:
+            _exec_exported_script(script)
+        except NameError as e:
+            self.fail(
+                f"Exported script raised NameError -- regression of #1157: {e}\n\n"
+                f"Script:\n{script}"
+            )
+
+
+class TestQtEventLoop(unittest.TestCase):
+    """PR #1159 — the exported script starts a Qt event loop so a standalone
+    run keeps the window open, but must stay safe on every install variant.
+
+    The loop is guarded on ``__name__ == "__main__"`` and on ``gui.qApp`` being
+    non-None, so that:
+
+    * ``python my_chip_design.py`` blocks on the loop (window stays open),
+    * importing the file, or exec'ing it inside a session that already runs a
+      Qt loop (Jupyter/IPython ``%gui qt``), does NOT block,
+    * a headless machine where no ``QApplication`` could be built (``qApp`` is
+      None) doesn't ``AttributeError``.
+    """
+
+    @staticmethod
+    def _script() -> str:
+        design = designs.DesignPlanar()
+        TransmonPocket(design, "Q1", options=dict(connection_pads=dict(a=dict())))
+        return design.to_python_script()
+
+    def test_uses_exec_not_deprecated_alias(self):
+        """PySide6 exposes ``exec()``; ``exec_()`` is the deprecated alias and
+        emits a DeprecationWarning."""
+        script = self._script()
+        self.assertIn("gui.qApp.exec()", script)
+        self.assertNotIn("exec_()", script)
+
+    def test_event_loop_is_guarded_on_main(self):
+        """The loop must be inside an ``if __name__ == "__main__"`` guard so
+        importing the exported script never blocks."""
+        script = self._script()
+        self.assertIn('if __name__ == "__main__"', script)
+
+    def test_not_run_as_main_does_not_start_loop(self):
+        """Imported / exec'd (not standalone): must NOT block on the loop."""
+        ns = _exec_exported_script(self._script(), run_name="__exported__")
+        self.assertEqual(ns["gui"].qApp.exec_calls, 0)
+
+    def test_run_as_main_starts_loop(self):
+        """Standalone run: the event loop must actually start, otherwise the
+        window flashes and closes (the bug PR #1159 fixed)."""
+        ns = _exec_exported_script(self._script(), run_name="__main__")
+        self.assertEqual(ns["gui"].qApp.exec_calls, 1)
+
+    def test_headless_no_qapp_does_not_raise(self):
+        """If no QApplication could be created, ``gui.qApp`` is None; the
+        script must skip the loop rather than AttributeError."""
+        ns = _exec_exported_script(
+            self._script(), run_name="__main__", gui_cls=_StubMetalGUINoQApp
+        )
+        self.assertIsNone(ns["gui"].qApp)
 
 
 class TestNumpyArrayImport(unittest.TestCase):


### PR DESCRIPTION
Follow-up on top of #1159 (thanks @LisithaDiz), plus a fix for #1157. Both live in `QDesign.to_python_script()`.

## 1. Harden the Qt event loop (follow-up to #1159)

#1159 correctly identified that the generated script never started the event loop, so a standalone `python my_chip_design.py` flashed the window and exited. It added `gui.qApp.exec_()` to the footer, unconditionally. That needed hardening for the install variants we support:

| Problem | Effect |
|---|---|
| `exec_()` is PySide6's **deprecated alias** for `exec()` | DeprecationWarning |
| Call was **unconditional** | Importing the exported script — or running it where a Qt loop already exists (Jupyter with `%gui qt`) — **blocks the caller** |
| `gui.qApp` is **None** when no `QApplication` could be created (headless; see `main_window_base._setup_qApp`) | `AttributeError` |

Generated footer is now:

```python
if __name__ == "__main__" and gui.qApp is not None:
    gui.qApp.exec()
```

A standalone run still keeps the window open — #1159's goal — while import, an existing-loop session, and headless are all safe.

## 2. Fix #1157 — generated script doesn't import `qiskit_metal`

The header emitted only `from qiskit_metal import designs, MetalGUI`. But when a component's `name` is not a valid Python identifier, `QComponent.to_script` falls back to a variable name built from the component's **full module path** (`qiskit_metal.qlibrary.tlines.straight_path<random>`), so the exported script hit:

```
NameError: name 'qiskit_metal' is not defined
```

Added a top-level `import qiskit_metal`. (Designs whose components all have identifier-safe names like `Q1` never hit this, which is why existing coverage missed it.)

## Tests

`tests/test_to_python_script.py` gains `TestQiskitMetalImport` and `TestQtEventLoop`, covering each variant explicitly:

- `exec()` is used, not the deprecated `exec_()`
- the loop sits behind an `if __name__ == "__main__"` guard
- **not** run as `__main__` → loop does **not** start (no blocking on import)
- run as `__main__` → loop **does** start (the window stays open)
- `qApp is None` (headless) → no `AttributeError`
- non-identifier component name → no `NameError` (#1157)

The `MetalGUI` test stub gained a `qApp` that records `exec()` calls instead of blocking, so these stay lite-install-safe (no PySide6 needed).

Locally: `tests/test_to_python_script.py` 12/12 pass. Full suite goes **33 failed / 506 passed → 32 failed / 514 passed** vs. this branch's base — the one fixed failure is the stub breakage #1159 introduced; the remaining 32 are pre-existing in a lite venv (missing `pyEPR`/`pyaedt`; CI installs `[full]`).

## Note on CI

The `lint` / `format` jobs are failing on **every** PR right now, unrelated to this change: the CI ruff action floats to the latest ruff, which moved to 0.16.0 and expanded its default rule set. Fixed separately.

Closes #1157.
