### PR TITLE
Pin the ruff rule set so a ruff release can't break CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,9 +169,20 @@
         "_dev",
         "docs/_archive",
         "docs/_build",
+        # ruff 0.16 began formatting Python code blocks embedded in Markdown.
+        # Our .md snippets (README quick-start, agent docs) are hand-wrapped for
+        # readability, not machine-formatted -- keep the formatter off them.
+        "*.md",
     ]
 
 [tool.ruff.lint]
+    # Pin the rule set explicitly. Without ``select`` ruff applies its
+    # *default* rules, which change between ruff releases -- and since CI
+    # installs the latest ruff, a new release silently breaks lint on every
+    # open PR (ruff 0.16.0 expanded the defaults and lit up ~3.8k pre-existing
+    # findings). These four are ruff's historical defaults, i.e. what this
+    # repo has actually been enforcing.
+    select = [ "E4", "E7", "E9", "F" ]
     ignore = [ "E402", "F401", "E731", "E722", "E741", "F821" ]
     # Ruff ignore codes:
     # To be sorted out in the future.


### PR DESCRIPTION
## The problem

`lint` and `format` went red on **every open PR** at once (#1158, #1159, #1160), with failures in files nobody touched — `tutorials/resources/skeleton_renderer.py`, `README.md`, `.claude/*.md`.

Root cause: `[tool.ruff.lint]` declares only `ignore`, never **`select`**. So ruff applies its *default* rule set — and that default is **version-dependent**. The CI ruff action installs whatever ruff is newest, which moved to **0.16.0** and substantially expanded the defaults:

```
1655  C408    unnecessary-collection-call
 366  I001    unsorted-imports
 250  BLE001  blind-except
 248  UP009   utf8-encoding-declaration
 ...
Found 3837 errors.
```

Under ruff 0.15.22 the same tree reports **0 errors**. Nothing in the repo changed — only ruff's defaults did. That makes our lint gate a floating dependency on ruff's release schedule.

Separately, ruff 0.16 began **formatting Python code blocks embedded in Markdown**, so `format --check` wanted to rewrite the README quick-start (expanding a compact 10-line snippet to 15 lines, one argument per line) and two `.claude/*.md` files.

## The fix (config only — no code changes)

1. **Declare `select` explicitly** as the four rule groups the repo has actually been enforcing (ruff's historical defaults). Lint results now depend on our config, not on which ruff CI happened to install.
2. **Exclude `*.md`** from ruff. Those snippets are hand-wrapped for readability; a Python formatter shouldn't be rewriting prose docs.

The existing `ignore` list, `per-file-ignores`, and `_dev` / `docs/_archive` exclusions are unchanged.

## Verified

Both commands, both ruff versions, on this branch:

| | `ruff check` | `ruff format --check` |
|---|---|---|
| **0.15.22** | All checks passed | 444 files already formatted |
| **0.16.0** | All checks passed | 444 files already formatted |

`scripts/check_env_consistency.py` also passes (no drift).

## Note

This deliberately does **not** adopt ruff 0.16's new rules. Doing so means ~3.8k findings — ~1.3k auto-fixable, ~2k needing `--unsafe-fixes` or manual work, much of it inside the `_gui/` and Ansys hard-touch zones. That's a real cleanup worth doing on purpose, not something to absorb by surprise because a dependency shipped a release. Adopting rule groups incrementally (e.g. `I` for import sorting) is now a one-line, reviewable change to `select`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_