### PR TITLE
Adopt the safely-fixable subset of ruff 0.16's expanded default rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,21 @@
     # open PR (ruff 0.16.0 expanded the defaults and lit up ~3.8k pre-existing
     # findings). These four are ruff's historical defaults, i.e. what this
     # repo has actually been enforcing.
-    select = [ "E4", "E7", "E9", "F" ]
+    select = [
+        "E4", "E7", "E9", "F",
+        # Adopted from ruff 0.16's expanded defaults: mechanical, safely
+        # auto-fixable rules that either fix a latent bug or change no runtime
+        # behaviour. See .claude/context/decision-log.md for the groups
+        # deliberately NOT adopted (I001, RUF012, BLE001, C408, B006, ...).
+        "W605",                            # non-raw strings used as regexes
+        "UP004", "UP008", "UP033", "UP034",
+        "PIE790", "PIE800", "PIE808",
+        "RUF010", "RUF022", "RUF046",
+        "PLR0402", "PLR1711", "PLR2044",
+        "B009", "B010",
+        "RET501", "SIM114", "FURB105",
+        "PYI016",
+    ]
     ignore = [ "E402", "F401", "E731", "E722", "E741", "F821" ]
     # Ruff ignore codes:
     # To be sorted out in the future.

--- a/scripts/check_env_consistency.py
+++ b/scripts/check_env_consistency.py
@@ -123,9 +123,7 @@ def ceiling_of(spec: SpecifierSet) -> Version | None:
     bound), or ``None`` if the spec has no upper bound."""
     candidates: list[Version] = []
     for s in spec:
-        if s.operator == "<":
-            candidates.append(Version(s.version))
-        elif s.operator == "<=":
+        if s.operator == "<" or s.operator == "<=":
             candidates.append(Version(s.version))
         elif s.operator == "~=":
             # ~=X.Y means >=X.Y, <X+1.0. ~=X.Y.Z means >=X.Y.Z, <X.Y+1.0.

--- a/scripts/check_tutorials_sync.py
+++ b/scripts/check_tutorials_sync.py
@@ -296,11 +296,11 @@ def main():
             f"docs/tut/ and tutorials/.",
             file=sys.stderr,
         )
-        print("", file=sys.stderr)
+        print(file=sys.stderr)
         for docs_p, tut_p in drift:
             print(f"  docs/tut: {docs_p}", file=sys.stderr)
             print(f"  tutorial: {tut_p}", file=sys.stderr)
-            print("", file=sys.stderr)
+            print(file=sys.stderr)
         print(
             "Both folders must contain byte-identical notebook cell content.\n"
             "Re-sync by running:\n\n"

--- a/src/qiskit_metal/_gui/component_widget_ui.py
+++ b/src/qiskit_metal/_gui/component_widget_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_ComponentWidget(object):
+class Ui_ComponentWidget:
     def setupUi(self, ComponentWidget):
         ComponentWidget.setObjectName("ComponentWidget")
         ComponentWidget.resize(539, 475)

--- a/src/qiskit_metal/_gui/elements_ui.py
+++ b/src/qiskit_metal/_gui/elements_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_ElementsWindow(object):
+class Ui_ElementsWindow:
     def setupUi(self, ElementsWindow):
         ElementsWindow.setObjectName("ElementsWindow")
         ElementsWindow.resize(841, 623)

--- a/src/qiskit_metal/_gui/endcap_hfss_ui.py
+++ b/src/qiskit_metal/_gui/endcap_hfss_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_mainWindow(object):
+class Ui_mainWindow:
     def setupUi(self, mainWindow):
         mainWindow.setObjectName("mainWindow")
         mainWindow.resize(400, 530)

--- a/src/qiskit_metal/_gui/endcap_q3d_ui.py
+++ b/src/qiskit_metal/_gui/endcap_q3d_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_mainWindow(object):
+class Ui_mainWindow:
     def setupUi(self, mainWindow):
         mainWindow.setObjectName("mainWindow")
         mainWindow.resize(322, 530)

--- a/src/qiskit_metal/_gui/main_window_base.py
+++ b/src/qiskit_metal/_gui/main_window_base.py
@@ -568,7 +568,6 @@ class QMainWindowBaseHandler:
 
     def _ui_adjustments(self):
         """Any touchups to the loaded ui that need be done soon."""
-        pass
 
     def _get_file_path(self):
         """Get the dir name of the current path in which this file is

--- a/src/qiskit_metal/_gui/main_window_ui.py
+++ b/src/qiskit_metal/_gui/main_window_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(1310, 847)

--- a/src/qiskit_metal/_gui/net_list_ui.py
+++ b/src/qiskit_metal/_gui/net_list_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_NetListWindow(object):
+class Ui_NetListWindow:
     def setupUi(self, NetListWindow):
         NetListWindow.setObjectName("NetListWindow")
         NetListWindow.resize(841, 623)

--- a/src/qiskit_metal/_gui/plot_window_ui.py
+++ b/src/qiskit_metal/_gui/plot_window_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindowPlot(object):
+class Ui_MainWindowPlot:
     def setupUi(self, MainWindowPlot):
         MainWindowPlot.setObjectName("MainWindowPlot")
         MainWindowPlot.resize(800, 600)

--- a/src/qiskit_metal/_gui/renderer_gds_ui.py
+++ b/src/qiskit_metal/_gui/renderer_gds_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(651, 581)

--- a/src/qiskit_metal/_gui/renderer_hfss_ui.py
+++ b/src/qiskit_metal/_gui/renderer_hfss_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(646, 544)

--- a/src/qiskit_metal/_gui/renderer_q3d_ui.py
+++ b/src/qiskit_metal/_gui/renderer_q3d_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(651, 544)

--- a/src/qiskit_metal/_gui/utility/_handle_qt_messages.py
+++ b/src/qiskit_metal/_gui/utility/_handle_qt_messages.py
@@ -25,7 +25,7 @@ from PySide6.QtCore import Slot
 
 from qiskit_metal import logger
 
-__all__ = ["slot_catch_error", "do_debug"]
+__all__ = ["do_debug", "slot_catch_error"]
 
 #######################################################################################
 # Core handler

--- a/src/qiskit_metal/_gui/widgets/all_components/table_model_all_components.py
+++ b/src/qiskit_metal/_gui/widgets/all_components/table_model_all_components.py
@@ -137,7 +137,7 @@ class QTableModel_AllComponents(QAbstractTableModel):
             int: The number of rows
         """
         if self.design:  # should we just enforce this
-            num = int(len(self.design.components))
+            num = len(self.design.components)
             if num == 0:
                 self._tableView.show_placeholder_text()
             else:

--- a/src/qiskit_metal/_gui/widgets/bases/dict_tree_base.py
+++ b/src/qiskit_metal/_gui/widgets/bases/dict_tree_base.py
@@ -78,7 +78,7 @@ class BranchNode:
             parent ([type]): The parent.  Defaults to None.
             data (dict): Node data.  Defaults to None.
         """
-        super(BranchNode, self).__init__()
+        super().__init__()
         self.name = name
         self.parent = parent
         self.children = []
@@ -177,7 +177,7 @@ class LeafNode:
             parent (Node): The parent.  Defaults to None.
             path (list): Node path.  Defaults to None.
         """
-        super(LeafNode, self).__init__()
+        super().__init__()
         self.path = path or []
         self.parent = parent
         self.label = label

--- a/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area.py
+++ b/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area.py
@@ -26,7 +26,7 @@ class BuildHistoryScrollArea(QScrollArea, Ui_BuildHistory):
                 Parent widget if necessary
 
         """
-        super(BuildHistoryScrollArea, self).__init__(parent, *args, **kwargs)
+        super().__init__(parent, *args, **kwargs)
         self.setupUi(self)
         self._previous_builds = previous_builds
         self._display_logs()

--- a/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area_ui.py
+++ b/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_BuildHistory(object):
+class Ui_BuildHistory:
     def setupUi(self, BuildHistory):
         BuildHistory.setObjectName("BuildHistory")
         BuildHistory.resize(1536, 865)

--- a/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
@@ -192,7 +192,7 @@ class ParameterEntryWindow(QMainWindow):
         """
 
         if imagepath.is_file():
-            text += f'''<img src="{str(imagepath)}"/>'''
+            text += f'''<img src="{imagepath!s}"/>'''
 
         text += f"""
             <div class="h1">Class docstring:</div>

--- a/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window_ui.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(753, 600)

--- a/src/qiskit_metal/_gui/widgets/log_widget/log_metal.py
+++ b/src/qiskit_metal/_gui/widgets/log_widget/log_metal.py
@@ -35,7 +35,7 @@ from qiskit_metal._gui.utility._handle_qt_messages import slot_catch_error
 if not config.is_building_docs():
     from ....toolbox_python.utility_functions import clean_name, monkey_patch
 
-__all__ = ["QTextEditLogger", "LogHandler_for_QTextLog"]
+__all__ = ["LogHandler_for_QTextLog", "QTextEditLogger"]
 
 
 class QTextEditLogger(QTextEdit):

--- a/src/qiskit_metal/_gui/widgets/qlibrary_display/file_model_qlibrary.py
+++ b/src/qiskit_metal/_gui/widgets/qlibrary_display/file_model_qlibrary.py
@@ -64,7 +64,7 @@ class QFileSystemLibraryModel(QFileSystemModel):
                 absoluteFilename = str(qfileinfo.absoluteFilePath())
                 if role == Qt.DecorationRole:
                     matches = findProperty(
-                        absoluteFilename, "\.\. image::[\r\n]+([^\r\n]+)"
+                        absoluteFilename, "\\.\\. image::[\r\n]+([^\r\n]+)"
                     )
                     if matches is not None and len(matches) != 0:
                         iconfile = matches[0].lstrip()

--- a/src/qiskit_metal/_gui/widgets/variable_table/add_delete_table_ui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/add_delete_table_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_MainWindow(object):
+class Ui_MainWindow:
     def setupUi(self, MainWindow):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(344, 206)

--- a/src/qiskit_metal/_gui/widgets/variable_table/dialog_popup_ui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/dialog_popup_ui.py
@@ -11,7 +11,7 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
-class Ui_Dialog(object):
+class Ui_Dialog:
     def setupUi(self, Dialog):
         Dialog.setObjectName("Dialog")
         Dialog.setWindowModality(QtCore.Qt.NonModal)

--- a/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_gui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_gui.py
@@ -37,7 +37,6 @@ class PropertyTableWidget(QMainWindow):
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
 
-        #
         self._design = design
 
         # Table View:

--- a/src/qiskit_metal/analyses/em/cpw_calculations.py
+++ b/src/qiskit_metal/analyses/em/cpw_calculations.py
@@ -36,10 +36,10 @@ e0 = 8.85419 * 10**-12
 u0 = 4 * np.pi * 10**-7
 
 __all__ = [
-    "guided_wavelength",
-    "lumped_cpw",
     "effective_dielectric_constant",
     "elliptic_int_constants",
+    "guided_wavelength",
+    "lumped_cpw",
 ]
 
 

--- a/src/qiskit_metal/analyses/hamiltonian/transmon_analytics.py
+++ b/src/qiskit_metal/analyses/hamiltonian/transmon_analytics.py
@@ -26,7 +26,7 @@ from scipy.special import mathieu_a
 import numpy as np
 import matplotlib.pyplot as plt
 
-__all__ = ["kidx_raw", "kidx", "transmon_eigenvalue", "plot_eigenvalues"]
+__all__ = ["kidx", "kidx_raw", "plot_eigenvalues", "transmon_eigenvalue"]
 
 
 def kidx_raw(m, my_ng):

--- a/src/qiskit_metal/analyses/hamiltonian/transmon_charge_basis.py
+++ b/src/qiskit_metal/analyses/hamiltonian/transmon_charge_basis.py
@@ -21,7 +21,7 @@ get the Ej, Ec or use input Ej, Ec to find the spectrum of the Cooper Pair Box.
 
 import numpy as np
 import qutip as qt
-import scipy.linalg as linalg
+from scipy import linalg
 import scipy.optimize as opt
 
 

--- a/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
+++ b/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
@@ -568,7 +568,7 @@ class CircuitGraph:
     @property
     @_maybe_remove_grd_node_then_cache
     def S_n(self):
-        """Linear transformation from original node basis to
+        r"""Linear transformation from original node basis to
         node-junction basis where all non-linear dipole fluxes are
         explicitly in the basis. The flux of the j-th dipole
         $\Phi_{j} = \Phi_{n2} - \Phi_{n1}$, where $\Phi_{n2}$ and
@@ -610,7 +610,7 @@ class CircuitGraph:
 
     @property
     def node_jj_basis(self):
-        """Node-junction basis which is linear transformation
+        r"""Node-junction basis which is linear transformation
         from original node basis to where all non-linear dipole fluxes are
         explicitly in the basis. The flux of the j-th dipole
         $\Phi_{j} = \Phi_{n2} - \Phi_{n1}$, where $\Phi_{n2}$ and
@@ -974,7 +974,7 @@ def set_builder_options(func):
         dflt_opts = getattr(self, "default_opts", {})
         build_options = QuantumBuilderOptions(**dflt_opts)
         build_options.set_from_input(subsystem.q_opts)
-        setattr(self, "builder_options", build_options)
+        self.builder_options = build_options
         func(self, subsystem)
 
     return wrapper
@@ -1612,7 +1612,7 @@ class CompositeSystem:
         ham_res["chi_in_MHz"] = LabeledNdarray(chi_mat, names)
 
         if print_info:
-            print("")
+            print()
             print("system frequencies in GHz:")
             print("--------------------------")
             print(ham_res["fQ_in_Ghz"])

--- a/src/qiskit_metal/analyses/quantization/lumped_capacitive.py
+++ b/src/qiskit_metal/analyses/quantization/lumped_capacitive.py
@@ -39,23 +39,23 @@ from qiskit_metal.analyses.quantization.constants import (
 )
 
 __all__ = [
-    "Ic_from_Lj",
-    "Ic_from_Ej",
     "Cs_from_Ec",
-    "transmon_props",
-    "chi",
-    "extract_transmon_coupled_Noscillator",
-    "levels_vs_ng_real_units",
-    "get_C_and_Ic",
-    "cos_to_mega_and_delta",
+    "Ic_from_Ej",
+    "Ic_from_Lj",
     "chargeline_T1",
+    "chi",
+    "cos_to_mega_and_delta",
+    "df_cmat_style_print",
+    "df_reorder_matrix_basis",
+    "extract_transmon_coupled_Noscillator",
+    "get_C_and_Ic",
+    "levels_vs_ng_real_units",
+    "load_q3d_capacitance_matrix",
+    "lumped_oscillator_from_path",
+    "move_index_to",
     "readin_q3d_matrix",
     "readin_q3d_matrix_m",
-    "load_q3d_capacitance_matrix",
-    "df_cmat_style_print",
-    "move_index_to",
-    "df_reorder_matrix_basis",
-    "lumped_oscillator_from_path",
+    "transmon_props",
 ]
 
 
@@ -404,7 +404,7 @@ def extract_transmon_coupled_Noscillator(
     if print_info:
         print(qubit_index, bus_index)
         print("Predicted Values")
-        print("")
+        print()
         print("Transmon Properties")
         print("f_Q %f [GHz]" % ham_dict["fQ"])
         print("EC %f [MHz]" % ham_dict["EC"])
@@ -414,7 +414,7 @@ def extract_transmon_coupled_Noscillator(
         print("Lq %f [nH]" % (phi0**2 / (hbar * EJ) / 1e-9))
         print("Cq %f [fF]" % (Cq / 1e-15))
         print("T1 %f [us]" % (T1 / (1e-6)))
-        print("")
+        print()
 
         print("**Coupling Properties**")
         for ii in range(N):

--- a/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
+++ b/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
@@ -571,9 +571,7 @@ class Sweeping:
             # Decide if need to clean the design.
             obj_names = a_hfss.pinfo.get_all_object_names()
             if obj_names:
-                if index == len_sweep and not leave_last_design:
-                    a_hfss.clean_active_design()
-                elif index != len_sweep:
+                if index == len_sweep and not leave_last_design or index != len_sweep:
                     a_hfss.clean_active_design()
 
         a_hfss.disconnect_ansys()
@@ -817,9 +815,7 @@ class Sweeping:
             # Decide if need to clean the design.
             obj_names = a_hfss.pinfo.get_all_object_names()
             if obj_names:
-                if index == len_sweep and not leave_last_design:
-                    a_hfss.clean_active_design()
-                elif index != len_sweep:
+                if index == len_sweep and not leave_last_design or index != len_sweep:
                     a_hfss.clean_active_design()
 
         a_hfss.disconnect_ansys()
@@ -1127,9 +1123,7 @@ class Sweeping:
             # Decide if need to clean the design.
             obj_names = a_q3d.pinfo.get_all_object_names()
             if obj_names:
-                if index == len_sweep and not leave_last_design:
-                    a_q3d.clean_active_design()
-                elif index != len_sweep:
+                if index == len_sweep and not leave_last_design or index != len_sweep:
                     a_q3d.clean_active_design()
 
         a_q3d.disconnect_ansys()

--- a/src/qiskit_metal/draw/__init__.py
+++ b/src/qiskit_metal/draw/__init__.py
@@ -13,7 +13,7 @@
 # that they have been altered from the originals.
 
 import shapely
-import shapely.wkt as wkt
+from shapely import wkt
 
 # Base Geometry Definitions - extend here
 from shapely.geometry.base import BaseGeometry

--- a/src/qiskit_metal/draw/basic.py
+++ b/src/qiskit_metal/draw/basic.py
@@ -38,17 +38,17 @@ from qiskit_metal.draw import BaseGeometry
 from qiskit_metal.draw.utility import get_poly_pts
 
 __all__ = [
-    "rectangle",
-    "is_rectangle",
+    "_iter_func_geom_",
+    "buffer",
     "flip_merge",
+    "is_rectangle",
+    "rectangle",
     "rotate",
     "rotate_position",
-    "_iter_func_geom_",
-    "translate",
     "scale",
-    "buffer",
-    "union",
     "subtract",
+    "translate",
+    "union",
 ]
 
 

--- a/src/qiskit_metal/draw/utility.py
+++ b/src/qiskit_metal/draw/utility.py
@@ -31,14 +31,14 @@ from qiskit_metal import is_component, logger
 from qiskit_metal.draw import BaseGeometry
 
 __all__ = [
-    "get_poly_pts",
+    "Vector",
+    "array_chop",
+    "flatten_all_filter",
     "get_all_component_bounds",
     "get_all_geoms",
-    "flatten_all_filter",
+    "get_poly_pts",
     "remove_colinear_pts",
-    "array_chop",
     "vec_unit_planar",
-    "Vector",
 ]
 
 # Used for numpy.round()
@@ -236,9 +236,7 @@ def remove_colinear_pts(points):
     for i in range(2, len(points)):
         v1 = array(points[i - 2]) - array(points[i - 1])
         v2 = array(points[i - 1]) - array(points[i - 0])
-        if Vector.are_same(v1, v2):
-            remove_idx += [i - 1]
-        elif Vector.angle_between(v1, v2) == 0:
+        if Vector.are_same(v1, v2) or Vector.angle_between(v1, v2) == 0:
             remove_idx += [i - 1]
     points = np.delete(points, remove_idx, axis=0)
 
@@ -817,7 +815,7 @@ class Vec3D(Vector):
                 ]
             )
             translate_vec = np.array([0, cvec[1], cvec[2]])
-            new_vec = rot_x.dot((vec - translate_vec)) + translate_vec
+            new_vec = rot_x.dot(vec - translate_vec) + translate_vec
 
         if ay:
             rot_y = np.array(
@@ -828,7 +826,7 @@ class Vec3D(Vector):
                 ]
             )
             translate_vec = np.array([cvec[0], 0, cvec[2]])
-            new_vec = rot_y.dot((vec - translate_vec)) + translate_vec
+            new_vec = rot_y.dot(vec - translate_vec) + translate_vec
 
         if az:
             rot_z = np.array(
@@ -839,7 +837,7 @@ class Vec3D(Vector):
                 ]
             )
             translate_vec = np.array([cvec[0], cvec[1], 0])
-            new_vec = rot_z.dot((vec - translate_vec)) + translate_vec
+            new_vec = rot_z.dot(vec - translate_vec) + translate_vec
 
         return new_vec
 

--- a/src/qiskit_metal/qgeometries/qgeometries_handler.py
+++ b/src/qiskit_metal/qgeometries/qgeometries_handler.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
     from ..designs import QDesign
     from ..qlibrary.core import QComponent
 
-__all__ = ["is_qgeometry_table", "QGeometryTables"]  # , 'ElementTypes']
+__all__ = ["QGeometryTables", "is_qgeometry_table"]  # , 'ElementTypes']
 
 # from collections import OrderedDict
 # dict are ordered in Python 3.6+ by default, this is for backward compatibility
@@ -154,7 +154,7 @@ ELEMENT_COLUMNS = dict(
 TRUE_BOOLS = [True, "True", "true", "Yes", "yes", "1", 1]
 
 
-class QGeometryTables(object):
+class QGeometryTables:
     """Class to create, store, and handle element tables.
 
     A regular user would not need to create tables themselves.
@@ -688,7 +688,7 @@ class QGeometryTables(object):
         component_int_id = int(component_id)
         a_comp = self.design._components[component_int_id]
         if a_comp is None:
-            return None
+            return
         else:
             # TODO: is this the best way to do this, or is there a faster way?
             for table_name in self.tables:

--- a/src/qiskit_metal/qlibrary/core/base.py
+++ b/src/qiskit_metal/qlibrary/core/base.py
@@ -40,7 +40,7 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-import qiskit_metal.qlibrary as qlibrary
+from qiskit_metal import qlibrary
 from qiskit_metal import config, draw, is_design, logger
 from qiskit_metal.draw import BaseGeometry
 from qiskit_metal.qlibrary.core._parsed_dynamic_attrs import (
@@ -729,7 +729,7 @@ name='{strname}'{other_args}
             self.status = "good"
 
             self.design.build_logs.add_success(
-                f"{str(datetime.now())} -- Component: {self.name} successfully built"
+                f"{datetime.now()!s} -- Component: {self.name} successfully built"
             )
 
         except Exception as error:
@@ -737,7 +737,7 @@ name='{strname}'{other_args}
                 f"ERROR in building component name={self.name}, error={error}"
             )
             self.design.build_logs.add_error(
-                f"{str(datetime.now())} -- Component: {self.name} failed with error\n: {error}"
+                f"{datetime.now()!s} -- Component: {self.name} failed with error\n: {error}"
             )
             raise error
 

--- a/src/qiskit_metal/qlibrary/core/design_check.py
+++ b/src/qiskit_metal/qlibrary/core/design_check.py
@@ -60,13 +60,13 @@ class QDesignCheck:
                     collision_counter_outer = 0.0
 
                     n = int(size(combined_geo_inner))
-                    for i in range(0, n):
+                    for i in range(n):
                         # print("inner element:", i)
                         el_inner = combined_geo.crosses(combined_geo_inner[i])
 
                         m = int(size(el_inner))
                         collision_counter = 0.0
-                        for j in range(0, m):
+                        for j in range(m):
                             if el_inner[j] == 1:
                                 collision_counter = collision_counter + 1.0
                             else:

--- a/src/qiskit_metal/qlibrary/core/qubit.py
+++ b/src/qiskit_metal/qlibrary/core/qubit.py
@@ -69,7 +69,7 @@ class BaseQubit(QComponent):
             # This qubit was not added to design.
             # self.logger.warning(
             # 'In BaseQubit.__init(), the qubit has not been added to design. The component is exiting with None.')
-            return None
+            return
         if options_connection_pads:
             self.options.connection_pads.update(options_connection_pads)
 

--- a/src/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -92,7 +92,7 @@ class TransmonConcentric(BaseQubit):
 
         # draw the concentric pad regions
         outer_pad = draw.Point(0, 0).buffer(p.rad_o)
-        space = draw.Point(0, 0).buffer((p.gap + p.rad_i))
+        space = draw.Point(0, 0).buffer(p.gap + p.rad_i)
         outer_pad = draw.subtract(outer_pad, space)
         inner_pad = draw.Point(0, 0).buffer(p.rad_i)
         # gap = draw.subtract(space, inner_pad)

--- a/src/qiskit_metal/qlibrary/qubits/transmon_concentric_type_2.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_concentric_type_2.py
@@ -100,7 +100,7 @@ class TransmonConcentricType2(BaseQubit):
         p = self.parse_options()  # Parse the string options into numbers
         # draw the concentric pad regions
         outer_pad = draw.Point(0, 0).buffer(p.rad_outer)
-        space = draw.Point(0, 0).buffer((p.gap + p.rad_inner))
+        space = draw.Point(0, 0).buffer(p.gap + p.rad_inner)
         cutout = draw.rectangle(
             8.0 * p.finger_N_width,
             p.finger_N_length,

--- a/src/qiskit_metal/qlibrary/qubits/transmon_pocket_teeth.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_pocket_teeth.py
@@ -23,7 +23,7 @@ from qiskit_metal.qlibrary.core import BaseQubit
 
 
 class TransmonPocketTeeth(BaseQubit):
-    """Transmon pocket with 'Teeth' connection pads.
+    r"""Transmon pocket with 'Teeth' connection pads.
 
     Inherits `BaseQubit` class
 

--- a/src/qiskit_metal/qlibrary/tlines/framed_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/framed_path.py
@@ -169,10 +169,12 @@ class RouteFramed(QRoute):
                             self.__pts = pts_right
         elif normdot == 0:
             # Normal vectors perpendicular to each other
-            if (m1[0] in [minx, maxx]) and (m2[1] in [miny, maxy]):
-                # Both pins on perimeter of overall bounding box, but not at corner
-                self.__pts = self.connect_frame(2)
-            elif (m1[1] in [miny, maxy]) and (m2[0] in [minx, maxx]):
+            if (
+                (m1[0] in [minx, maxx])
+                and (m2[1] in [miny, maxy])
+                or (m1[1] in [miny, maxy])
+                and (m2[0] in [minx, maxx])
+            ):
                 # Both pins on perimeter of overall bounding box, but not at corner
                 self.__pts = self.connect_frame(2)
             elif (

--- a/src/qiskit_metal/qlibrary/tlines/meandered.py
+++ b/src/qiskit_metal/qlibrary/tlines/meandered.py
@@ -407,26 +407,26 @@ class RouteMeander(QRoute):
         end_pt_adjusted_down = end_pt.position - fillet_shift
 
         # if start_pt.position is below axes + shift - 2xfillet &  first_meander_sideways
-        if first_meander_sideways and not self.issideways(
-            start_pt_adjusted_up, pts[0], pts[1]
-        ):
-            pass
-        # if start_pt.position is above axes - shift + 2xfillet &  not first_meander_sideways
-        elif not first_meander_sideways and self.issideways(
-            start_pt_adjusted_down, pts[0], pts[1]
+        if (
+            first_meander_sideways
+            and not self.issideways(start_pt_adjusted_up, pts[0], pts[1])
+            or not first_meander_sideways
+            and self.issideways(start_pt_adjusted_down, pts[0], pts[1])
         ):
             pass
         else:
             # else block first mender
             adjustment_vector[:2] = [0, 0]
         # if end_pt.position is below axes + shift - 2xfillet &  last_meander_sideways
-        if last_meander_sideways and not self.issideways(
-            end_pt_adjusted_up, pts[-2 - term_point], pts[-1 - term_point]
-        ):
-            pass
-        # if end_pt.position is above axes - shift + 2xfillet &  not last_meander_sideways
-        elif not last_meander_sideways and self.issideways(
-            end_pt_adjusted_down, pts[-2 - term_point], pts[-1 - term_point]
+        if (
+            last_meander_sideways
+            and not self.issideways(
+                end_pt_adjusted_up, pts[-2 - term_point], pts[-1 - term_point]
+            )
+            or not last_meander_sideways
+            and self.issideways(
+                end_pt_adjusted_down, pts[-2 - term_point], pts[-1 - term_point]
+            )
         ):
             pass
         else:

--- a/src/qiskit_metal/qlibrary/tlines/pathfinder.py
+++ b/src/qiskit_metal/qlibrary/tlines/pathfinder.py
@@ -124,7 +124,6 @@ class RoutePathfinder(RouteAnchors):
             except QiskitMetalDesignError:
                 simple_path = None
                 # try the pathfinder algorithm
-                pass
 
             if simple_path is not None:
                 current_path.extend(simple_path)

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
@@ -1,4 +1,3 @@
-#
 """
 Variables
 
@@ -524,7 +523,6 @@ class QHFSSPyaedt(QPyaedt):
         Returns:
             bool: _description_
         """
-        pass
 
     def render_element_junction(self,
                                 qgeom: pd.Series,
@@ -905,7 +903,6 @@ class QHFSSPyaedt(QPyaedt):
             port_list (list): _description_
         """
         # This should be overwritten by drivenmodal class.
-        pass
 
     def jj_to_port_list_dict_populate(self, jj_to_port: list):
         """Convert jj_to_port to a searchable dict.
@@ -914,7 +911,6 @@ class QHFSSPyaedt(QPyaedt):
             jj_to_port (list): _description_
         """
         # This should be overwritten by drivenmodal class.
-        pass
 
     def set_variable(self, name: str, value: str):
         """

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
@@ -1,4 +1,3 @@
-#
 from __future__ import annotations
 
 from ast import parse

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/pyaedt_base.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/pyaedt_base.py
@@ -233,7 +233,6 @@ class QPyaedt(QRendererAnalysis):
         Args:
             component (QComponent): Component to render.
         """
-        pass
 
     def render_chips(
         self, draw_sample_holder: bool = True, box_plus_buffer: bool = True
@@ -247,8 +246,6 @@ class QPyaedt(QRendererAnalysis):
         # Abstract method. Must be implemented by the subclass.
         # Render all chips of the design.
         # Calls render_chip for each chip.
-
-        pass
 
         chip_list = self.get_chip_names()
         for chip_name in chip_list:
@@ -278,7 +275,6 @@ class QPyaedt(QRendererAnalysis):
 
         # This is for HFSS, will do later.  Also, we may want to do just once, BUT
         # not for every chip.
-        pass
 
     def render_components(
         self,
@@ -600,7 +596,6 @@ class QPyaedt(QRendererAnalysis):
         Returns:
             pathlib.WindowsPath: path to png formatted screenshot.
         """
-        pass
 
     def render_design(
         self, selection: Union[List, None] = None, box_plus_buffer: bool = True
@@ -947,7 +942,6 @@ class QPyaedt(QRendererAnalysis):
         #                     material="pec",
         #                     solve_inside=False,
         #                 )
-        pass
 
     def get_chip_names(self) -> List[str]:
         """

--- a/src/qiskit_metal/renderers/renderer_base/rndr_analysis.py
+++ b/src/qiskit_metal/renderers/renderer_base/rndr_analysis.py
@@ -47,7 +47,6 @@ class QRendererAnalysis(QRenderer):
         Render all chips of the design.
         Calls render_chip for each chip.
         """
-        pass
 
     @abstractmethod
     def render_chip(self, name):
@@ -57,7 +56,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             name (str): chip to render
         """
-        pass
 
     @abstractmethod
     def render_components(self, selection=None):
@@ -68,7 +66,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             selection (QComponent): Component to render.
         """
-        pass
 
     @abstractmethod
     def render_component(self, component):
@@ -78,7 +75,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             component (QComponent): Component to render.
         """
-        pass
 
     @abstractmethod
     def render_element(self, element):
@@ -88,7 +84,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             element (Element): Element to render.
         """
-        pass
         # if isinstance(element, path):
         #    self.render_element_path(element)
 
@@ -106,7 +101,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             path (str): Path to render.
         """
-        pass
 
     @abstractmethod
     def render_element_poly(self, poly):
@@ -116,7 +110,6 @@ class QRendererAnalysis(QRenderer):
         Args:
             poly (Poly): Poly to render.
         """
-        pass
 
     @abstractmethod
     def save_screenshot(self, path: str = None, show: bool = True):
@@ -129,7 +122,6 @@ class QRendererAnalysis(QRenderer):
         Returns:
             pathlib.WindowsPath: path to png formatted screenshot.
         """
-        pass
 
 
 # class Cap():

--- a/src/qiskit_metal/renderers/renderer_elmer/elmer_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_elmer/elmer_renderer.py
@@ -674,7 +674,6 @@ class QElmerRenderer(QRendererAnalysis):
         Render all chips of the design.
         Calls render_chip for each chip.
         """
-        pass
 
     def render_chip(self, chip_name: str):
         """Abstract method. Must be implemented by the subclass.
@@ -683,7 +682,6 @@ class QElmerRenderer(QRendererAnalysis):
         Args:
             name (str): chip to render
         """
-        pass
 
     def render_layers(
         self,

--- a/src/qiskit_metal/renderers/renderer_gds/make_cheese.py
+++ b/src/qiskit_metal/renderers/renderer_gds/make_cheese.py
@@ -262,7 +262,7 @@ class Cheesing:
         self.one_hole_cell.add(*a_poly)
 
         if self.one_hole_cell.bounding_box() is not None:
-            next((c for c in self.lib.cells if c.name == chip_layer_only_top_name)).add(
+            next(c for c in self.lib.cells if c.name == chip_layer_only_top_name).add(
                 gdstk.Reference(self.one_hole_cell)
             )
         else:
@@ -431,9 +431,7 @@ class Cheesing:
         top_chip_layer_name = f"TOP_{self.chip_name}_{self.layer}"
         ground_cell_name = f"ground_{self.chip_name}_{self.layer}"
         if next((c for c in self.lib.cells if c.name == top_chip_layer_name), None):
-            ground_cell = next(
-                (c for c in self.lib.cells if c.name == ground_cell_name)
-            )
+            ground_cell = next(c for c in self.lib.cells if c.name == ground_cell_name)
             # Need to keep the depth at 0, otherwise all the
             # cell references (junctions) will be added for boolean.
             ground_cheese = gdstk.boolean(

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
@@ -51,7 +51,7 @@ class Vec3DArray:
         CAUTION: Please don't change this unless you really need to!
         """
         self.path_vecs = []
-        for i in range(0, len(self.points) - 1):
+        for i in range(len(self.points) - 1):
             v1 = self.points[i]
             v2 = self.points[i + 1]
             v12 = Vec3D.normed(Vec3D.sub(v2, v1))

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_canvas.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_canvas.py
@@ -19,7 +19,7 @@ import warnings
 import logging
 import matplotlib
 import matplotlib as mpl
-import matplotlib.patches as patches
+from matplotlib import patches
 import matplotlib.pyplot as plt
 
 from cycler import cycler
@@ -591,7 +591,7 @@ class PlotCanvas(FigureCanvas):
 
     def style_figure(self):
         """Style a figure."""
-        pass  # self.figure.tight_layout()
+        # self.figure.tight_layout()
 
     def auto_scale(self):
         """Automaticlaly scale."""

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
@@ -120,10 +120,10 @@ warnings.filterwarnings(
     message=r".*Ignoring fixed .* limits to fulfill fixed data aspect.*",
 )
 
-__all__ = ["figure_pz", "MplInteraction", "PanAndZoom"]
+__all__ = ["MplInteraction", "PanAndZoom", "figure_pz"]
 
 
-class MplInteraction(object):
+class MplInteraction:
     """Base class for class providing interaction to a matplotlib Figure."""
 
     def __init__(self, figure):
@@ -215,7 +215,7 @@ class ZoomOnWheel(MplInteraction):
             figure (matplotlib.figure.Figure): The matplotlib figure to attach the behavior to.
             scale_factor (float): The scale factor to apply on wheel event.
         """
-        super(ZoomOnWheel, self).__init__(figure)
+        super().__init__(figure)
         self._add_connection("scroll_event", self._on_mouse_wheel)
 
         self.scale_factor = scale_factor
@@ -361,7 +361,7 @@ class PanAndZoom(ZoomOnWheel):
             figure (matplotlib.figure.Figure): The matplotlib figure to attach the behavior to.
             scale_factor (float): The scale factor to apply on wheel event.
         """
-        super(PanAndZoom, self).__init__(figure, scale_factor)
+        super().__init__(figure, scale_factor)
         self._add_connection("button_press_event", self._on_mouse_press)
         self._add_connection("button_release_event", self._on_mouse_release)
         self._add_connection("motion_notify_event", self._on_mouse_motion)
@@ -507,7 +507,6 @@ class PanAndZoom(ZoomOnWheel):
     def _style_figure(self):
         """Style figure."""
         # self.figure.dpi = 150
-        pass
 
     @staticmethod
     def _pan_update_limits(ax, axis_id, event, last_event):

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_toolbox.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_toolbox.py
@@ -14,8 +14,8 @@
 """Plotting functions for shapely components using mpl."""
 
 import matplotlib as mpl
-import matplotlib.cbook as cbook
-import matplotlib.image as image
+from matplotlib import cbook
+from matplotlib import image
 import matplotlib.pyplot as plt
 import numpy as np
 import shapely
@@ -29,15 +29,15 @@ from qiskit_metal.renderers.renderer_mpl.mpl_interaction import figure_pz
 from qiskit_metal.renderers.renderer_mpl.patch import PolygonPatch
 
 __all__ = [
-    "_render_poly_zkm",
-    "render_poly",
-    "render",
-    "style_axis_simple",
-    "get_prop_cycle",
-    "style_axis_standard",
-    "figure_spawn",
     "_axis_set_watermark_img",
+    "_render_poly_zkm",
     "clear_axis",
+    "figure_spawn",
+    "get_prop_cycle",
+    "render",
+    "render_poly",
+    "style_axis_simple",
+    "style_axis_standard",
 ]
 
 ##########################################################################################
@@ -77,9 +77,7 @@ def _render_poly_zkm(poly: Polygon, ax, kw=None, kw_hole=None):
         mpl_poly = mpl.patches.Polygon(coords)
         color = ax._get_lines.get_next_color()
         ax.add_collection(
-            mpl.collections.PatchCollection(
-                [mpl_poly], **{**{"facecolor": color}, **kw}
-            )
+            mpl.collections.PatchCollection([mpl_poly], **{"facecolor": color, **kw})
         )
 
         # Interior (i.e., holes)

--- a/src/qiskit_metal/renderers/renderer_mpl/patch.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/patch.py
@@ -42,7 +42,7 @@ from matplotlib.path import Path
 from numpy import asarray, concatenate, ones
 
 
-class Polygon(object):
+class Polygon:
     """Adapt Shapely or GeoJSON/geo_interface polygons to a common interface"""
 
     def __init__(self, context):

--- a/src/qiskit_metal/toolbox_metal/about.py
+++ b/src/qiskit_metal/toolbox_metal/about.py
@@ -29,7 +29,7 @@ import qutip
 
 from qiskit_metal.toolbox_python.display import Color, style_colon_list
 
-__all__ = ["about", "open_docs", "get_platform_info", "get_module_doc_page"]
+__all__ = ["about", "get_module_doc_page", "get_platform_info", "open_docs"]
 
 
 def about():

--- a/src/qiskit_metal/toolbox_metal/bounds_for_path_and_poly_tables.py
+++ b/src/qiskit_metal/toolbox_metal/bounds_for_path_and_poly_tables.py
@@ -210,7 +210,7 @@ class BoundsForPathAndPolyTables:
 
     def get_box_for_xy_bounds(
         self,
-    ) -> Union[None, Union[Tuple[float, float, float, float], None]]:
+    ) -> Union[None, Tuple[float, float, float, float]]:
         """Assuming the chip size is used from Multiplanar design, and list of chip_names
         comes from layer_stack that will be used to determine the box size for simulation.
 

--- a/src/qiskit_metal/toolbox_metal/import_export.py
+++ b/src/qiskit_metal/toolbox_metal/import_export.py
@@ -19,7 +19,7 @@ import pickle
 # from ..designs.base
 from qiskit_metal.toolbox_python.utility_functions import log_error_easy
 
-__all__ = ["save_metal", "load_metal_design"]
+__all__ = ["load_metal_design", "save_metal"]
 
 
 def save_metal(filename: str, design):

--- a/src/qiskit_metal/toolbox_metal/math_and_overrides.py
+++ b/src/qiskit_metal/toolbox_metal/math_and_overrides.py
@@ -16,7 +16,7 @@
 
 import numpy as np
 
-__all__ = ["set_decimal_precision", "dot", "cross", "round"]
+__all__ = ["cross", "dot", "round", "set_decimal_precision"]
 
 DECIMAL_PRECISION = 10
 

--- a/src/qiskit_metal/toolbox_metal/parsing.py
+++ b/src/qiskit_metal/toolbox_metal/parsing.py
@@ -178,12 +178,12 @@ from pint import UnitRegistry
 from qiskit_metal import Dict, config, logger
 
 __all__ = [
-    "parse_value",  # Main function
-    "is_variable_name",  # extra helpers
-    "is_numeric_possible",
     "is_for_ast_eval",
+    "is_numeric_possible",
     "is_true",
+    "is_variable_name",  # extra helpers
     "parse_options",
+    "parse_value",  # Main function
 ]
 
 #########################################################################

--- a/src/qiskit_metal/toolbox_python/_logging.py
+++ b/src/qiskit_metal/toolbox_python/_logging.py
@@ -20,7 +20,7 @@ import logging
 import collections
 from typing import List
 
-__all__ = ["setup_logger", "LogStore"]
+__all__ = ["LogStore", "setup_logger"]
 
 
 def setup_logger(

--- a/src/qiskit_metal/toolbox_python/display.py
+++ b/src/qiskit_metal/toolbox_python/display.py
@@ -51,7 +51,7 @@ except ImportError:  # pragma: no cover — exercised on lite installs without J
 
     _HAVE_IPYTHON = False
 
-__all__ = ["get_screenshot", "format_dict_ala_z"]
+__all__ = ["format_dict_ala_z", "get_screenshot"]
 
 
 @magics_class
@@ -250,7 +250,7 @@ def format_dict_ala_z(
             if do_repr:
                 k = repr(k)
                 v = repr(v) + ","
-            text += f"{'':{indent_all_full}s}{k:<{key_width}s}: {str(v):<30s}\n"
+            text += f"{'':{indent_all_full}s}{k:<{key_width}s}: {v!s:<30s}\n"
 
     if indent == 0:
         if len(text) > 1:

--- a/src/qiskit_metal/toolbox_python/utility_functions.py
+++ b/src/qiskit_metal/toolbox_python/utility_functions.py
@@ -32,21 +32,21 @@ if TYPE_CHECKING:
     from qiskit_metal import logger
 
 __all__ = [
-    "copy_update",
-    "dict_start_with",
-    "data_frame_empty_typed",
-    "clean_name",
-    "enable_warning_traceback",
-    "get_traceback",
-    "print_traceback_easy",
-    "log_error_easy",
-    "monkey_patch",
+    "bad_fillet_idxs",
     "can_write_to_path",
     "can_write_to_path_with_warning",
-    "toggle_numbers",
-    "bad_fillet_idxs",
+    "clean_name",
     "compress_vertex_list",
+    "copy_update",
+    "data_frame_empty_typed",
+    "dict_start_with",
+    "enable_warning_traceback",
     "get_range_of_vertex_to_not_fillet",
+    "get_traceback",
+    "log_error_easy",
+    "monkey_patch",
+    "print_traceback_easy",
+    "toggle_numbers",
 ]
 
 ####################################################################################
@@ -163,7 +163,7 @@ def clean_name(text: str):
 
     See https://stackoverflow.com/questions/3303312/how-do-i-convert-a-string-to-a-valid-variable-name-in-python
     """
-    return re.sub("\W|^(?=\d)", "_", text)
+    return re.sub(r"\W|^(?=\d)", "_", text)
 
 
 ####################################################################################

--- a/src/qiskit_metal/viewer/__init__.py
+++ b/src/qiskit_metal/viewer/__init__.py
@@ -42,4 +42,4 @@ from .view import view
 from .headless_gui import MetalGUIHeadless, gui
 from .show_inline import show_inline
 
-__all__ = ["view", "gui", "MetalGUIHeadless", "show_inline"]
+__all__ = ["MetalGUIHeadless", "gui", "show_inline", "view"]

--- a/src/qiskit_metal/viewer/headless_gui.py
+++ b/src/qiskit_metal/viewer/headless_gui.py
@@ -57,15 +57,15 @@ class _NoOpMainWindow:
 
     def close(self) -> None:  # noqa: D401
         """No-op in headless mode."""
-        return None
+        return
 
     def show(self) -> None:
         """No-op in headless mode."""
-        return None
+        return
 
     def raise_(self) -> None:
         """No-op in headless mode."""
-        return None
+        return
 
 
 class MetalGUIHeadless:
@@ -171,7 +171,7 @@ class MetalGUIHeadless:
         ``design.components['Q1'].options.<field> = ...`` followed by
         ``gui.rebuild()`` (edit).
         """
-        return None
+        return
 
     def highlight_components(self, component_names: List[str]) -> Optional["Figure"]:
         """Mark components for highlighting on the next render.
@@ -287,7 +287,7 @@ class MetalGUIHeadless:
         panels. There are no docks in the headless inline view, so this
         silently does nothing.
         """
-        return None
+        return
 
     def change_design(self, design: "QDesign") -> None:
         """Alias of :meth:`set_design` to match older ``MetalGUI`` API."""

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -104,6 +104,6 @@ class AssertionsMixin:
                     item1, item2, rel_tol=rel_tol, abs_tol=abs_tol
                 )
             except AssertionError as err:
-                standardMsg = f"Iterable elements {index} not almost equal: {str(err)}"
+                standardMsg = f"Iterable elements {index} not almost equal: {err!s}"
                 msg = self._formatMessage(msg, standardMsg)
                 raise self.failureException(msg) from None

--- a/tests/test_analyses_1_inst_options.py
+++ b/tests/test_analyses_1_inst_options.py
@@ -38,11 +38,9 @@ class TestAnalyses(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_analyses_sweeping_importable(self):
         """Regression guard: sweeping.py used an unquoted ``Union`` return

--- a/tests/test_analyses_2_functionality.py
+++ b/tests/test_analyses_2_functionality.py
@@ -41,11 +41,9 @@ class TestAnalyses(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_analyses_cpw_guided_wavelength(self):
         """Test the functionality of guided_wavelength in

--- a/tests/test_default_options.py
+++ b/tests/test_default_options.py
@@ -25,11 +25,9 @@ class TestDefautOptions(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_default_options_instantiation_default_metal_options(self):
         """Test instantiation of DefaultMetalOptions."""

--- a/tests/test_designs.py
+++ b/tests/test_designs.py
@@ -33,11 +33,9 @@ class TestDesign(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_design_instantiate_qdesign(self):
         """Test the instantiation of QDesign."""

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -34,11 +34,9 @@ class TestDraw(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_draw_instantiate_vector(self):
         """Test instantiation of Vector class."""

--- a/tests/test_gui_basic.py
+++ b/tests/test_gui_basic.py
@@ -27,11 +27,9 @@ class TestGUIBasic(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_instantiate_branch_node(self):
         """Test instantiation of BranchNode in dict_tree_base.py."""

--- a/tests/test_pyepr_integration.py
+++ b/tests/test_pyepr_integration.py
@@ -248,7 +248,7 @@ class TestEigenmodeConvergencePlotHelpers(unittest.TestCase, AssertionsMixin):
 
     def test_pyepr_reports_exposes_helpers(self):
         """The four convergence-plot helpers must remain in pyEPR.reports."""
-        import pyEPR.reports as reports
+        from pyEPR import reports
 
         for name in self.HELPERS:
             self.assertTrue(

--- a/tests/test_qgeometries.py
+++ b/tests/test_qgeometries.py
@@ -31,11 +31,9 @@ class TestElements(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_qgeometry_instantiate_q_geometry_tables(self):
         """Test instantiation of QGeometryTables."""

--- a/tests/test_qlibrary_1_instantiate.py
+++ b/tests/test_qlibrary_1_instantiate.py
@@ -70,11 +70,9 @@ class TestComponentInstantiation(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_qlibrary_instantiate_qcomponent(self):
         """Test the instantiaion of QComponent."""

--- a/tests/test_qlibrary_2_options.py
+++ b/tests/test_qlibrary_2_options.py
@@ -64,11 +64,9 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_qlibrary_circle_caterpiller_options(self):
         """Test that default options of circle_caterpiller in

--- a/tests/test_qlibrary_3_functionality.py
+++ b/tests/test_qlibrary_3_functionality.py
@@ -60,11 +60,9 @@ class TestComponentFunctionality(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_qlibrary_get_nested_dict_item(self):
         """Test the functionality of get_nested_dict_item in

--- a/tests/test_qlibrary_3_options.py
+++ b/tests/test_qlibrary_3_options.py
@@ -63,11 +63,9 @@ class TestComponentOptions(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_qlibrary_circle_caterpiller_options(self):
         """Test that default options of circle_caterpiller in

--- a/tests/test_quantization_constants.py
+++ b/tests/test_quantization_constants.py
@@ -180,7 +180,6 @@ class TestVendoredJosephsonHelpers(unittest.TestCase):
                 def find_spec(self, name, path, target=None):
                     if name == "pyEPR" or name.startswith("pyEPR."):
                         raise ImportError(f"BLOCKED: {name}")
-                    return None
 
             blocker = _BlockpyEPR()
             sys.meta_path.insert(0, blocker)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -50,11 +50,9 @@ class TestRenderers(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_renderer_instanitate_qansys_renderer(self):
         """Test instantiation of QAnsysRenderer in ansys_renderer.py"""

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -24,11 +24,9 @@ class TestSpeed(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     @timeout(5)
     def test_example_test(self):

--- a/tests/test_toolbox_metal.py
+++ b/tests/test_toolbox_metal.py
@@ -51,7 +51,6 @@ class TestToolboxMetal(unittest.TestCase, AssertionsMixin):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
@@ -444,7 +443,7 @@ class TestToolboxMetal(unittest.TestCase, AssertionsMixin):
                 layer=1,
             ),
         )
-        chip = getattr(multiplanar_design, "_chips")
+        chip = multiplanar_design._chips
         for main in chip.items():
             coords = main[1]
         for item in coords.values():

--- a/tests/test_toolbox_python.py
+++ b/tests/test_toolbox_python.py
@@ -28,11 +28,9 @@ class TestToolboxPython(unittest.TestCase):
 
     def setUp(self):
         """Setup unit test."""
-        pass
 
     def tearDown(self):
         """Tie any loose ends."""
-        pass
 
     def test_instantiate_log_store(self):
         """Test instantiation of LogStore class."""


### PR DESCRIPTION
Follow-up to #1161, which pinned `select` so the enforced rule set stops floating with ruff's releases — leaving ~3.8k findings from ruff 0.16's expanded defaults unadopted.

This adopts the subset that is **mechanical, safely auto-fixable, and either fixes a latent bug or changes no runtime behaviour**: 164 fixes across 84 files, all applied by `ruff check --fix` — **no `--unsafe-fixes`**.

## The one real bug class

`W605` — non-raw strings used as regexes. Two are live:

```python
# toolbox_python/utility_functions.py
- re.sub("\W|^(?=\d)", "_", text)
+ re.sub(r"\W|^(?=\d)", "_", text)
```

and the MetalGUI `.. image::` thumbnail scanner in `_gui/.../file_model_qlibrary.py`. These work today **only because Python preserves unknown escape sequences** — which is deprecated and becomes a syntax error. Both were verified to match identically after the fix (the thumbnail scanner still resolves `.. image::\n    Airbridge.png`, and the slugifier still maps `7q name` → `_7q_name`). The remaining `W605` hits are LaTeX in non-raw docstrings.

## Everything else is a runtime no-op

`UP004` useless object inheritance (17) · `PIE790` unnecessary placeholders (51) · `UP034` extraneous parens · `UP008` redundant `super()` args · `RET501` · `SIM114` · `RUF010` · `RUF022` · `PLR0402` · `PLR1711` · `PLR2044` · `B009`/`B010` · `PIE800`/`PIE808` · `FURB105` · `PYI016` · `UP033` · `RUF046`.

The adopted rules are added to `select` so they stay enforced going forward.

## Deliberately still not adopted

Per `.claude/context/decision-log.md`: `I001` (import order is load-bearing for the lazy-Qt design — must import without PySide6), `RUF012` (would flag `default_options` on every `QComponent`, the library's core idiom), `BLE001` (many are deliberate defensive catches around COM/Qt, see #1132), `C408`, `B006`, and the large `UP006`/`UP045`/`UP009` typing/header sweep.

**Three more excluded after inspecting their actual fixes** — they were auto-fixable but not clear improvements here:

- **`RUF100`** would strip `# noqa: F401` from availability-probe imports (`import PySide6  # noqa: F401`, `import gmsh  # noqa: F401`). They're redundant only because `F401` is currently in `ignore`; the marker documents deliberate intent for exactly the lazy-import probes that matter in this repo.
- **`PLR1733`** rewrote the `fragment_interfaces` remapping in `gmsh_renderer.py`. Verified equivalent (`geom_id`/`geoms` alias the same objects), but it's a cosmetic gain inside subtle renderer code touched by #1150 — not worth the risk surface.
- **`PYI041`** narrowed explicit `Union[int, float, ...]` signatures to `Union[float, ...]`; correct per the numeric tower, but less readable in a public-facing signature.

## Verification

- `ruff check` and `ruff format --check` clean; `check_env_consistency.py` reports no drift.
- Full suite **unchanged vs. base: 32 failed / 514 passed** — the same pre-existing lite-venv failures (`renderer_ansys` tests needing `pyEPR`/`pyaedt`; CI installs `[full]`).
- `_gui/` and `renderer_ansys_pyaedt/` are touched only by `class X(object)` → `class X` and removal of unnecessary `pass` — no logic changes in the hard-touch zones.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_