### PR TITLE
decision-log: put the public-document guardrail at the top

### DIFF
--- a/.claude/context/decision-log.md
+++ b/.claude/context/decision-log.md
@@ -1,12 +1,33 @@
 # Decision log
 
+> **Before adding an entry — this file is public.** It is committed,
+> searchable, and permanent, like every other file in the repo. Write only
+> what you would be comfortable seeing quoted, out of context, by someone
+> outside the project.
+>
+> Record **technical facts and the reasoning behind them**. Leave out:
+>
+> - strategy, positioning, roadmap intent, or anything about adoption,
+>   competitors, or other projects beyond neutral technical fact;
+> - commentary about people — contributors, maintainers, reviewers — beyond
+>   standard attribution (name + link). No characterisations, no assessments
+>   of anyone's work or motives, no notes on how a contribution was handled;
+> - anything from a private conversation with the maintainer, including how
+>   or why a piece of work was prioritised;
+> - self-narration ("we decided to…", "we accepted…") where a plain statement
+>   of the technical choice would do.
+>
+> If it belongs in chat with the maintainer, it stays in chat. When in doubt,
+> write the shorter, drier version — or leave it out. See also the
+> "Public commits, PRs, and files" section of `CLAUDE.md`.
+
 Append-only record of **decisions and deferrals** — the things
 `git log` doesn't capture.
 
 Git already records *what* changed and PRs record *how*. What gets lost is
-**why we chose this over the alternative**, and **what we deliberately did
-not do**. Those are the expensive things to reconstruct six months later,
-usually at the moment someone is about to undo them.
+**why one approach was chosen over the alternative**, and **what was
+deliberately not done**. Those are the expensive things to reconstruct six
+months later, usually at the moment someone is about to undo them.
 
 Scope rules, so this stays useful instead of becoming a diary:
 
@@ -14,8 +35,7 @@ Scope rules, so this stays useful instead of becoming a diary:
   **deliberate deferral**. Routine fixes need no entry — the PR is enough.
 - Record the **road not taken** and why. That's the load-bearing part.
 - Link PR/issue numbers rather than restating them.
-- Keep it factual and terse (see the "public commits" section of
-  `CLAUDE.md`). No strategy, no commentary about people.
+- Keep it factual and terse — see the callout above.
 - Newest entry at the top.
 
 Related: `lessons-learned.md` is for things that *bit us in production*;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Don't reach for `_dev/` as a halfway house — it's still public.
 | File | Read when |
 |------|-----------|
 | `.claude/context/lessons-learned.md` | **Always.** Every hard-won fix from real debugging — pandas-2.2 indexing, qutip-5 API, lazy Qt, uv-auto-sync, the v0.6.0 release failure, etc. Avoids re-discovering each from scratch. |
-| `.claude/context/decision-log.md` | Before undoing something that looks odd, or picking up deferred work. Records *why* we chose an approach and what we deliberately did **not** do (e.g. the deferred ruff-0.16 rule adoption). Append an entry when you make a non-obvious call. |
+| `.claude/context/decision-log.md` | Before undoing something that looks odd, or picking up deferred work. Records *why* we chose an approach and what we deliberately did **not** do (e.g. the deferred ruff-0.16 rule adoption). Append an entry when you make a non-obvious call — **read the callout at the top of that file first; it is a public document.** |
 | `.claude/context/architecture.md` | When you need to make structural changes — class hierarchy, option flow, renderer dispatch, lazy-Qt design. |
 | `.claude/context/ecosystem.md` | When making roadmap / API / version decisions — who the users are, the pyEPR/pyaedt/AWS-Palace relationships, the v0.7.0 lite-by-default plan. |
 | `docs/architecture/renderer_protocol.md` | When adding or modifying a renderer. The full inheritance map and override matrix. |


### PR DESCRIPTION
The "keep it factual and terse" rule was one bullet among several in `.claude/context/decision-log.md` — easy to skim past when appending an entry in a later session, which is exactly the moment it needs to be read.

Promotes it to a callout at the very top and makes it concrete about what to leave out:

- strategy, positioning, roadmap intent, or anything about adoption / competitors / other projects beyond neutral technical fact;
- commentary about people — contributors, maintainers, reviewers — beyond standard attribution (name + link);
- anything from a private conversation, including how or why work was prioritised;
- self-narration where a plain statement of the technical choice would do.

Plus the general test: *write only what you'd be comfortable seeing quoted, out of context, by someone outside the project*; when in doubt, write the shorter, drier version or leave it out.

Also points at the callout from the `CLAUDE.md` table entry, so an agent that only reads `CLAUDE.md` still learns the file is public before appending to it. Cross-references the existing "Public commits, PRs, and files" section rather than restating it.

Docs only. `ruff check` and `ruff format --check` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_