### PR TITLE
Isolate the flaky gmsh meshing test, document script-mode GUI (#1013), and adopt a second ruff tier

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -162,6 +162,39 @@ If you're working on the lite install (no Qt), see the headless workflow at
 a lighter alternative to the desktop GUI (see
 `ROADMAP.md <https://github.com/qiskit-community/qiskit-metal/blob/main/ROADMAP.md>`_).
 
+**Q: The GUI opens and closes immediately when I run my script with**
+``python my_script.py`` **— but the same code works in Jupyter. Why?**
+
+**A:** Nothing is starting the **Qt event loop**. Without it the Python process
+reaches the end of your script and exits, taking the window with it. Jupyter
+already runs an event loop in the background, which is why the same code
+appears to work there.
+
+Add a blocking ``exec()`` call at the end of the script:
+
+.. code-block:: python
+
+   from qiskit_metal import designs, MetalGUI
+
+   design = designs.DesignPlanar()
+   gui = MetalGUI(design)
+   # ... build your design ...
+
+   if __name__ == "__main__":
+       gui.qApp.exec()          # blocks until you close the window
+
+Two details matter:
+
+* Use ``exec()``, not ``exec_()`` — the latter is PySide6's deprecated alias.
+* Keep the ``__name__ == "__main__"`` guard. ``exec()`` **blocks**, so an
+  unguarded call hangs anything that imports your script, and hangs a Jupyter
+  session that already runs a Qt loop. On a headless machine ``gui.qApp`` can
+  also be ``None``, so guard on that too if your script has to run there:
+  ``if __name__ == "__main__" and gui.qApp is not None:``.
+
+Scripts produced by :meth:`~qiskit_metal.designs.design_base.QDesign.to_python_script`
+already include this guard, so an exported design runs standalone as-is.
+
 
 .. _docs:
 

--- a/docs/tut/2-From-components-to-chip/2.31-Create-a-QComponent-Basic.ipynb
+++ b/docs/tut/2-From-components-to-chip/2.31-Create-a-QComponent-Basic.ipynb
@@ -40,8 +40,6 @@
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
-    "\n",
     "# This code is part of Qiskit.\n",
     "#\n",
     "# (C) Copyright IBM 2017, 2021.\n",

--- a/docs/tut/resources/my429_qcomponents.py
+++ b/docs/tut/resources/my429_qcomponents.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,11 @@
         "B009", "B010",
         "RET501", "SIM114", "FURB105",
         "PYI016",
+        # Second tier (#1163 follow-up): also safely auto-fixable, no runtime
+        # behaviour change on the supported Python range (3.10-3.12).
+        "UP009",                           # redundant utf-8 coding declaration
+        "UP006", "UP045",                  # PEP 585/604 annotations
+        "RET502",                          # bare return in a value-returning fn
     ]
     ignore = [ "E402", "F401", "E731", "E722", "E741", "F821" ]
     # Ruff ignore codes:

--- a/src/qiskit_metal/__init__.py
+++ b/src/qiskit_metal/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_defaults.py
+++ b/src/qiskit_metal/_defaults.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/__init__.py
+++ b/src/qiskit_metal/_gui/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/_init_trace.py
+++ b/src/qiskit_metal/_gui/_init_trace.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/component_widget_ui.py
+++ b/src/qiskit_metal/_gui/component_widget_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './component_widget_ui.ui',
 # licensing of './component_widget_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/elements_ui.py
+++ b/src/qiskit_metal/_gui/elements_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './elements_ui.ui',
 # licensing of './elements_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/elements_window.py
+++ b/src/qiskit_metal/_gui/elements_window.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -274,12 +272,12 @@ class ElementTableModel(QAbstractTableModel):
         """
 
         if not index.isValid():
-            return
+            return None
         # if not 0 <= index.row() < self.rowCount():
         #    return None
 
         if self.table is None:
-            return
+            return None
 
         if role == QtCore.Qt.DisplayRole:
             row = index.row()

--- a/src/qiskit_metal/_gui/endcap_hfss_gui.py
+++ b/src/qiskit_metal/_gui/endcap_hfss_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -108,7 +106,7 @@ class EndcapHFSSWidget(QMainWindow):
 
     def get_unconnected_pins(
         self, components_to_render: list = None
-    ) -> Tuple[set, set]:
+    ) -> tuple[set, set]:
         """Given a list of components to render, obtain 2 sets: open_set and
         short_set. Each contains pins belonging to components in
         components_to_render, but with the following difference. Open_set

--- a/src/qiskit_metal/_gui/endcap_hfss_ui.py
+++ b/src/qiskit_metal/_gui/endcap_hfss_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './endcap_hfss_ui.ui',
 # licensing of './endcap_hfss_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/endcap_q3d_gui.py
+++ b/src/qiskit_metal/_gui/endcap_q3d_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -85,7 +83,7 @@ class EndcapQ3DWidget(QMainWindow):
 
     def get_unconnected_pins(
         self, components_to_render: list = None
-    ) -> Tuple[set, set]:
+    ) -> tuple[set, set]:
         """Given a list of components to render, obtain 2 sets: open_set and
         short_set. Each contains pins belonging to components in
         components_to_render, but with the following difference. Open_set

--- a/src/qiskit_metal/_gui/endcap_q3d_ui.py
+++ b/src/qiskit_metal/_gui/endcap_q3d_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './endcap_q3d_ui.ui',
 # licensing of './endcap_q3d_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/list_model_base.py
+++ b/src/qiskit_metal/_gui/list_model_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/main_window.py
+++ b/src/qiskit_metal/_gui/main_window.py
@@ -963,7 +963,7 @@ class MetalGUI(QMainWindowBaseHandler):
         return axes
 
     @property
-    def axes(self) -> List["matplotlib.plt.Axes"]:
+    def axes(self) -> list["matplotlib.plt.Axes"]:
         """Returns the axes."""
         return self.plot_win.canvas.axes
 
@@ -1041,7 +1041,7 @@ class MetalGUI(QMainWindowBaseHandler):
         if self.component_window:
             self.component_window.set_component(name)
 
-    def highlight_components(self, component_names: List[str]):
+    def highlight_components(self, component_names: list[str]):
         """Visually highlight components in the plot canvas.
 
         Args:
@@ -1049,7 +1049,7 @@ class MetalGUI(QMainWindowBaseHandler):
         """
         self.canvas.highlight_components(component_names)
 
-    def zoom_on_components(self, components: List[str]):
+    def zoom_on_components(self, components: list[str]):
         """Zoom the canvas to fit the given components.
 
         Args:

--- a/src/qiskit_metal/_gui/main_window_base.py
+++ b/src/qiskit_metal/_gui/main_window_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/main_window_rc_rc.py
+++ b/src/qiskit_metal/_gui/main_window_rc_rc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Resource object code
 #
 # Created: Thu Jun 30 16:30:21 2022

--- a/src/qiskit_metal/_gui/main_window_ui.py
+++ b/src/qiskit_metal/_gui/main_window_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './main_window_ui.ui',
 # licensing of './main_window_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/net_list_ui.py
+++ b/src/qiskit_metal/_gui/net_list_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './net_list_ui.ui',
 # licensing of './net_list_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/net_list_window.py
+++ b/src/qiskit_metal/_gui/net_list_window.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -243,12 +241,12 @@ class NetListTableModel(QAbstractTableModel):
         """
 
         if not index.isValid():
-            return
+            return None
         # if not 0 <= index.row() < self.rowCount():
         #    return None
 
         if self.net_info is None:
-            return
+            return None
 
         if role == QtCore.Qt.DisplayRole:
             row = index.row()

--- a/src/qiskit_metal/_gui/plot_window_ui.py
+++ b/src/qiskit_metal/_gui/plot_window_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './plot_window_ui.ui',
 # licensing of './plot_window_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/renderer_gds_gui.py
+++ b/src/qiskit_metal/_gui/renderer_gds_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_gds_model.py
+++ b/src/qiskit_metal/_gui/renderer_gds_model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_gds_ui.py
+++ b/src/qiskit_metal/_gui/renderer_gds_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file 'c:\Temp\GitHub\qiskit-metal\qiskit_metal\_gui\renderer_gds_ui.ui'
 #
 # Created: Sat Jun 19 22:02:30 2021

--- a/src/qiskit_metal/_gui/renderer_hfss_gui.py
+++ b/src/qiskit_metal/_gui/renderer_hfss_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_hfss_model.py
+++ b/src/qiskit_metal/_gui/renderer_hfss_model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_hfss_ui.py
+++ b/src/qiskit_metal/_gui/renderer_hfss_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file 'c:\Temp\GitHub\qiskit-metal\qiskit_metal\_gui\renderer_hfss_ui.ui'
 #
 # Created: Sat Jun 19 22:02:29 2021

--- a/src/qiskit_metal/_gui/renderer_q3d_gui.py
+++ b/src/qiskit_metal/_gui/renderer_q3d_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_q3d_model.py
+++ b/src/qiskit_metal/_gui/renderer_q3d_model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/renderer_q3d_ui.py
+++ b/src/qiskit_metal/_gui/renderer_q3d_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file 'c:\Temp\GitHub\qiskit-metal\qiskit_metal\_gui\renderer_q3d_ui.ui'
 #
 # Created: Sat Jun 19 22:02:29 2021

--- a/src/qiskit_metal/_gui/tree_view_base.py
+++ b/src/qiskit_metal/_gui/tree_view_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/utility/__init__.py
+++ b/src/qiskit_metal/_gui/utility/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/utility/_handle_qt_messages.py
+++ b/src/qiskit_metal/_gui/utility/_handle_qt_messages.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/utility/_toolbox_qt.py
+++ b/src/qiskit_metal/_gui/utility/_toolbox_qt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/all_components/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/all_components/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/all_components/table_model_all_components.py
+++ b/src/qiskit_metal/_gui/widgets/all_components/table_model_all_components.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -210,7 +208,7 @@ class QTableModel_AllComponents(QAbstractTableModel):
         """
 
         if not index.isValid() or not self.design:
-            return
+            return None
 
         component_name = list(self.design.components.keys())[index.row()]
 

--- a/src/qiskit_metal/_gui/widgets/all_components/table_view_all_components.py
+++ b/src/qiskit_metal/_gui/widgets/all_components/table_view_all_components.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -248,7 +246,7 @@ class QTableView_AllComponents(QTableView, QWidget_PlaceholderText):
         self.gui.canvas.zoom_on_components([name])
         # self.logger.info(f'Double clicked component {name}')
 
-    def rows_to_names(self, rows: List[int]) -> List[str]:
+    def rows_to_names(self, rows: list[int]) -> list[str]:
         """Based on user highlighting  rows of components in GUI, return the
         name of components.
 
@@ -341,7 +339,7 @@ class QTableView_AllComponents(QTableView, QWidget_PlaceholderText):
         index_list = self.selectedIndexes()
         name_set = set()
         if len(index_list) == 0:
-            return
+            return None
 
         for ind in index_list:
             name_ind = model.index(ind.row(), 0)

--- a/src/qiskit_metal/_gui/widgets/bases/QWidget_PlaceholderText.py
+++ b/src/qiskit_metal/_gui/widgets/bases/QWidget_PlaceholderText.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/bases/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/bases/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/bases/dict_tree_base.py
+++ b/src/qiskit_metal/_gui/widgets/bases/dict_tree_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/bases/expanding_toolbar.py
+++ b/src/qiskit_metal/_gui/widgets/bases/expanding_toolbar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/build_history/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/build_history/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area.py
+++ b/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area.py
@@ -13,7 +13,7 @@ class BuildHistoryScrollArea(QScrollArea, Ui_BuildHistory):
     This class extends the `QScrollArea` class
     """
 
-    def __init__(self, previous_builds: List[str], parent=None, *args, **kwargs):
+    def __init__(self, previous_builds: list[str], parent=None, *args, **kwargs):
         """
         Args:
             previous_builds (List[str]):

--- a/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area_ui.py
+++ b/src/qiskit_metal/_gui/widgets/build_history/build_history_scroll_area_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './widgets/build_history/build_history_scroll_area_ui.ui',
 # licensing of './widgets/build_history/build_history_scroll_area_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_delegate_param_entry.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_delegate_param_entry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_model_param_entry.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_model_param_entry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_view_param_entry.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/model_view/tree_view_param_entry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -58,7 +56,7 @@ class ParameterEntryWindow(QMainWindow):
 
     def __init__(
         self,
-        qcomp_class: Type,
+        qcomp_class: type,
         design: designs.DesignPlanar,
         parent: QWidget = None,
         gui: "MetalGUI" = None,

--- a/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window_ui.py
+++ b/src/qiskit_metal/_gui/widgets/create_component_window/parameter_entry_window_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './widgets/create_component_window/parameter_entry_window_ui.ui',
 # licensing of './widgets/create_component_window/parameter_entry_window_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/widgets/edit_component/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/edit_component/component_widget.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/component_widget.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -196,7 +194,7 @@ class ComponentWidget(QTabWidget):
             """)
         self.src_doc = create_QTextDocument(self.ui.textSource)
         self._html_css_lex: pygments.formatters.html.HtmlFormatter = None
-        self.src_widgets: List[QtWidgets.QWidget] = []
+        self.src_widgets: list[QtWidgets.QWidget] = []
 
         # Help stylesheet
         document = self.ui.textHelp.document()

--- a/src/qiskit_metal/_gui/widgets/edit_component/table_model_options.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/table_model_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -162,12 +160,12 @@ class QTableModel_Options(QAbstractTableModel):
         """
 
         if not index.isValid():
-            return
+            return None
         # if not 0 <= index.row() < self.rowCount():
         #    return None
 
         if self.component is None:
-            return
+            return None
 
         # The key data to be rendered in the form of text. (QString)
         if role == Qt.DisplayRole:

--- a/src/qiskit_metal/_gui/widgets/edit_component/table_view_options.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/table_view_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/edit_component/tree_model_options.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/tree_model_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/edit_component/tree_view_options.py
+++ b/src/qiskit_metal/_gui/widgets/edit_component/tree_view_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/log_widget/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/log_widget/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/log_widget/log_metal.py
+++ b/src/qiskit_metal/_gui/widgets/log_widget/log_metal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/plot_widget/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/plot_widget/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/plot_widget/plot_window.py
+++ b/src/qiskit_metal/_gui/widgets/plot_widget/plot_window.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/qlibrary_display/delegate_qlibrary.py
+++ b/src/qiskit_metal/_gui/widgets/qlibrary_display/delegate_qlibrary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/qlibrary_display/file_model_qlibrary.py
+++ b/src/qiskit_metal/_gui/widgets/qlibrary_display/file_model_qlibrary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/qlibrary_display/proxy_model_qlibrary.py
+++ b/src/qiskit_metal/_gui/widgets/qlibrary_display/proxy_model_qlibrary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/qlibrary_display/tree_view_qlibrary.py
+++ b/src/qiskit_metal/_gui/widgets/qlibrary_display/tree_view_qlibrary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/variable_table/__init__.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/variable_table/add_delete_table_ui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/add_delete_table_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './widgets/variable_table/add_delete_table_ui.ui',
 # licensing of './widgets/variable_table/add_delete_table_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/widgets/variable_table/dialog_popup_ui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/dialog_popup_ui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Form implementation generated from reading ui file './widgets/variable_table/dialog_popup_ui.ui',
 # licensing of './widgets/variable_table/dialog_popup_ui.ui' applies.
 #

--- a/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_gui.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_model.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/prop_val_table_model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_gui/widgets/variable_table/right_click_table_view.py
+++ b/src/qiskit_metal/_gui/widgets/variable_table/right_click_table_view.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/_is_design.py
+++ b/src/qiskit_metal/_is_design.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/__init__.py
+++ b/src/qiskit_metal/analyses/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/core/__init__.py
+++ b/src/qiskit_metal/analyses/core/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/core/base.py
+++ b/src/qiskit_metal/analyses/core/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/core/simulation.py
+++ b/src/qiskit_metal/analyses/core/simulation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -43,7 +41,7 @@ class QSimulation(QAnalysis):
     def __init__(
         self,
         design: Optional["QDesign"] = None,
-        renderer_name: Optional[str] = None,
+        renderer_name: str | None = None,
         *args,
         **kwargs,
     ):

--- a/src/qiskit_metal/analyses/em/__init__.py
+++ b/src/qiskit_metal/analyses/em/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/em/cpw_calculations.py
+++ b/src/qiskit_metal/analyses/em/cpw_calculations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/em/transmission_fitting.py
+++ b/src/qiskit_metal/analyses/em/transmission_fitting.py
@@ -1,5 +1,3 @@
-# # -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/hamiltonian/HO_wavefunctions.py
+++ b/src/qiskit_metal/analyses/hamiltonian/HO_wavefunctions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/hamiltonian/__init__.py
+++ b/src/qiskit_metal/analyses/hamiltonian/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/hamiltonian/states_energies.py
+++ b/src/qiskit_metal/analyses/hamiltonian/states_energies.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -24,7 +22,7 @@ import qutip
 from qutip import Qobj
 
 
-def basis_state_on(mode_size: List[int], excitations: Dict_[int, int]):
+def basis_state_on(mode_size: list[int], excitations: dict[int, int]):
     """Construct a qutip Qobj. Taken from pyEPR
     https://github.com/zlatko-minev/pyEPR/blob/master/pyEPR/calcs/back_box_numeric.py
 
@@ -47,7 +45,7 @@ def basis_state_on(mode_size: List[int], excitations: Dict_[int, int]):
 
 
 def extract_energies(
-    esys_array: np.ndarray, mode_size: List[int], zero_evals: bool = True
+    esys_array: np.ndarray, mode_size: list[int], zero_evals: bool = True
 ):
     """
     Returns the frequencies, anharmonicities, and dispersive shifts of the modes.

--- a/src/qiskit_metal/analyses/hamiltonian/transmon_CPB_analytic.py
+++ b/src/qiskit_metal/analyses/hamiltonian/transmon_CPB_analytic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/hamiltonian/transmon_analytics.py
+++ b/src/qiskit_metal/analyses/hamiltonian/transmon_analytics.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/hamiltonian/transmon_charge_basis.py
+++ b/src/qiskit_metal/analyses/hamiltonian/transmon_charge_basis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/quantization/__init__.py
+++ b/src/qiskit_metal/analyses/quantization/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/quantization/energy_participation_ratio.py
+++ b/src/qiskit_metal/analyses/quantization/energy_participation_ratio.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
+++ b/src/qiskit_metal/analyses/quantization/lom_core_analysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -77,7 +75,7 @@ class CouplingType:
     INDUCTIVE = "INDUCTIVE"
 
 
-def analyze_loaded_tl(fr, vp, Z0, cap_loading: Dict[str, float], shorted=False):
+def analyze_loaded_tl(fr, vp, Z0, cap_loading: dict[str, float], shorted=False):
     """Calculate charge operator zero point fluctuation, Q_zpf at the point of the loading
     capacitor.
     https://arxiv.org/pdf/2103.10344.pdf
@@ -184,7 +182,7 @@ def analyze_loaded_tl(fr, vp, Z0, cap_loading: Dict[str, float], shorted=False):
     return Q_zpf, Phi_zpf, phi, Ltl
 
 
-def _product_no_duplicate(*args) -> List[List]:
+def _product_no_duplicate(*args) -> list[list]:
     """
     product_no_duplicate('ABCDx', 'xy') --> Ax Ay Bx By Cx Cy Dx Dy xy
     ** Note that xx is not included **
@@ -213,7 +211,7 @@ def _make_cmat_df(cmat, nodes):
     return df
 
 
-def _df_cmat_to_adj_list(df_cmat: pd.DataFrame) -> DefaultDict(list):
+def _df_cmat_to_adj_list(df_cmat: pd.DataFrame) -> defaultdict(list):
     """
     generate an adjacency list from a capacitance matrix in a dataframe
     """
@@ -226,7 +224,7 @@ def _df_cmat_to_adj_list(df_cmat: pd.DataFrame) -> DefaultDict(list):
     return graph
 
 
-def _cj_dict_to_adj_list(cj_dict: Dict[Tuple, float]) -> DefaultDict(list):
+def _cj_dict_to_adj_list(cj_dict: dict[tuple, float]) -> defaultdict(list):
     graph = defaultdict(list)
     for (n1, n2), c in cj_dict.items():
         graph[n1].append((n2, -c))
@@ -245,7 +243,7 @@ def _remove_row_col_at_idx(mat, idx):
 
 
 def _extract_matrix_from_transform(
-    transform: BasisTransform, junctions: Mapping[Tuple[str, str], str], index: pd.Index
+    transform: BasisTransform, junctions: Mapping[tuple[str, str], str], index: pd.Index
 ) -> np.ndarray:
     """
     calculate the S_n^{-1} matrix that corresponds to a given transform
@@ -270,7 +268,7 @@ def _extract_matrix_from_transform(
 
 def _transform_to_junction_flux_basis(
     orig_nodes,
-    junctions: Mapping[Tuple[str, str], str],
+    junctions: Mapping[tuple[str, str], str],
     choose_least_num_neg: bool = True,
 ):
     """
@@ -407,10 +405,10 @@ class CircuitGraph:
         self,
         nodes: Sequence,
         grd_node: str,
-        cmats: List[pd.DataFrame],
-        ind_lists: List[Dict[Tuple, float]],
-        junctions: Mapping[Tuple[str, str], str],
-        cj_dicts: List[Dict[Tuple, float]] = None,
+        cmats: list[pd.DataFrame],
+        ind_lists: list[dict[tuple, float]],
+        junctions: Mapping[tuple[str, str], str],
+        cj_dicts: list[dict[tuple, float]] = None,
         nodes_force_keep: Sequence = None,
         s_remove_provided: Union[np.ndarray, bool] = False,
         s_keep_provided: Union[np.ndarray, bool] = False,
@@ -746,13 +744,13 @@ class CircuitGraph:
 # ----------------------------------------------------------------------------------------------------
 
 
-def _rename_nodes_in_df(node_rename: Dict, df: pd.DataFrame) -> pd.DataFrame:
+def _rename_nodes_in_df(node_rename: dict, df: pd.DataFrame) -> pd.DataFrame:
     orig_nodes = df.columns.values.tolist()
     new_nodes = [n if n not in node_rename else node_rename[n] for n in orig_nodes]
     return _make_cmat_df(df.values, new_nodes)
 
 
-def _rename_nodes_in_dict(node_rename: Dict, dict_input: Dict[Tuple[str], Any]) -> Dict:
+def _rename_nodes_in_dict(node_rename: dict, dict_input: dict[tuple[str], Any]) -> dict:
     renamed = {}
     for nodes, val in dict_input.items():
         _renamed_key = tuple(
@@ -864,7 +862,7 @@ class Subsystem:
     coupled-transmon examples.
     """
 
-    def __init__(self, name: str, sys_type: str, nodes: List[str], q_opts: dict = None):
+    def __init__(self, name: str, sys_type: str, nodes: list[str], q_opts: dict = None):
         """Initialize the Subsystem object
 
         Args:
@@ -952,7 +950,7 @@ class QuantumBuilder(metaclass=_QuantumBuilderMeta):
 
 
 class QuantumBuilderOptions(argparse.Namespace):
-    def set_from_input(self, input_opts: Dict):
+    def set_from_input(self, input_opts: dict):
         if input_opts is not None and len(input_opts):
             for k, v in input_opts.items():
                 setattr(self, k, v)
@@ -1252,7 +1250,7 @@ class Cell:
     the the user provides as inputs to this object
     """
 
-    def __init__(self, options: Dict):
+    def __init__(self, options: dict):
         """Initialize the cell object
 
         Args:
@@ -1339,8 +1337,8 @@ class CompositeSystem:
 
     def __init__(
         self,
-        subsystems: List[Subsystem],
-        cells: List[Cell],
+        subsystems: list[Subsystem],
+        cells: list[Cell],
         grd_node: str,
         nodes_force_keep: Sequence = None,
         s_remove_provided: Union[np.ndarray, bool] = False,

--- a/src/qiskit_metal/analyses/quantization/lom_extensions.py
+++ b/src/qiskit_metal/analyses/quantization/lom_extensions.py
@@ -4,7 +4,7 @@ import sequencing as seq
 from qiskit_metal.analyses.quantization.lom_core_analysis import Subsystem
 
 
-def to_external_system(lom_subsystem: Subsystem, mapping: Dict[str, Any]):
+def to_external_system(lom_subsystem: Subsystem, mapping: dict[str, Any]):
     """Convert a Metal LOM subsystem to an external system based on a custom mapping
 
     Args:

--- a/src/qiskit_metal/analyses/quantization/lom_time_evolution_sim.py
+++ b/src/qiskit_metal/analyses/quantization/lom_time_evolution_sim.py
@@ -16,7 +16,7 @@ from qiskit_metal.analyses.quantization.lom_extensions import (
 def lom_composite_sys_to_seq_sys(
     lom_composite: CompositeSystem,
     hilbertspace: scq.HilbertSpace,
-    levels: List[int] = None,
+    levels: list[int] = None,
     system_name="system",
 ) -> seq.System:
     ## TODO: params for setting detuning and levels

--- a/src/qiskit_metal/analyses/quantization/lumped_capacitive.py
+++ b/src/qiskit_metal/analyses/quantization/lumped_capacitive.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -171,9 +169,9 @@ def extract_transmon_coupled_Noscillator(
     Ic: float,
     CJ: float,
     N: int,
-    fb: List[float],
+    fb: list[float],
     fr: float,
-    res_L4_corr: Optional[List[float]] = None,
+    res_L4_corr: list[float] | None = None,
     g_scale: float = 1.0,
     print_info: bool = False,
 ):
@@ -841,7 +839,7 @@ def df_cmat_style_print(df_cmat: pd.DataFrame):
 # Utility functions - Zlatko
 
 
-def move_index_to(i_from: List[int], i_to: List[int], len_):
+def move_index_to(i_from: list[int], i_to: list[int], len_):
     """Utility function to swap index.
 
     Args:

--- a/src/qiskit_metal/analyses/quantization/lumped_oscillator_model.py
+++ b/src/qiskit_metal/analyses/quantization/lumped_oscillator_model.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -55,7 +53,7 @@ class LOManalysis(QAnalysis):
     """Default data labels."""
 
     def __init__(
-        self, design: Optional["QDesign"] = None, renderer_name: Optional[str] = None
+        self, design: Optional["QDesign"] = None, renderer_name: str | None = None
     ):
         """Initialize the Lumped Oscillator Model analysis.
 
@@ -156,7 +154,7 @@ class LOManalysis(QAnalysis):
                     "Please initialize the capacitance_matrix before executing this method."
                     "`self.sim.capacitance_matrix = pd.DataFrame(...)`"
                 )
-                return
+                return None
             if self.sim.capacitance_all_passes == {}:
                 self.sim.capacitance_all_passes[1] = self.sim.capacitance_matrix.values
 

--- a/src/qiskit_metal/analyses/simulation/__init__.py
+++ b/src/qiskit_metal/analyses/simulation/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/simulation/eigenmode.py
+++ b/src/qiskit_metal/analyses/simulation/eigenmode.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -83,14 +81,14 @@ class EigenmodeSim(QSimulation):
 
     def run_sim(
         self,
-        name: Optional[str] = None,
-        components: Optional[list] = None,
-        open_terminations: Optional[list] = None,
-        port_list: Optional[list] = None,
-        jj_to_port: Optional[list] = None,
-        ignored_jjs: Optional[list] = None,
+        name: str | None = None,
+        components: list | None = None,
+        open_terminations: list | None = None,
+        port_list: list | None = None,
+        jj_to_port: list | None = None,
+        ignored_jjs: list | None = None,
         box_plus_buffer: bool = True,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """Executes the entire eigenmode analysis and convergence result export.
         First it makes sure the tool is running. Then it does what's necessary to render the design.
         Finally it runs the setup defined in this class. So you need to modify the setup ahead.
@@ -191,7 +189,7 @@ class EigenmodeSim(QSimulation):
             return
         self.set_data("convergence_t", data)
 
-    def compute_convergences(self, variation: Optional[str] = None):
+    def compute_convergences(self, variation: str | None = None):
         """Convergence plots are computed as part of run(). However, in special cases
         you might need to recalculate them using a different variation.
 
@@ -205,8 +203,8 @@ class EigenmodeSim(QSimulation):
 
     def plot_convergences(
         self,
-        convergence_t: Optional[pd.DataFrame] = None,
-        convergence_f: Optional[pd.DataFrame] = None,
+        convergence_t: pd.DataFrame | None = None,
+        convergence_f: pd.DataFrame | None = None,
         fig: mpl.figure.Figure = None,
         _display: bool = True,
     ):
@@ -277,7 +275,7 @@ class EigenmodeSim(QSimulation):
         self.renderer.set_mode(eigenmode, self.sim_setup_name)
         return self.renderer.plot_fields(*args, **kwargs, object_name=object_name)
 
-    def clear_fields(self, names: Optional[list] = None):
+    def clear_fields(self, names: list | None = None):
         """
         Delete field plots from renderer.
 

--- a/src/qiskit_metal/analyses/simulation/lumped_elements.py
+++ b/src/qiskit_metal/analyses/simulation/lumped_elements.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -102,11 +100,11 @@ class LumpedElementsSim(QSimulation):
 
     def run_sim(
         self,
-        name: Optional[str] = None,
-        components: Optional[list] = None,
-        open_terminations: Optional[list] = None,
+        name: str | None = None,
+        components: list | None = None,
+        open_terminations: list | None = None,
         box_plus_buffer: bool = True,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """Executes the capacitance matrix extraction.
         First it makes sure the tool is running. Then it does the necessary to render the design.
         Finally it runs the setup defined in this class. So you need to modify the setup ahead.

--- a/src/qiskit_metal/analyses/simulation/scattering_impedance.py
+++ b/src/qiskit_metal/analyses/simulation/scattering_impedance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -132,14 +130,14 @@ class ScatteringImpedanceSim(QSimulation):
 
     def run_sim(
         self,
-        name: Optional[str] = None,
-        components: Optional[list] = None,
-        open_terminations: Optional[list] = None,
-        port_list: Optional[list] = None,
-        jj_to_port: Optional[list] = None,
-        ignored_jjs: Optional[list] = None,
+        name: str | None = None,
+        components: list | None = None,
+        open_terminations: list | None = None,
+        port_list: list | None = None,
+        jj_to_port: list | None = None,
+        ignored_jjs: list | None = None,
         box_plus_buffer: bool = True,
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         """Executes the entire drivenmodal analysis and convergence result export.
         First it makes sure the tool is running. Then it does what's necessary to render the design.
         Finally it runs the setup and sweep defined in this class. You need to modify the setup

--- a/src/qiskit_metal/analyses/sweep_and_optimize/__init__.py
+++ b/src/qiskit_metal/analyses/sweep_and_optimize/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
+++ b/src/qiskit_metal/analyses/sweep_and_optimize/sweeper.py
@@ -25,7 +25,7 @@ class Sweeper:
         else:
             self.design = None
 
-    def run_sweep(self, *args, **kwarg) -> Tuple[Dict, int]:
+    def run_sweep(self, *args, **kwarg) -> tuple[Dict, int]:
         """Ansys will be opened, if not already open, with an inserted project.
         A design will be inserted by this method.
 
@@ -135,7 +135,7 @@ class Sweeper:
         option_path: list,
         a_value: Dict,
         all_sweep: Dict,
-    ) -> Tuple[Dict, int]:
+    ) -> tuple[Dict, int]:
         """Iterate through the values that user gave in option_sweep.
 
         Args:
@@ -204,7 +204,7 @@ class Sweeper:
 
     def error_check_sweep_input(
         self, qcomp_name: str, option_name: str, option_sweep: list
-    ) -> Tuple[list, Dict, int]:
+    ) -> tuple[list, Dict, int]:
         """Implement error checking of data for sweeping.
 
         Args:

--- a/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
+++ b/src/qiskit_metal/analyses/sweep_and_optimize/sweeping.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -52,7 +50,7 @@ class Sweeping:
 
     def error_check_sweep_input(
         self, qcomp_name: str, option_name: str, option_sweep: list
-    ) -> Tuple[Optional[list], Optional[Dict], int]:
+    ) -> tuple[list | None, Dict | None, int]:
         """Implement error checking of data for sweeping.
 
         Args:
@@ -443,10 +441,10 @@ class Sweeping:
         endcaps_render: list,
         ignored_jjs_render: list,
         box_plus_buffer_render: bool = True,
-        setup_args: Optional[Dict] = None,
+        setup_args: Dict | None = None,
         leave_last_design: bool = True,
         design_name: str = "Sweep_Eigenmode",
-    ) -> Tuple[Dict, int]:
+    ) -> tuple[Dict, int]:
         """
         Ansys must be open with inserted project. A design, "HFSS Design"
         with eigenmode solution-type will be inserted by this method.
@@ -578,8 +576,8 @@ class Sweeping:
         return all_sweep, 0
 
     def hfss_em_get_convergence(
-        self, a_hfss: "QHFSSRenderer", variation: Optional[str] = None
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, str, bool]:
+        self, a_hfss: "QHFSSRenderer", variation: str | None = None
+    ) -> tuple[pd.DataFrame, pd.DataFrame, str, bool]:
         """Use QHFSSRenderer to get convergence data from Ansys for eigenmode.
 
         Args:
@@ -601,7 +599,7 @@ class Sweeping:
 
         return convergence_t, convergence_f, text_list, convergence
 
-    def parse_text_from_hfss_convergence(self, gui_text: str) -> Tuple[list, bool]:
+    def parse_text_from_hfss_convergence(self, gui_text: str) -> tuple[list, bool]:
         """Parse the text obtained from hfss after analysis.
 
         Args:
@@ -630,8 +628,8 @@ class Sweeping:
         return text_list, convergence
 
     def hfss_dm_get_convergence(
-        self, a_hfss: "QHFSSRenderer", variation: Optional[str] = None
-    ) -> Tuple[pd.DataFrame, str, bool]:
+        self, a_hfss: "QHFSSRenderer", variation: str | None = None
+    ) -> tuple[pd.DataFrame, str, bool]:
         """Use QHFSSRenderer to get convergence data from Ansys for drivenmodal.
 
         Args:
@@ -658,10 +656,10 @@ class Sweeping:
         option_sweep: list,
         dm_render_args: Dict,
         dm_add_sweep_args: Dict,
-        setup_args: Optional[Dict] = None,
+        setup_args: Dict | None = None,
         leave_last_design: bool = True,
         design_name: str = "Sweep_DrivenModal",
-    ) -> Tuple[Dict, int]:
+    ) -> tuple[Dict, int]:
         """
         Ansys must be open with inserted project. A design, "HFSS Design"
         with Driven Modal solution-type will be inserted by this method.
@@ -1000,8 +998,8 @@ class Sweeping:
         return 0
 
     def get_quality_factor(
-        self, freqs: Optional[list] = None, kappa_over_2pis: Optional[list] = None
-    ) -> Optional[list]:
+        self, freqs: list | None = None, kappa_over_2pis: list | None = None
+    ) -> list | None:
         """Calculate Quality Factor = freqs/kappa_over_2pis.  Before division,
         some error checking.
 
@@ -1040,10 +1038,10 @@ class Sweeping:
         option_sweep: list,
         qcomp_render: list,
         endcaps_render: list,
-        setup_args: Optional[Dict] = None,
+        setup_args: Dict | None = None,
         leave_last_design: bool = True,
         design_name: str = "Sweep_Capacitance",
-    ) -> Tuple[Dict, int]:
+    ) -> tuple[Dict, int]:
         """Ansys must be open with an inserted project.  A design,
         "Q3D Extractor Design", will be inserted by this method.
 
@@ -1172,7 +1170,7 @@ class Sweeping:
     @classmethod
     def _test_if_q3d_analysis_converged(
         cls, target: float, current: float, passes_min: int
-    ) -> Optional[bool]:
+    ) -> bool | None:
         """Use solution-data from Ansys-Q3d to determine if converged.
 
         Args:
@@ -1198,7 +1196,7 @@ class Sweeping:
 
     def _parse_text_from_q3d_convergence(
         self, gui_text: str
-    ) -> Tuple[Optional[float], Optional[float]]:
+    ) -> tuple[float | None, float | None]:
         """Parse gui_text using a priori known formatting. Ansys-Q3D
         solution-data provides gui_text.
 
@@ -1258,7 +1256,7 @@ class Sweeping:
             )
         return min_num_of_passes
 
-    def _extract_target_delta(self, target_all: list) -> Optional[float]:
+    def _extract_target_delta(self, target_all: list) -> float | None:
         """Given a pre-formatted list, search and return the target-delta
         percentage for convergence.
 
@@ -1287,7 +1285,7 @@ class Sweeping:
             )
         return target
 
-    def _extract_current_delta(self, current_all: list) -> Optional[float]:
+    def _extract_current_delta(self, current_all: list) -> float | None:
         """Given a pre-formatted list, search and return the current-delta
         percentage for convergence.
 

--- a/src/qiskit_metal/config.py
+++ b/src/qiskit_metal/config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/designs/__init__.py
+++ b/src/qiskit_metal/designs/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/designs/design_base.py
+++ b/src/qiskit_metal/designs/design_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -103,7 +102,7 @@ class QDesign:
 
     def __init__(
         self,
-        metadata: Optional[dict] = None,
+        metadata: dict | None = None,
         overwrite_enabled: bool = False,
         enable_renderers: bool = True,
     ) -> None:
@@ -165,7 +164,7 @@ class QDesign:
         if metadata:
             self.update_metadata(metadata)
 
-        self.save_path: Optional[str] = None
+        self.save_path: str | None = None
 
         self.logger = logger  # type: logging.Logger
         self.build_logs = LogStore("Build Logs", 30)
@@ -235,7 +234,7 @@ class QDesign:
     #########PROPERTIES##################################################
 
     @property
-    def variables(self) -> Dict_[str, str]:
+    def variables(self) -> dict[str, str]:
         """Return the Dict object that keeps track of all variables in the
         design."""
         return self._variables
@@ -792,7 +791,7 @@ class QDesign:
         design = load_metal_design(path)
         return design
 
-    def save_design(self, path: Optional[str] = None):
+    def save_design(self, path: str | None = None):
         """Save the metal design to a Metal file. If no path is given, then
         tried to use self.save_path if it is set.
 
@@ -836,7 +835,7 @@ class QDesign:
 
     #########Creating Components##############################################
 
-    def parse_value(self, value: Union[Any, List, Dict, Iterable]) -> Any:
+    def parse_value(self, value: Union[Any, list, Dict, Iterable]) -> Any:
         """Main parsing function. Parse a string, mappable (dict, Dict),
         iterable (list, tuple) to account for units conversion, some basic
         arithmetic, and design variables.

--- a/src/qiskit_metal/designs/design_flipchip.py
+++ b/src/qiskit_metal/designs/design_flipchip.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -103,7 +101,7 @@ class DesignFlipChip(QDesign):
             sample_holder_bottom=self.variables["sample_holder_bottom"],
         )
 
-    def get_x_y_for_chip(self, chip_name: str) -> Tuple[tuple, int]:
+    def get_x_y_for_chip(self, chip_name: str) -> tuple[tuple, int]:
         """
         If the chip_name is in self.chips, along with entry for size
         information then return a tuple=(minx, miny, maxx, maxy). Used for

--- a/src/qiskit_metal/designs/design_multiplanar.py
+++ b/src/qiskit_metal/designs/design_multiplanar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -99,7 +97,7 @@ class MultiPlanar(QDesign):
             size_y="7mm",
         )
 
-    def get_x_y_for_chip(self, chip_name: str) -> Tuple[tuple, int]:
+    def get_x_y_for_chip(self, chip_name: str) -> tuple[tuple, int]:
         """If the chip_name is in self.chips, along with entry for size
         information then return a tuple=(minx, miny, maxx, maxy). Used for
         subtraction while exporting design.

--- a/src/qiskit_metal/designs/design_planar.py
+++ b/src/qiskit_metal/designs/design_planar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -60,7 +58,7 @@ class DesignPlanar(QDesign):
 
     def __init__(
         self,
-        metadata: Optional[dict] = None,
+        metadata: dict | None = None,
         overwrite_enabled: bool = False,
         enable_renderers: bool = True,
     ):
@@ -112,7 +110,7 @@ class DesignPlanar(QDesign):
 
     def get_x_y_for_chip(
         self, chip_name: str
-    ) -> Tuple[Tuple[float, float, float, float], int]:
+    ) -> tuple[tuple[float, float, float, float], int]:
         """If the chip_name is in self.chips, along with entry for size
         information then return a tuple=(minx, miny, maxx, maxy). Used for
         subtraction while exporting design.

--- a/src/qiskit_metal/designs/interface_components.py
+++ b/src/qiskit_metal/designs/interface_components.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -61,7 +59,7 @@ class Components:
         """
         return len(self.components)
 
-    def get_list_ints(self, component_names: List[str]) -> List[int]:
+    def get_list_ints(self, component_names: list[str]) -> list[int]:
         """Provide corresponding ints to be used as keys for dict:
         design._components, when list of names is provided.
 
@@ -263,7 +261,7 @@ class Components:
     #     #         # Why every class needs one?  https://dbader.org/blog/python-repr-vs-str
     #     #         return str(self.__actual_place_I_store_components__.give_me_repr())
 
-    def __dir__(self) -> List:
+    def __dir__(self) -> list:
         """Provide all the names in design._components.
 
         Returns:

--- a/src/qiskit_metal/designs/net_info.py
+++ b/src/qiskit_metal/designs/net_info.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/draw/__init__.py
+++ b/src/qiskit_metal/draw/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/draw/basic.py
+++ b/src/qiskit_metal/draw/basic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/draw/mpl.py
+++ b/src/qiskit_metal/draw/mpl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/draw/utility.py
+++ b/src/qiskit_metal/draw/utility.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -340,7 +338,7 @@ def vec_unit_planar(vector: np.array):
         raise Exception("You did not give a 2 or 3 vec")
 
 
-def to_vec3D(list_of_2d_pts: List[Tuple], z=0) -> np.ndarray:
+def to_vec3D(list_of_2d_pts: list[tuple], z=0) -> np.ndarray:
     """Adds 3rd point to list of 2D points. For the given design, get the z
     values in HFSS UNITS! Manually specify z dimension.
 
@@ -359,7 +357,7 @@ def to_vec3D(list_of_2d_pts: List[Tuple], z=0) -> np.ndarray:
     return vec3d
 
 
-def to_vec3D_list(list_of_2d_pts: List[Tuple], z=0) -> list:
+def to_vec3D_list(list_of_2d_pts: list[tuple], z=0) -> list:
     """Adds 3rd point to list of 2D points. For the given design, get the z
     values in HFSS UNITS! Manually specify z dimension.
 
@@ -581,7 +579,7 @@ class Vector:
         return round(abs(norm(u - v)), precision)
 
     @staticmethod
-    def two_points_described(points2D: List[Vec2D]) -> Tuple[np.ndarray]:
+    def two_points_described(points2D: list[Vec2D]) -> tuple[np.ndarray]:
         """Get the distance, units and tangents.
 
         Args:
@@ -895,8 +893,8 @@ class Vec3D(Vector):
 
     @staticmethod
     def two_points_described(
-        points3D: List[np.ndarray], user_plane: np.ndarray
-    ) -> Tuple[np.ndarray]:
+        points3D: list[np.ndarray], user_plane: np.ndarray
+    ) -> tuple[np.ndarray]:
         """Get the distance, units and tangents.
 
         Args:

--- a/src/qiskit_metal/qgeometries/__init__.py
+++ b/src/qiskit_metal/qgeometries/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qgeometries/qgeometries_handler.py
+++ b/src/qiskit_metal/qgeometries/qgeometries_handler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -269,7 +267,7 @@ class QGeometryTables:
         return self._design.logger
 
     @property
-    def tables(self) -> Dict_[str, GeoDataFrame]:
+    def tables(self) -> dict[str, GeoDataFrame]:
         """The dictionary of tables containing qgeometry.
 
         Returns:
@@ -312,7 +310,7 @@ class QGeometryTables:
     # could use weakref memorization
     # https://stackoverflow.com/questions/33672412/python-functools-lru-cache-with-class-methods-release-object
     @classmethod
-    def get_element_types(cls) -> List[str]:
+    def get_element_types(cls) -> list[str]:
         """Return the names of the available qgeometry to create. This does not
         include 'base', but is rather such as poly and path.
 
@@ -583,7 +581,7 @@ class QGeometryTables:
                             f"are index(es) in shapely geometry."
                         )
 
-    def parse_value(self, value: Union[Any, List, Dict, Iterable]) -> Any:
+    def parse_value(self, value: Union[Any, list, Dict, Iterable]) -> Any:
         """Same as design.parse_value. See design for help.
 
         Returns:
@@ -628,7 +626,7 @@ class QGeometryTables:
 
     def get_component(
         self, name: str, table_name: str = "all"
-    ) -> Union[GeoDataFrame, Dict_[str, GeoDataFrame], None]:
+    ) -> Union[GeoDataFrame, dict[str, GeoDataFrame], None]:
         """Return the table for just a given component. If all, returns a
         dictionary with keys as table names and tables of components as values.
 
@@ -660,7 +658,7 @@ class QGeometryTables:
             # comp_id = self.design.components[name].id
             # return df[df.component == comp_id]
 
-    def get_component_bounds(self, name: str) -> Tuple[float, float, float, float]:
+    def get_component_bounds(self, name: str) -> tuple[float, float, float, float]:
         """Returns a tuple containing minx, miny, maxx, maxy values for the
         bounds of the component as a whole.
 
@@ -698,7 +696,7 @@ class QGeometryTables:
 
     def get_component_geometry_list(
         self, name: str, table_name: str = "all"
-    ) -> List[BaseGeometry]:
+    ) -> list[BaseGeometry]:
         """Return just the bare element geometry (shapely geometry objects) as
         a list, for the selected component.
 
@@ -746,7 +744,7 @@ class QGeometryTables:
 
     def get_component_geometry_dict(
         self, name: str, table_name: str = "all"
-    ) -> List[BaseGeometry]:
+    ) -> list[BaseGeometry]:
         """Return just the bare element geometry (shapely geometry objects) as
         a dict, with key being the names of the qgeometry and the values as the
         shapely geometry, for the selected component.

--- a/src/qiskit_metal/qlibrary/__init__.py
+++ b/src/qiskit_metal/qlibrary/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/_template.py
+++ b/src/qiskit_metal/qlibrary/_template.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/core/__init__.py
+++ b/src/qiskit_metal/qlibrary/core/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/core/_parsed_dynamic_attrs.py
+++ b/src/qiskit_metal/qlibrary/core/_parsed_dynamic_attrs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -75,7 +73,7 @@ class ParsedDynamicAttributes_Component:
         __delattr__:        Called when an attribute deletion is attempted.
     """
 
-    def __init__(self, component: "QComponent", key_list: List[str] = None):
+    def __init__(self, component: "QComponent", key_list: list[str] = None):
         """
         Args:
             component (QComponent): Component to get options from.

--- a/src/qiskit_metal/qlibrary/core/base.py
+++ b/src/qiskit_metal/qlibrary/core/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -154,10 +152,10 @@ class QComponent:
     def __init__(
         self,
         design: "QDesign",
-        name: Optional[str] = None,
-        options: Optional[Dict] = None,
+        name: str | None = None,
+        options: Dict | None = None,
         make: bool = True,
-        component_template: Optional[Dict] = None,
+        component_template: Dict | None = None,
     ) -> None:
         """Create a new Metal component and adds it's default_options to the
         design.
@@ -450,9 +448,9 @@ class QComponent:
     def get_template_options(
         cls,
         design: "QDesign",
-        component_template: Optional[Dict] = None,
-        logger_: Optional[logging.Logger] = None,
-        template_key: Optional[str] = None,
+        component_template: Dict | None = None,
+        logger_: logging.Logger | None = None,
+        template_key: str | None = None,
     ) -> Dict:
         """Creates template options for the Metal Component class required for
         the class to function, based on the design template; i.e., be created,
@@ -502,7 +500,7 @@ class QComponent:
 
         return template_options
 
-    def _delete_evaluation(self, check_name: Optional[str] = None):
+    def _delete_evaluation(self, check_name: str | None = None):
         """When design.overwrite_enabled, the user is allowed to delete an
         existing component within the design if the name is being used.
 
@@ -547,7 +545,7 @@ class QComponent:
         """
         raise NotImplementedError()
 
-    def to_script(self, thin: bool = False, is_part_of_chip: bool = False) -> Tuple:
+    def to_script(self, thin: bool = False, is_part_of_chip: bool = False) -> tuple:
         """
 
         Args:
@@ -752,8 +750,8 @@ name='{strname}'{other_args}
     # Though the data table approach and rendering directly via shapely could lead to problem
     # with variable use
     def parse_value(
-        self, value: Union[Any, List, Dict, Iterable]
-    ) -> Union[Any, List, Dict, Iterable]:
+        self, value: Union[Any, list, Dict, Iterable]
+    ) -> Union[Any, list, Dict, Iterable]:
         """Parse a string, mappable (dict, Dict), iterable (list, tuple) to
         account for units conversion, some basic arithmetic, and design
         variables. This is the main parsing function of Qiskit Metal.
@@ -799,7 +797,7 @@ name='{strname}'{other_args}
         """
         return self.design.parse_value(value)
 
-    def parse_options(self, options: Optional[Dict] = None) -> Dict:
+    def parse_options(self, options: Dict | None = None) -> Dict:
         """Parse the options, converting string into interpreted values. Parses
         units, variables, strings, lists, and dictionaries. Explained by
         example below.
@@ -848,8 +846,8 @@ name='{strname}'{other_args}
         points: np.ndarray,
         width: float,
         input_as_norm: bool = False,
-        chip: Optional[str] = None,
-        gap: Optional[float] = None,
+        chip: str | None = None,
+        gap: float | None = None,
     ) -> None:  # gap defaults to 0.6 * width
         """Adds a pin from two points which are normal/tangent to the intended
         plane of the pin. The normal should 'point' in the direction of
@@ -1104,7 +1102,7 @@ name='{strname}'{other_args}
         subtract: bool = False,
         helper: bool = False,
         layer: Union[int, str, None] = None,  # chip will be here
-        chip: Optional[str] = None,
+        chip: str | None = None,
         **kwargs,
     ) -> None:
         r"""Add QGeometry.
@@ -1248,7 +1246,7 @@ name='{strname}'{other_args}
     # Geometry handling of created qgeometry
 
     @property
-    def qgeometry_types(self) -> List[str]:
+    def qgeometry_types(self) -> list[str]:
         """Get a list of the names of the element tables.
 
         Returns:
@@ -1256,7 +1254,7 @@ name='{strname}'{other_args}
         """
         return self.design.qgeometry.get_element_types()
 
-    def qgeometry_dict(self, element_type: str) -> Dict_[str, BaseGeometry]:
+    def qgeometry_dict(self, element_type: str) -> dict[str, BaseGeometry]:
         """Returns a dict of element qgeometry (shapely geometry) of the
         component as a python dict, where the dict keys are the names of the
         qgeometry and the corresponding values are the shapely geometries.
@@ -1276,7 +1274,7 @@ name='{strname}'{other_args}
                 self.name, element_type
             )
 
-    def qgeometry_list(self, element_type: str = "all") -> List[BaseGeometry]:
+    def qgeometry_list(self, element_type: str = "all") -> list[BaseGeometry]:
         """Returns a list of element qgeometry (shapely geometry) of the
         component as a python list of shapely geometries.
 
@@ -1312,7 +1310,7 @@ name='{strname}'{other_args}
         ):
             return self.design.qgeometry.get_component(self.name, element_type)
 
-    def qgeometry_bounds(self) -> Tuple:
+    def qgeometry_bounds(self) -> tuple:
         """Fetched the component bound dict_value.
 
         Returns:
@@ -1326,8 +1324,8 @@ name='{strname}'{other_args}
         return bounds
 
     def qgeometry_plot(
-        self, ax: "matplotlib.axes.Axes" = None, plot_kw: Optional[dict] = None
-    ) -> List:
+        self, ax: "matplotlib.axes.Axes" = None, plot_kw: dict | None = None
+    ) -> list:
         """Draw all the qgeometry of the component (polys and path etc.)
 
         Args:

--- a/src/qiskit_metal/qlibrary/core/qroute.py
+++ b/src/qiskit_metal/qlibrary/core/qroute.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -399,7 +397,7 @@ class QRoute(QComponent):
         # return the last QRoutePoint of the lead
         return lead.get_tip()
 
-    def _get_lead2pts_array(self, arr) -> Tuple:
+    def _get_lead2pts_array(self, arr) -> tuple:
         """Return the last "diff pts" of the array. If the array is one
         dimensional or has only identical points, return -1 for tip_pt_minus_1.
 
@@ -459,7 +457,7 @@ class QRoute(QComponent):
                 "unsupported type for self.intermediate_pts",
                 type(self.intermediate_pts),
             )
-            return
+            return None
         if tip_pt is None:
             # no point in the intermediate array
             return self.head.get_tip()
@@ -479,7 +477,7 @@ class QRoute(QComponent):
             list: List of points without colinear points
         """
         if len(inarray) <= 1:
-            return
+            return None
         else:
             outarray = list()  # outarray = np.empty(shape=[0, 2])
             pts = [None, None, inarray[0]]
@@ -531,7 +529,7 @@ class QRoute(QComponent):
 
     def get_unit_vectors(
         self, start: QRoutePoint, end: QRoutePoint, snap: bool = False
-    ) -> Tuple:
+    ) -> tuple:
         """Return the unit and target vector in which the CPW should process as
         its coordinate sys.
 

--- a/src/qiskit_metal/qlibrary/core/qubit.py
+++ b/src/qiskit_metal/qlibrary/core/qubit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/__init__.py
+++ b/src/qiskit_metal/qlibrary/couplers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/cap_n_interdigital_tee.py
+++ b/src/qiskit_metal/qlibrary/couplers/cap_n_interdigital_tee.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/coupled_line_tee.py
+++ b/src/qiskit_metal/qlibrary/couplers/coupled_line_tee.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/line_tee.py
+++ b/src/qiskit_metal/qlibrary/couplers/line_tee.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/tunable_coupler_01.py
+++ b/src/qiskit_metal/qlibrary/couplers/tunable_coupler_01.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/couplers/tunable_coupler_02.py
+++ b/src/qiskit_metal/qlibrary/couplers/tunable_coupler_02.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/lumped/__init__.py
+++ b/src/qiskit_metal/qlibrary/lumped/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/lumped/cap_3_interdigital.py
+++ b/src/qiskit_metal/qlibrary/lumped/cap_3_interdigital.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/lumped/cap_n_interdigital.py
+++ b/src/qiskit_metal/qlibrary/lumped/cap_n_interdigital.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/lumped/resonator_coil_rect.py
+++ b/src/qiskit_metal/qlibrary/lumped/resonator_coil_rect.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/JJ_Dolan.py
+++ b/src/qiskit_metal/qlibrary/qubits/JJ_Dolan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/JJ_Manhattan.py
+++ b/src/qiskit_metal/qlibrary/qubits/JJ_Manhattan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/SNAIL.py
+++ b/src/qiskit_metal/qlibrary/qubits/SNAIL.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/SQUID_loop.py
+++ b/src/qiskit_metal/qlibrary/qubits/SQUID_loop.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
+++ b/src/qiskit_metal/qlibrary/qubits/Transmon_Interdigitated.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/__init__.py
+++ b/src/qiskit_metal/qlibrary/qubits/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/star_qubit.py
+++ b/src/qiskit_metal/qlibrary/qubits/star_qubit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_concentric.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_concentric.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_concentric_type_2.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_concentric_type_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_cross_fl.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_cross_fl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_pocket.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_pocket.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_pocket_6.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_pocket_6.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_pocket_cl.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_pocket_cl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/qubits/transmon_pocket_teeth.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_pocket_teeth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/resonators/__init__.py
+++ b/src/qiskit_metal/qlibrary/resonators/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/resonators/resonator_lumped.py
+++ b/src/qiskit_metal/qlibrary/resonators/resonator_lumped.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/__init__.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/circle_caterpillar.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/circle_caterpillar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/circle_raster.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/circle_raster.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/n_gon.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/n_gon.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/n_square_spiral.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/n_square_spiral.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/rectangle.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/rectangle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/rectangle_hollow.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/rectangle_hollow.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/sample_shapes/smiley_face.py
+++ b/src/qiskit_metal/qlibrary/sample_shapes/smiley_face.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/__init__.py
+++ b/src/qiskit_metal/qlibrary/terminations/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/launchpad_wb.py
+++ b/src/qiskit_metal/qlibrary/terminations/launchpad_wb.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/launchpad_wb_coupled.py
+++ b/src/qiskit_metal/qlibrary/terminations/launchpad_wb_coupled.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/launchpad_wb_driven.py
+++ b/src/qiskit_metal/qlibrary/terminations/launchpad_wb_driven.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/open_to_ground.py
+++ b/src/qiskit_metal/qlibrary/terminations/open_to_ground.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/terminations/short_to_ground.py
+++ b/src/qiskit_metal/qlibrary/terminations/short_to_ground.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/__init__.py
+++ b/src/qiskit_metal/qlibrary/tlines/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/airbridge.py
+++ b/src/qiskit_metal/qlibrary/tlines/airbridge.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/anchored_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/anchored_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/framed_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/framed_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/meandered.py
+++ b/src/qiskit_metal/qlibrary/tlines/meandered.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/mixed_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/mixed_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/pathfinder.py
+++ b/src/qiskit_metal/qlibrary/tlines/pathfinder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/tlines/straight_path.py
+++ b/src/qiskit_metal/qlibrary/tlines/straight_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/qlibrary/user_components/my_qcomponent.py
+++ b/src/qiskit_metal/qlibrary/user_components/my_qcomponent.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/__init__.py
+++ b/src/qiskit_metal/renderers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_ansys/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/ansys_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -629,22 +627,22 @@ class QAnsysRenderer(QRendererAnalysis):
         self.modeler._modeler.ShowWindow()
         if not self.pinfo:
             self.logger.warning("pinfo is None.")
-            return
+            return None
 
         if self.pinfo.design:
             if not self.pinfo.design._fields_calc:
                 self.logger.warning("The _fields_calc in design is None.")
-                return
+                return None
             if not self.pinfo.design._modeler:
                 self.logger.warning("The _modeler in design is None.")
-                return
+                return None
         else:
             self.logger.warning("The design in pinfo is None.")
-            return
+            return None
 
         if not self.pinfo.setup:
             self.logger.warning("The setup in pinfo is None.")
-            return
+            return None
 
         # TODO: This is just a prototype - should add features and flexibility.
         oFieldsReport = (
@@ -1417,7 +1415,7 @@ class QAnsysRenderer(QRendererAnalysis):
                 )
             self.chip_subtract_dict[pin_dict["chip"]].add(endcap_name)
 
-    def get_chip_names(self) -> List[str]:
+    def get_chip_names(self) -> list[str]:
         """
         Obtain a list of chips on which the selection of components, if valid, resides.
 
@@ -1484,7 +1482,7 @@ class QAnsysRenderer(QRendererAnalysis):
             "The chip designation for this component is not 'main'. Please set chip='main' in its default_options dictionary, restart the kernel, and try again."
         )
 
-    def get_min_bounding_box(self) -> Tuple[float]:
+    def get_min_bounding_box(self) -> tuple[float]:
         """
         Determine the max/min x/y coordinates of the smallest rectangular, axis-aligned
         bounding box that will enclose a selection of components to render, given by

--- a/src/qiskit_metal/renderers/renderer_ansys/hfss_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/hfss_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -75,9 +73,7 @@ class QHFSSRenderer(QAnsysRenderer):
     )
     """HFSS Options"""
 
-    def __init__(
-        self, design: "QDesign", initiate=True, options: Optional[Dict] = None
-    ):
+    def __init__(self, design: "QDesign", initiate=True, options: Dict | None = None):
         """Create a QRenderer for HFSS simulations, subclassed from QAnsysRenderer.
 
         Args:
@@ -93,11 +89,11 @@ class QHFSSRenderer(QAnsysRenderer):
 
     def render_design(
         self,
-        selection: Optional[list] = None,
-        open_pins: Optional[list] = None,
-        port_list: Optional[list] = None,
-        jj_to_port: Optional[list] = None,
-        ignored_jjs: Optional[list] = None,
+        selection: list | None = None,
+        open_pins: list | None = None,
+        port_list: list | None = None,
+        jj_to_port: list | None = None,
+        ignored_jjs: list | None = None,
         box_plus_buffer: bool = True,
     ):
         """Initiate rendering of components in design contained in selection,
@@ -473,7 +469,7 @@ class QHFSSRenderer(QAnsysRenderer):
         )
         self.activate_ansys_design(name, "drivenmodal")
 
-    def activate_drivenmodal_setup(self, setup_name_activate: Optional[str] = None):
+    def activate_drivenmodal_setup(self, setup_name_activate: str | None = None):
         """
         (deprecated) use activate_ansys_setup()
         """
@@ -484,14 +480,14 @@ class QHFSSRenderer(QAnsysRenderer):
 
     def add_drivenmodal_setup(
         self,
-        name: Optional[str] = None,
-        freq_ghz: Optional[int] = None,
-        max_delta_s: Optional[float] = None,
-        max_passes: Optional[int] = None,
-        min_passes: Optional[int] = None,
-        min_converged: Optional[int] = None,
-        pct_refinement: Optional[int] = None,
-        basis_order: Optional[int] = None,
+        name: str | None = None,
+        freq_ghz: int | None = None,
+        max_delta_s: float | None = None,
+        max_passes: int | None = None,
+        min_passes: int | None = None,
+        min_converged: int | None = None,
+        pct_refinement: int | None = None,
+        basis_order: int | None = None,
         *args,
         **kwargs,
     ):
@@ -558,7 +554,7 @@ class QHFSSRenderer(QAnsysRenderer):
         )
         self.activate_ansys_design(name, "eigenmode")
 
-    def activate_eigenmode_setup(self, setup_name_activate: Optional[str] = None):
+    def activate_eigenmode_setup(self, setup_name_activate: str | None = None):
         """
         (deprecated) use activate_ansys_setup()
         """
@@ -569,15 +565,15 @@ class QHFSSRenderer(QAnsysRenderer):
 
     def add_eigenmode_setup(
         self,
-        name: Optional[str] = None,
-        min_freq_ghz: Optional[int] = None,
-        n_modes: Optional[int] = None,
-        max_delta_f: Optional[float] = None,
-        max_passes: Optional[int] = None,
-        min_passes: Optional[int] = None,
-        min_converged: Optional[int] = None,
-        pct_refinement: Optional[int] = None,
-        basis_order: Optional[int] = None,
+        name: str | None = None,
+        min_freq_ghz: int | None = None,
+        n_modes: int | None = None,
+        max_delta_f: float | None = None,
+        max_passes: int | None = None,
+        min_passes: int | None = None,
+        min_converged: int | None = None,
+        pct_refinement: int | None = None,
+        basis_order: int | None = None,
         *args,
         **kwargs,
     ):
@@ -975,7 +971,7 @@ class QHFSSRenderer(QAnsysRenderer):
             sweep.analyze_sweep()
             self.current_sweep = sweep
 
-    def get_params(self, param_name: Optional[list] = None):
+    def get_params(self, param_name: list | None = None):
         """Get one or more parameters (S, Y, or Z) as a function of frequency.
 
         Args:
@@ -989,10 +985,10 @@ class QHFSSRenderer(QAnsysRenderer):
         return freqs, Pcurves, Pparams
 
     # yapf: disable
-    def get_all_Pparms_matrices(self, matrix_size: int) -> Tuple[
-            Optional[pd.DataFrame],
-            Optional[pd.DataFrame],
-            Optional[pd.DataFrame]]:
+    def get_all_Pparms_matrices(self, matrix_size: int) -> tuple[
+            pd.DataFrame | None,
+            pd.DataFrame | None,
+            pd.DataFrame | None]:
         #yapf: enable
         '''
         S = scattering matrix, Y = Admittance, Z= impedance.
@@ -1019,7 +1015,7 @@ class QHFSSRenderer(QAnsysRenderer):
 
         return S_Pparams, Y_Pparams, Z_Pparams
 
-    def plot_params(self, param_name: Optional[list] = None):
+    def plot_params(self, param_name: list | None = None):
         """Plot one or more parameters (S, Y, or Z) as a function of frequency.
         S = scattering matrix, Y = Admittance, Z= impedance.
 
@@ -1053,7 +1049,7 @@ class QHFSSRenderer(QAnsysRenderer):
         if self.pinfo:
             return epr.DistributedAnalysis(self.pinfo)
 
-    def get_convergences(self, variation: Optional[str] = None):
+    def get_convergences(self, variation: str | None = None):
         """Get convergence for convergence_t, convergence_f, and text from GUI for solution data.
 
         Args:
@@ -1072,7 +1068,7 @@ class QHFSSRenderer(QAnsysRenderer):
             return convergence_t, convergence_f, text
 
     def plot_convergences(self,
-                          variation: Optional[str] = None,
+                          variation: str | None = None,
                           fig: mpl.figure.Figure = None):
         """
         (deprecated) use EPRanalysis.plot_convergences()
@@ -1082,7 +1078,7 @@ class QHFSSRenderer(QAnsysRenderer):
             'plot_convergence() that has been moved inside the EPRanalysis class.'
         )
 
-    def get_f_convergence(self, variation: Optional[str] = None, save_csv: bool = True):
+    def get_f_convergence(self, variation: str | None = None, save_csv: bool = True):
         """Create a report inside HFSS to plot the converge of frequency and
         style it. Saves report to csv file.
 

--- a/src/qiskit_metal/renderers/renderer_ansys/parse.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/parse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/q3d_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -515,7 +513,7 @@ class QQ3DRenderer(QAnsysRenderer):
 
     def _parse_text_from_q3d_convergence(
         self, gui_text: str
-    ) -> Tuple[Union[None, float], Union[None, float]]:
+    ) -> tuple[Union[None, float], Union[None, float]]:
         """Parse gui_text using a priori known formatting. Ansys-Q3D
         solution-data provides gui_text.
 

--- a/src/qiskit_metal/renderers/renderer_ansys/solution_types.py
+++ b/src/qiskit_metal/renderers/renderer_ansys/solution_types.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -82,30 +80,30 @@ Q3D_NAMES = frozenset(
 )
 
 
-def is_eigenmode(solution_type: Optional[str]) -> bool:
+def is_eigenmode(solution_type: str | None) -> bool:
     """True if ``solution_type`` names the HFSS Eigenmode solver."""
     return solution_type in EIGENMODE_NAMES
 
 
-def is_drivenmodal(solution_type: Optional[str]) -> bool:
+def is_drivenmodal(solution_type: str | None) -> bool:
     """True if ``solution_type`` names any alias of the HFSS Driven
     Modal solver, including the post-2024.1 ``HFSS Modal Network`` and
     ``HFSS Hybrid Modal Network`` identifiers."""
     return solution_type in DRIVEN_MODAL_NAMES
 
 
-def is_driventerminal(solution_type: Optional[str]) -> bool:
+def is_driventerminal(solution_type: str | None) -> bool:
     """True if ``solution_type`` names any alias of the HFSS Driven
     Terminal solver."""
     return solution_type in DRIVEN_TERMINAL_NAMES
 
 
-def is_q3d(solution_type: Optional[str]) -> bool:
+def is_q3d(solution_type: str | None) -> bool:
     """True if ``solution_type`` names the Q3D Extractor solver."""
     return solution_type in Q3D_NAMES
 
 
-def canonical_kind(solution_type: Optional[str]) -> Optional[str]:
+def canonical_kind(solution_type: str | None) -> str | None:
     """Map a raw HFSS / Q3D ``solution_type`` string to its canonical
     metal-internal kind.
 

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/__init__.py
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 # """ Renderer using pyaedt and multiplanar using Ansys API."""

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_aedt.py
@@ -354,7 +354,7 @@ class QHFSSPyaedt(QPyaedt):
                     port_list: Union[list, None],
                     jj_to_port: Union[list, None],
                     ignored_jjs: Union[list,None],
-                    layer_num: int) -> Tuple[
+                    layer_num: int) -> tuple[
                                             Union[list, None],
                                             Union[list, None],
                                             Union[list, None],

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_drivenmodal_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_drivenmodal_aedt.py
@@ -140,7 +140,7 @@ class QHFSSDrivenmodalPyaedt(QHFSSPyaedt):
                 f"project:{self.project_name} design: {self.design_name}. "
                 f"So a new setup with name={name} was NOT added to design."
             )
-            return
+            return None
 
         if not Frequency:
             Frequency = float(self.parse_value(dsu["Frequency"]))

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/hfss_renderer_eigenmode_aedt.py
@@ -130,7 +130,7 @@ class QHFSSEigenmodePyaedt(QHFSSPyaedt):
                 f"project:{self.project_name} design: {self.design_name}. "
                 f"So a new setup with name={name} was NOT added to design."
             )
-            return
+            return None
 
         if not MinimumFrequency:
             MinimumFrequency = float(self.parse_value(esu["MinimumFrequency"]))

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/pyaedt_base.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/pyaedt_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import List, Union
@@ -598,7 +596,7 @@ class QPyaedt(QRendererAnalysis):
         """
 
     def render_design(
-        self, selection: Union[List, None] = None, box_plus_buffer: bool = True
+        self, selection: Union[list, None] = None, box_plus_buffer: bool = True
     ):
         """Must be implemented by the subclass to finish the logic for HFSS  OR Q3D within project.
 
@@ -943,7 +941,7 @@ class QPyaedt(QRendererAnalysis):
         #                     solve_inside=False,
         #                 )
 
-    def get_chip_names(self) -> List[str]:
+    def get_chip_names(self) -> list[str]:
         """
         Obtain a list of chips on which the selection of components, if valid, resides.
 

--- a/src/qiskit_metal/renderers/renderer_ansys_pyaedt/q3d_renderer_aedt.py
+++ b/src/qiskit_metal/renderers/renderer_ansys_pyaedt/q3d_renderer_aedt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import annotations
 
 from typing import Union, Tuple, Optional
@@ -52,10 +50,10 @@ class QQ3DPyaedt(QPyaedt):
     def __init__(
         self,
         multilayer_design: "MultiPlanar",
-        project_name: Optional[str] = None,
-        design_name: Optional[str] = None,
+        project_name: str | None = None,
+        design_name: str | None = None,
         initiate=False,
-        options: Optional[Dict] = None,
+        options: Dict | None = None,
     ):
         """Create a QRenderer for Q3D simulations using pyaedt and multiplanar design.
         QQ3DPyaedt is subclassed from QPyaedt, subclassed from QRendererAnalysis and
@@ -125,18 +123,18 @@ class QQ3DPyaedt(QPyaedt):
 
     def add_q3d_setup(
         self,
-        name: Optional[str] = None,
-        AdaptiveFreq: Optional[float] = None,
-        SaveFields: Optional[bool] = None,
-        Enabled: Optional[bool] = None,
-        MaxPass: Optional[int] = None,
-        MinPass: Optional[int] = None,
-        MinConvPass: Optional[int] = None,
-        PerError: Optional[float] = None,
-        PerRefine: Optional[int] = None,
-        AutoIncreaseSolutionOrder: Optional[bool] = None,
-        SolutionOrder: Optional[str] = None,
-        Solver_Type: Optional[str] = None,
+        name: str | None = None,
+        AdaptiveFreq: float | None = None,
+        SaveFields: bool | None = None,
+        Enabled: bool | None = None,
+        MaxPass: int | None = None,
+        MinPass: int | None = None,
+        MinConvPass: int | None = None,
+        PerError: float | None = None,
+        PerRefine: int | None = None,
+        AutoIncreaseSolutionOrder: bool | None = None,
+        SolutionOrder: str | None = None,
+        Solver_Type: str | None = None,
     ):
         """Create a solution setup in Ansys Q3D. If user does not provide
         arguments, they will be obtained from QQ3DPyaedt.default_setup dict.
@@ -454,7 +452,7 @@ class QQ3DPyaedt(QPyaedt):
             all_cap_data_magnitude_freqs[freq] = all_cap_data_magnitude
         return all_cap_data_magnitude_freqs
 
-    def convert_to_dataframe(self, cap_series: pd.Series) -> Optional[pd.DataFrame]:
+    def convert_to_dataframe(self, cap_series: pd.Series) -> pd.DataFrame | None:
         """Convert the series to a dataframe based on the column names.
         If the names are missing, then the dataframe will be None.
 
@@ -492,7 +490,7 @@ class QQ3DPyaedt(QPyaedt):
 
         return df
 
-    def get_unique_row_and_col_names(self, cap_series: pd.Series) -> Tuple[list, list]:
+    def get_unique_row_and_col_names(self, cap_series: pd.Series) -> tuple[list, list]:
         """Parse the names in the series and identify the unique names
         for rows and columns
 

--- a/src/qiskit_metal/renderers/renderer_base/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_base/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_base/renderer_base.py
+++ b/src/qiskit_metal/renderers/renderer_base/renderer_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -306,7 +304,7 @@ class QRenderer(ABC):
 
         return options
 
-    def parse_value(self, value: Union[Any, List, Dict, Iterable]) -> Any:
+    def parse_value(self, value: Union[Any, list, Dict, Iterable]) -> Any:
         """Same as design.parse_value. See design for help.
 
         Returns:
@@ -412,7 +410,7 @@ class QRenderer(ABC):
 
     def get_unique_component_ids(
         self, highlight_qcomponents: Union[list, None] = None
-    ) -> Tuple[list, int]:
+    ) -> tuple[list, int]:
         """Confirm the list doesn't have names of components repeated. Confirm
         that the name of component exists in QDesign. If QDesign doesn't
         contain any component, or if all components in QDesign are found in

--- a/src/qiskit_metal/renderers/renderer_base/renderer_gui_base.py
+++ b/src/qiskit_metal/renderers/renderer_base/renderer_gui_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_base/rndr_analysis.py
+++ b/src/qiskit_metal/renderers/renderer_base/rndr_analysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_elmer/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_elmer/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2022.

--- a/src/qiskit_metal/renderers/renderer_elmer/elmer_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_elmer/elmer_renderer.py
@@ -188,7 +188,7 @@ class QElmerRenderer(QRendererAnalysis):
         skip_junctions: bool = False,
         mesh_geoms: bool = True,
         ignore_metal_volume: bool = False,
-        omit_ground_for_layers: Optional[list[int]] = None,
+        omit_ground_for_layers: list[int] | None = None,
     ):
         """Render the design in Gmsh and apply changes to modify the geometries
         according to the type of simulation. Simulation parameters provided by the user.
@@ -759,7 +759,7 @@ class QElmerRenderer(QRendererAnalysis):
         """
         self.gmsh.render_element_poly(poly)
 
-    def save_screenshot(self, path: Optional[str] = None, show: bool = True):
+    def save_screenshot(self, path: str | None = None, show: bool = True):
         """Save the screenshot.
 
         Args:

--- a/src/qiskit_metal/renderers/renderer_gds/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_gds/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_gds/gds_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_gds/gds_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -271,8 +269,8 @@ class QGDSRenderer(QRenderer):
         self,
         design: "QDesign",
         initiate=True,
-        render_template: Optional[Dict] = None,
-        render_options: Optional[Dict] = None,
+        render_template: Dict | None = None,
+        render_options: Dict | None = None,
     ):
         """Create a QRenderer for GDS interface: export and import.
 
@@ -297,10 +295,10 @@ class QGDSRenderer(QRenderer):
         self.lib: Union[gdstk.Library, None] = None
         self.new_gds_library()
 
-        self.dict_bounds: DictType[str, Dict] = Dict()
+        self.dict_bounds: dict[str, Dict] = Dict()
 
         # Updated each time export_to_gds() is called.
-        self.chip_info: DictType[str, dict] = dict()
+        self.chip_info: dict[str, dict] = dict()
 
         # check the scale
         self._check_bounding_box_scale()
@@ -399,7 +397,7 @@ class QGDSRenderer(QRenderer):
     @staticmethod
     def _get_bounds(
         gs_table: geopandas.GeoDataFrame,
-    ) -> Tuple[float, float, float, float]:
+    ) -> tuple[float, float, float, float]:
         """Get the bounds for all of the elements in gs_table.
 
         Args:
@@ -445,7 +443,7 @@ class QGDSRenderer(QRenderer):
     @staticmethod
     def _midpoint_xy(
         x_1: float, y_1: float, x_2: float, y_2: float
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """Calculate the center of a line segment with endpoints (x1,y1) and
         (x2,y2).
 
@@ -467,7 +465,7 @@ class QGDSRenderer(QRenderer):
 
     def _scale_max_bounds(
         self, chip_name: str, all_bounds: list
-    ) -> Tuple[tuple, tuple]:
+    ) -> tuple[tuple, tuple]:
         """Given the list of tuples to represent all of the bounds for path,
         poly, etc. This will return the scaled using self.bounding_box_scale_x
         and self.bounding_box_scale_y, and the max bounds of the tuples
@@ -516,8 +514,8 @@ class QGDSRenderer(QRenderer):
         return scaled_box, (minx, miny, maxx, maxy)
 
     def _check_qcomps(
-        self, highlight_qcomponents: Optional[list] = None
-    ) -> Tuple[list, int]:
+        self, highlight_qcomponents: list | None = None
+    ) -> tuple[list, int]:
         """Confirm the list doesn't have names of components repeated. Confirm
         that the name of component exists in QDesign.
 
@@ -561,7 +559,7 @@ class QGDSRenderer(QRenderer):
         return unique_qcomponents, 0
 
     def _create_qgeometry_for_gds(
-        self, highlight_qcomponents: Optional[list] = None
+        self, highlight_qcomponents: list | None = None
     ) -> int:
         """Using self.design, this method does the following:
 
@@ -785,7 +783,7 @@ class QGDSRenderer(QRenderer):
 
     def _check_length(
         self, a_shapely: shapely.geometry.LineString, a_fillet: float
-    ) -> Tuple[int, Dict]:
+    ) -> tuple[int, Dict]:
         """Determine if a_shapely has short segments based on scaled fillet
         value.
 
@@ -1507,7 +1505,7 @@ class QGDSRenderer(QRenderer):
             return combo_shapely
         return None  # Need explicitly to avoid lint warnings.
 
-    def _get_rectangle_points(self, chip_name: str) -> Tuple[list, list]:
+    def _get_rectangle_points(self, chip_name: str) -> tuple[list, list]:
         """There can be more than one chip in QGeometry. All chips export to
         one gds file. Each chip uses its own subtract rectangle.
 
@@ -1763,7 +1761,7 @@ class QGDSRenderer(QRenderer):
 
     def _get_linestring_characteristics(
         self, row: pd.Series
-    ) -> Tuple[Tuple, float, float]:
+    ) -> tuple[tuple, float, float]:
         """Given a row in the Junction table, give the characteristics of
         LineString in row.geometry.
 
@@ -1796,9 +1794,9 @@ class QGDSRenderer(QRenderer):
 
     def _give_rotation_center_twopads(
         self, row: pd.Series, a_cell_bounding_box: np.ndarray
-    ) -> Tuple[
+    ) -> tuple[
         float,
-        Tuple[float, float],
+        tuple[float, float],
         Union[gdstk.Polygon, None],
         Union[gdstk.Polygon, None],
     ]:
@@ -1878,7 +1876,7 @@ class QGDSRenderer(QRenderer):
     ############
 
     def import_junction_gds_file(
-        self, lib: gdstk.Library, directory_name: Optional[str] = None
+        self, lib: gdstk.Library, directory_name: str | None = None
     ) -> bool:
         """Import the file which contains all junctions for design.
 
@@ -2610,7 +2608,7 @@ class QGDSRenderer(QRenderer):
                 gds.debug_summarize_gds_library(lib, show=True, scale=200, width=1000)
         """
         # Collect per (layer, datatype) stats first so we can colour the SVG.
-        layer_stats: DictType[Tuple[int, int], DictType[str, int]] = defaultdict(
+        layer_stats: dict[tuple[int, int], dict[str, int]] = defaultdict(
             lambda: {"polygons": 0, "paths": 0}
         )
 
@@ -2729,11 +2727,11 @@ class QGDSRenderer(QRenderer):
     @staticmethod
     def plot_gds_zoom(
         lib: gdstk.Library,
-        center_mm: Tuple[float, float],
+        center_mm: tuple[float, float],
         span_mm: float = 0.10,
-        title: Optional[str] = None,
-        ax: Optional[object] = None,
-        figsize: Tuple[float, float] = (5.0, 5.0),
+        title: str | None = None,
+        ax: object | None = None,
+        figsize: tuple[float, float] = (5.0, 5.0),
     ) -> object:
         """Render a zoomed window of a GDS library using matplotlib.
 
@@ -2798,7 +2796,7 @@ class QGDSRenderer(QRenderer):
         top = next((c for c in lib.cells if c.name == "TOP"), lib.cells[0])
 
         # Collect visible polygons grouped by (layer, datatype)
-        groups: DictType[Tuple[int, int], list] = {}
+        groups: dict[tuple[int, int], list] = {}
         for poly in top.get_polygons(depth=None):
             pts = poly.points
             if pts[:, 0].max() < x0 or pts[:, 0].min() > x1:

--- a/src/qiskit_metal/renderers/renderer_gds/make_cheese.py
+++ b/src/qiskit_metal/renderers/renderer_gds/make_cheese.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_gmsh/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2022.

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_renderer.py
@@ -241,7 +241,7 @@ class QGmshRenderer(QRenderer):
         skip_junctions: bool = False,
         mesh_geoms: bool = True,
         ignore_metal_volume: bool = False,
-        omit_ground_for_layers: Optional[list[int]] = None,
+        omit_ground_for_layers: list[int] | None = None,
     ):
         """Render the design in Gmsh and apply changes to modify the geometries
         according to the type of simulation. Simulation parameters provided by the user.
@@ -311,7 +311,7 @@ class QGmshRenderer(QRenderer):
         open_pins: Union[list, None] = None,
         box_plus_buffer: bool = True,
         skip_junctions: bool = False,
-        omit_ground_for_layers: Optional[list[int]] = None,
+        omit_ground_for_layers: list[int] | None = None,
     ):
         """This function draws the raw geometries in Gmsh as taken from the
         QGeometry tables and applies thickness depending on the layer-stack.
@@ -424,7 +424,7 @@ class QGmshRenderer(QRenderer):
         else:
             self.logger.error(f"RENDERER ERROR: Unkown element type: {table_type}")
 
-    def make_general_surface(self, curves: List[int]) -> int:
+    def make_general_surface(self, curves: list[int]) -> int:
         """Create a general Gmsh surface.
 
         Args:
@@ -568,7 +568,7 @@ class QGmshRenderer(QRenderer):
             else:
                 self.paths_dict[path.layer][qc_name] = [surface]
 
-    def make_poly_surface(self, points: List[np.ndarray], chip_z: float) -> int:
+    def make_poly_surface(self, points: list[np.ndarray], chip_z: float) -> int:
         """Make a Gmsh surface for creating poly type QGeometries
 
         Args:
@@ -706,7 +706,7 @@ class QGmshRenderer(QRenderer):
     def render_layers(
         self,
         draw_sample_holder: bool,
-        omit_layers: Optional[List[int]] = None,
+        omit_layers: list[int] | None = None,
         box_plus_buffer: bool = True,
     ):
         """Render all chips of the design. calls `render_chip` to render the actual geometries
@@ -805,7 +805,7 @@ class QGmshRenderer(QRenderer):
 
         self.layers_dict[layer_number] = [layer_tag]
 
-    def subtract_from_layers(self, omit_layers: Optional[list[int]] = None):
+    def subtract_from_layers(self, omit_layers: list[int] | None = None):
         """Subtract the QGeometries in tables from the chip ground plane
 
         Args:

--- a/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
+++ b/src/qiskit_metal/renderers/renderer_gmsh/gmsh_utils.py
@@ -40,8 +40,8 @@ class Vec3DArray:
         Vec3DArray: Array of np.ndarray objects
     """
 
-    points: List[np.ndarray]
-    path_vecs: List[np.ndarray] = field(init=False)
+    points: list[np.ndarray]
+    path_vecs: list[np.ndarray] = field(init=False)
 
     def __post_init__(self):
         """This is to initialize the `path_vecs` field separately
@@ -57,7 +57,7 @@ class Vec3DArray:
             v12 = Vec3D.normed(Vec3D.sub(v2, v1))
             self.path_vecs.append(v12)
 
-    def append(self, vecs: List[np.ndarray]):
+    def append(self, vecs: list[np.ndarray]):
         """Append vector to the array
 
         Args:
@@ -87,7 +87,7 @@ class Vec3DArray:
         return np.round(np.pi - np.arccos(Vec3D.dot(v1, v2)), decimals=9)
 
     @staticmethod
-    def make_vec3DArray(points: List[List[Union[int, float]]], layer_z: float = None):
+    def make_vec3DArray(points: list[list[Union[int, float]]], layer_z: float = None):
         """Create a Vec3DArray object from list of points
 
         Args:
@@ -121,7 +121,7 @@ class Vec3DArray:
         return Vec3DArray(vecs)
 
 
-def vecs_to_gmsh_points(vecs: List[np.ndarray], layer_z: float) -> list:
+def vecs_to_gmsh_points(vecs: list[np.ndarray], layer_z: float) -> list:
     """Create Gmsh points from np.ndarray objs
 
     Args:
@@ -212,7 +212,7 @@ def arc_width_offset_pts(
 
 def make_arc_vecs(
     angle: float, fillet: float
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Create vectors for the circle arc
 
     Args:
@@ -315,7 +315,7 @@ def remove_degenerate_segments(coords: list, min_len: float) -> list:
 
 def draw_curves(
     recent_pts: list, curves1: list, curves2: list
-) -> Tuple[list, list, list]:
+) -> tuple[list, list, list]:
     """Draw the curves using control points
 
     Args:
@@ -358,7 +358,7 @@ def render_path_curves(
     layer_z: float,
     fillet: float,
     width: float,
-    bad_fillet_idxs: List[int],
+    bad_fillet_idxs: list[int],
     straight_line_tol: float = 1e-9,
 ) -> list:
     """Helper function for rendering path QGeometry curves

--- a/src/qiskit_metal/renderers/renderer_mpl/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_mpl/extensions/__init__.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/extensions/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_mpl/extensions/animated_text.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/extensions/animated_text.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_canvas.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_canvas.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -671,7 +669,7 @@ class PlotCanvas(FigureCanvas):
             # ax.redraw_in_frame()
             self.refresh()
 
-    def find_component_bounds(self, components: List[str], zoom: float = 1.2):
+    def find_component_bounds(self, components: list[str], zoom: float = 1.2):
         """Find bounds of a set of components.
 
         Args:
@@ -735,7 +733,7 @@ class PlotCanvas(FigureCanvas):
         self._annotations["patch"] = []
         self._annotations["text"] = []
 
-    def highlight_components(self, component_names: List[str]):
+    def highlight_components(self, component_names: list[str]):
         """Highlight a list of components.
 
         Args:

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_interaction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -65,7 +63,7 @@ class QMplRenderer:
         design: QDesign,
         *,
         canvas: Optional["PlotCanvas"] = None,
-        logger: Optional[logging.Logger] = None,
+        logger: logging.Logger | None = None,
     ):
         """
         Args:
@@ -285,7 +283,7 @@ class QMplRenderer:
         table: pd.DataFrame,
         ax: Axes,
         subtracted: bool = False,
-        extra_kw: Optional[dict] = None,
+        extra_kw: dict | None = None,
     ):
         """Render a table of junction geometry.
         A junction is basically drawn like a path with finite width and no fillet.
@@ -326,7 +324,7 @@ class QMplRenderer:
         table: pd.DataFrame,
         ax: Axes,
         subtracted: bool = False,
-        extra_kw: Optional[dict] = None,
+        extra_kw: dict | None = None,
     ):
         """Render a table of poly geometry.
         Args:
@@ -483,7 +481,7 @@ class QMplRenderer:
         table: pd.DataFrame,
         ax: Axes,
         subtracted: bool = False,
-        extra_kw: Optional[dict] = None,
+        extra_kw: dict | None = None,
     ):
         """Render a table of path geometry.
         Args:

--- a/src/qiskit_metal/renderers/renderer_mpl/mpl_toolbox.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/mpl_toolbox.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/renderer_mpl/patch.py
+++ b/src/qiskit_metal/renderers/renderer_mpl/patch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2022.

--- a/src/qiskit_metal/renderers/setup_default.py
+++ b/src/qiskit_metal/renderers/setup_default.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/renderers/utils.py
+++ b/src/qiskit_metal/renderers/utils.py
@@ -3,8 +3,8 @@ from qiskit_metal.designs.design_base import QDesign
 
 
 def get_min_bounding_box(
-    design: QDesign, qcomp_ids: List[int], case: int, logger
-) -> Tuple[float]:
+    design: QDesign, qcomp_ids: list[int], case: int, logger
+) -> tuple[float]:
     """
     Determine the max/min x/y coordinates of the smallest rectangular, axis-aligned
     bounding box that will enclose a selection of components to render, given by

--- a/src/qiskit_metal/toolbox_metal/__init__.py
+++ b/src/qiskit_metal/toolbox_metal/__init__.py
@@ -1,5 +1,3 @@
-## -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_metal/bounds_for_path_and_poly_tables.py
+++ b/src/qiskit_metal/toolbox_metal/bounds_for_path_and_poly_tables.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from re import sub
 from typing import List, Tuple, Union
 from copy import deepcopy
@@ -12,7 +11,7 @@ def determine_larger_box(
     maxx: Union[None, float],
     maxy: Union[None, float],
     chip_box: tuple,
-) -> Tuple[float, float, float, float]:
+) -> tuple[float, float, float, float]:
     """Return box which includes the two boxes.
 
     Args:
@@ -56,7 +55,7 @@ class BoundsForPathAndPolyTables:
     def get_bounds_of_path_and_poly_tables(
         self,
         box_plus_buffer: bool,
-        qcomp_ids: List,
+        qcomp_ids: list,
         case: int,
         x_buff: float,
         y_buff: float,
@@ -167,8 +166,8 @@ class BoundsForPathAndPolyTables:
 
     @classmethod
     def ensure_component_box_smaller_than_chip_box_(
-        cls, box_for_xy_bounds: Tuple, chip_bounds_xy: Tuple
-    ) -> Tuple:
+        cls, box_for_xy_bounds: tuple, chip_bounds_xy: tuple
+    ) -> tuple:
         """If the box_plus_buffer is larger than the aggregate chip bounds from DesignPlanar,
         use the chip bounds as the cutoff.
 
@@ -210,7 +209,7 @@ class BoundsForPathAndPolyTables:
 
     def get_box_for_xy_bounds(
         self,
-    ) -> Union[None, Tuple[float, float, float, float]]:
+    ) -> Union[None, tuple[float, float, float, float]]:
         """Assuming the chip size is used from Multiplanar design, and list of chip_names
         comes from layer_stack that will be used to determine the box size for simulation.
 
@@ -242,7 +241,7 @@ class BoundsForPathAndPolyTables:
 
         return minx, miny, maxx, maxy
 
-    def are_all_chipnames_in_design(self) -> Tuple[bool, Union[set, None]]:
+    def are_all_chipnames_in_design(self) -> tuple[bool, Union[set, None]]:
         """Using chip names in layer_stack information,
         then check if the information is in MultiPlanar design.
 
@@ -262,7 +261,7 @@ class BoundsForPathAndPolyTables:
 
         return True, chip_set_from_layer_stack
 
-    def get_x_y_for_chip(self, chip_name: str) -> Tuple[tuple, int]:
+    def get_x_y_for_chip(self, chip_name: str) -> tuple[tuple, int]:
         """If the chip_name is in self.chips, along with entry for size
         information then return a tuple=(minx, miny, maxx, maxy). Used for
         subtraction while exporting design.

--- a/src/qiskit_metal/toolbox_metal/exceptions.py
+++ b/src/qiskit_metal/toolbox_metal/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_metal/import_export.py
+++ b/src/qiskit_metal/toolbox_metal/import_export.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_metal/layer_stack_handler.py
+++ b/src/qiskit_metal/toolbox_metal/layer_stack_handler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 from re import search
@@ -30,7 +28,7 @@ class LayerStackHandler:
     ]
 
     def __init__(
-        self, multi_planar_design: "MultiPlanar", fname: Optional[str] = None
+        self, multi_planar_design: "MultiPlanar", fname: str | None = None
     ) -> None:
         """Use the information in MultiPlanar design to parse_value
         and get the name of filename for layer stack.
@@ -88,7 +86,7 @@ class LayerStackHandler:
             # enter very basic default data for pandas table.
             self.ls_df = pd.DataFrame(data=self.layer_stack_default)
 
-    def get_layer_datatype_when_fill_is_true(self) -> Optional[dict]:
+    def get_layer_datatype_when_fill_is_true(self) -> dict | None:
         """Return layer/datatype rows where ``fill`` is True.
 
         Returns:
@@ -135,8 +133,8 @@ class LayerStackHandler:
         return None
 
     def get_properties_for_layer_datatype(
-        self, properties: List[str], layer_number: int, datatype: int = 0
-    ) -> Optional[Tuple[Union[float, str, bool]]]:
+        self, properties: list[str], layer_number: int, datatype: int = 0
+    ) -> tuple[Union[float, str, bool]] | None:
         """When user provides a layer and datatype, they can get properties
          from the layer_stack file. The allowed options for properties must
          be in Col_Names.  If any of the properties are not in Col_Names,

--- a/src/qiskit_metal/toolbox_metal/math_and_overrides.py
+++ b/src/qiskit_metal/toolbox_metal/math_and_overrides.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_metal/parsing.py
+++ b/src/qiskit_metal/toolbox_metal/parsing.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_python/__init__.py
+++ b/src/qiskit_metal/toolbox_python/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_python/_logging.py
+++ b/src/qiskit_metal/toolbox_python/_logging.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -116,7 +114,7 @@ class LogStore(collections.deque):
         self,
         title: str,
         log_limit: int,
-        _previous_builds: List[str] = [],
+        _previous_builds: list[str] = [],
         *args,
         **kwargs,
     ):

--- a/src/qiskit_metal/toolbox_python/attr_dict.py
+++ b/src/qiskit_metal/toolbox_python/attr_dict.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/toolbox_python/display.py
+++ b/src/qiskit_metal/toolbox_python/display.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -201,7 +199,7 @@ def style_colon_list(
 
 
 def format_dict_ala_z(
-    dic: Dict_,
+    dic: dict,
     indent=0,
     key_width=20,
     do_repr=True,

--- a/src/qiskit_metal/toolbox_python/utility_functions.py
+++ b/src/qiskit_metal/toolbox_python/utility_functions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -567,7 +565,7 @@ def can_write_to_path_with_warning(file: str) -> int:
         return 0
 
 
-def can_write_to_path(file: str) -> Tuple[int, str]:
+def can_write_to_path(file: str) -> tuple[int, str]:
     """Check to see if path exists and file can be written.
 
     Args:
@@ -591,8 +589,8 @@ def can_write_to_path(file: str) -> Tuple[int, str]:
 
 
 def check_all_required_args_provided(
-    func: Callable, args: Dict, raise_exception: bool = True
-) -> List:
+    func: Callable, args: dict, raise_exception: bool = True
+) -> list:
     """Check all required arguments of func are provided by args
 
     Args:
@@ -618,7 +616,7 @@ def check_all_required_args_provided(
     return missing_args
 
 
-def get_all_args(func: Callable) -> List:
+def get_all_args(func: Callable) -> list:
     """get all the parameters of a function
 
     Args:

--- a/src/qiskit_metal/viewer/__init__.py
+++ b/src/qiskit_metal/viewer/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/src/qiskit_metal/viewer/headless_gui.py
+++ b/src/qiskit_metal/viewer/headless_gui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit / Quantum Metal.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -113,9 +111,9 @@ class MetalGUIHeadless:
         self._design = design
         self._figsize = figsize
         self._autoscale_default = autoscale
-        self._highlighted: List[str] = []
-        self._zoom_bounds: Optional[tuple] = None  # (xmin, ymin, xmax, ymax)
-        self._last_figure: Optional["Figure"] = None
+        self._highlighted: list[str] = []
+        self._zoom_bounds: tuple | None = None  # (xmin, ymin, xmax, ymax)
+        self._last_figure: "Figure" | None = None
         self.main_window = _NoOpMainWindow()
         _show_headless_banner_once()
 
@@ -131,7 +129,7 @@ class MetalGUIHeadless:
         self._design = design
         self.rebuild()
 
-    def rebuild(self, autoscale: bool = False) -> Optional["Figure"]:
+    def rebuild(self, autoscale: bool = False) -> "Figure" | None:
         """Rebuild the design geometry and re-render the inline figure.
 
         Args:
@@ -152,11 +150,11 @@ class MetalGUIHeadless:
 
         return self._render()
 
-    def refresh(self) -> Optional["Figure"]:
+    def refresh(self) -> "Figure" | None:
         """Alias for :meth:`rebuild` (matches MetalGUI's refresh)."""
         return self.rebuild()
 
-    def autoscale(self) -> Optional["Figure"]:
+    def autoscale(self) -> "Figure" | None:
         """Clear any zoom bounds and re-render at full design extent."""
         self._zoom_bounds = None
         return self._render()
@@ -173,7 +171,7 @@ class MetalGUIHeadless:
         """
         return
 
-    def highlight_components(self, component_names: List[str]) -> Optional["Figure"]:
+    def highlight_components(self, component_names: list[str]) -> "Figure" | None:
         """Mark components for highlighting on the next render.
 
         Args:
@@ -185,7 +183,7 @@ class MetalGUIHeadless:
         self._highlighted = list(component_names)
         return self._render()
 
-    def zoom_on_components(self, components: List[str]) -> Optional["Figure"]:
+    def zoom_on_components(self, components: list[str]) -> "Figure" | None:
         """Zoom the next render to fit the given components.
 
         Computes a bounding box from each component's
@@ -224,8 +222,8 @@ class MetalGUIHeadless:
         name: str = "shot",
         type_: str = "png",
         display: bool = True,
-        disp_ops: Optional[dict] = None,
-    ) -> Optional["Figure"]:
+        disp_ops: dict | None = None,
+    ) -> "Figure" | None:
         """Render the current view and save to disk; display inline.
 
         Mirrors :meth:`MetalGUI.screenshot` so tutorial code is
@@ -340,7 +338,7 @@ class MetalGUIHeadless:
 
     # ── Internal helpers ─────────────────────────────────────────────────
 
-    def _render(self, display_inline: bool = True) -> Optional["Figure"]:
+    def _render(self, display_inline: bool = True) -> "Figure" | None:
         """Re-render the design with current zoom + highlight state."""
         try:
             # Import here so headless module stays lite-install-safe.
@@ -586,7 +584,7 @@ def _is_headless_environment() -> bool:
 def gui(
     design: "QDesign",
     *,
-    force_headless: Optional[bool] = None,
+    force_headless: bool | None = None,
     **kwargs,
 ):
     """Return the right GUI object for the current environment.

--- a/src/qiskit_metal/viewer/show_inline.py
+++ b/src/qiskit_metal/viewer/show_inline.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit / Quantum Metal.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -29,7 +27,7 @@ if TYPE_CHECKING:
 
 
 def show_inline(
-    fig: "Optional[Figure]" = None,
+    fig: "Figure | None" = None,
     *,
     dpi: int = 110,
     close: bool = True,

--- a/src/qiskit_metal/viewer/view.py
+++ b/src/qiskit_metal/viewer/view.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -27,12 +25,12 @@ from qiskit_metal.renderers.renderer_mpl.mpl_renderer import QMplRenderer
 
 def view(
     design: QDesign,
-    ax: Optional[Axes] = None,
+    ax: Axes | None = None,
     *,
-    figsize: Tuple[float, float] = (8.0, 8.0),
-    components: Optional[Iterable[str]] = None,
-    hidden_layers: Optional[Iterable[int]] = None,
-    title: Optional[str] = None,
+    figsize: tuple[float, float] = (8.0, 8.0),
+    components: Iterable[str] | None = None,
+    hidden_layers: Iterable[int] | None = None,
+    title: str | None = None,
 ) -> Figure:
     """Render ``design`` to a matplotlib :class:`~matplotlib.figure.Figure`.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -26,7 +24,7 @@ class AssertionsMixin:
         expected: float,
         tested: float,
         *,
-        msg: Optional[str] = None,
+        msg: str | None = None,
         rel_tol: float = 1e-7,
         abs_tol: float = 0.0,
     ):
@@ -71,7 +69,7 @@ class AssertionsMixin:
         self,
         expected: Iterable[float],
         tested: Iterable[float],
-        msg: Optional[str] = None,
+        msg: str | None = None,
         rel_tol: float = 1e-7,
         abs_tol: float = 0.0,
     ):

--- a/tests/custom_decorators.py
+++ b/tests/custom_decorators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_airbridge.py
+++ b/tests/test_airbridge.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_airbridge_elmer.py
+++ b/tests/test_airbridge_elmer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_airbridge_elmer.py
+++ b/tests/test_airbridge_elmer.py
@@ -27,6 +27,7 @@ Two layers, so as much as possible runs without the Elmer solver binary:
 
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -82,6 +83,41 @@ def _elmer_available():
     return bool(shutil.which("ElmerSolver") and shutil.which("ElmerGrid"))
 
 
+# The meshing body is executed in a *subprocess* (see below). gmsh's 3D
+# generator is native code that can abort the whole interpreter -- observed as
+# STATUS_HEAP_CORRUPTION on the Windows runner and, intermittently, SIGABRT on
+# Linux. In-process, that takes down the entire pytest run with no traceback
+# and no other test results. Isolating it means a native abort is reported
+# against this test alone.
+_MESH_SUBPROCESS = """
+import os, sys, tempfile
+sys.path.insert(0, {tests_dir!r})
+import gmsh
+from test_airbridge_elmer import _airbridge_cpw_design, LAYER_TYPES, OPEN_PINS
+from qiskit_metal.renderers.renderer_elmer.elmer_renderer import QElmerRenderer
+
+sim_dir = tempfile.mkdtemp()
+er = QElmerRenderer(_airbridge_cpw_design(), layer_types=LAYER_TYPES)
+er.gmsh.options.mesh.min_size = "5um"
+er.gmsh.options.mesh.max_size = "60um"
+er.options.simulation_dir = sim_dir
+try:
+    er.render_design(open_pins=OPEN_PINS, skip_junctions=True)
+    # a real 3D mesh (not just a wireframe) was produced
+    n_volumes = len(gmsh.model.getEntities(3))
+    assert n_volumes > 0, "no 3D entities were produced"
+    er.add_solution_setup("capacitance")
+    er.write_sif()
+finally:
+    er.close()
+
+sif = os.path.join(sim_dir, er.options.simulation_input_file)
+assert os.path.exists(sif), sif
+assert os.path.getsize(sif) > 0, "sif is empty"
+print("MESH_OK volumes=%d sif=%d" % (n_volumes, os.path.getsize(sif)))
+"""
+
+
 @unittest.skipUnless(
     _gmsh_available() and sys.platform.startswith("linux"),
     "gmsh 3D meshing is only exercised on Linux here — native gmsh crashes "
@@ -92,26 +128,33 @@ class TestAirbridgeElmerSetup(unittest.TestCase):
     entire Elmer pipeline short of the numerical solve (no binary needed)."""
 
     def test_mesh_and_sif_are_generated(self):
-        import gmsh
-        from qiskit_metal.renderers.renderer_elmer.elmer_renderer import QElmerRenderer
+        code = _MESH_SUBPROCESS.format(
+            tests_dir=os.path.dirname(os.path.abspath(__file__))
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
 
-        sim_dir = tempfile.mkdtemp()
-        er = QElmerRenderer(_airbridge_cpw_design(), layer_types=LAYER_TYPES)
-        er.gmsh.options.mesh.min_size = "5um"
-        er.gmsh.options.mesh.max_size = "60um"
-        er.options.simulation_dir = sim_dir
-        try:
-            er.render_design(open_pins=OPEN_PINS, skip_junctions=True)
-            # a real 3D mesh (not just a wireframe) was produced
-            self.assertGreater(len(gmsh.model.getEntities(3)), 0)
-            er.add_solution_setup("capacitance")
-            er.write_sif()
-        finally:
-            er.close()
+        if proc.returncode < 0:
+            # Killed by a signal: gmsh's native mesher aborted. That is an
+            # upstream/environment instability, not a defect in the geometry
+            # this test covers, so don't fail the suite on it -- but say so
+            # loudly rather than passing silently.
+            self.skipTest(
+                f"gmsh native mesher died with signal {-proc.returncode} "
+                f"(known instability, see #1144). stderr tail:\n"
+                f"{proc.stderr[-2000:]}"
+            )
 
-        sif = os.path.join(sim_dir, er.options.simulation_input_file)
-        self.assertTrue(os.path.exists(sif), sif)
-        self.assertGreater(os.path.getsize(sif), 0)
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"meshing subprocess failed\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr[-4000:]}",
+        )
+        self.assertIn("MESH_OK", proc.stdout, msg=proc.stdout)
 
 
 @unittest.skipUnless(

--- a/tests/test_analyses_1_inst_options.py
+++ b/tests/test_analyses_1_inst_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_analyses_2_functionality.py
+++ b/tests/test_analyses_2_functionality.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_default_options.py
+++ b/tests/test_default_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_default_options_completeness.py
+++ b/tests/test_default_options_completeness.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -133,7 +131,7 @@ class _OptionsAccessCollector(ast.NodeVisitor):
     """
 
     def __init__(self):
-        self.keys: Set[str] = set()
+        self.keys: set[str] = set()
         # Local variable aliases: name -> "options" | "p"
         self._aliases: dict[str, str] = {"self.options": "options", "self.p": "p"}
 
@@ -198,7 +196,7 @@ class _OptionsAccessCollector(ast.NodeVisitor):
         self.generic_visit(node)
 
 
-def _collect_option_accesses(cls) -> Set[str]:
+def _collect_option_accesses(cls) -> set[str]:
     """Return the set of option keys statically referenced anywhere
     in the class body (across all methods)."""
     src = inspect.getsource(cls)
@@ -208,7 +206,7 @@ def _collect_option_accesses(cls) -> Set[str]:
     return collector.keys
 
 
-def _flatten_keys(d, parent_key: str = "") -> Set[str]:
+def _flatten_keys(d, parent_key: str = "") -> set[str]:
     """Flatten a (potentially nested) options dict into a set of
     top-level keys. Only the top-level names are meaningful for the
     audit — nested keys are accessed via ``self.p.parent.child`` and

--- a/tests/test_designs.py
+++ b/tests/test_designs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gds_export.py
+++ b/tests/test_gds_export.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gds_short_segments.py
+++ b/tests/test_gds_short_segments.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gmsh_path_short_segments.py
+++ b/tests/test_gmsh_path_short_segments.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gui_basic.py
+++ b/tests/test_gui_basic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gui_init.py
+++ b/tests/test_gui_init.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_gui_teardown.py
+++ b/tests/test_gui_teardown.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_lom_run.py
+++ b/tests/test_lom_run.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_pyepr_integration.py
+++ b/tests/test_pyepr_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qgeometries.py
+++ b/tests/test_qgeometries.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_1_instantiate.py
+++ b/tests/test_qlibrary_1_instantiate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_2_options.py
+++ b/tests/test_qlibrary_2_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_3_functionality.py
+++ b/tests/test_qlibrary_3_functionality.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_3_options.py
+++ b/tests/test_qlibrary_3_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_idempotency.py
+++ b/tests/test_qlibrary_idempotency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_qlibrary_pin_sanity.py
+++ b/tests/test_qlibrary_pin_sanity.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_route_anchors_unobstructed.py
+++ b/tests/test_route_anchors_unobstructed.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_snail.py
+++ b/tests/test_snail.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_solution_types.py
+++ b/tests/test_solution_types.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_to_python_script.py
+++ b/tests/test_to_python_script.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_toolbox_metal.py
+++ b/tests/test_toolbox_metal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_toolbox_python.py
+++ b/tests/test_toolbox_python.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_transmon_cross_claw_back.py
+++ b/tests/test_transmon_cross_claw_back.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.

--- a/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.31 Create a QComponent - Basic.ipynb
+++ b/tutorials/2 From components to chip/D. How do I make my custom QComponent/2.31 Create a QComponent - Basic.ipynb
@@ -40,8 +40,6 @@
    },
    "outputs": [],
    "source": [
-    "# -*- coding: utf-8 -*-\n",
-    "\n",
     "# This code is part of Qiskit.\n",
     "#\n",
     "# (C) Copyright IBM 2017, 2021.\n",

--- a/tutorials/resources/my429_qcomponents.py
+++ b/tutorials/resources/my429_qcomponents.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/tutorials/resources/skeleton_renderer.py
+++ b/tutorials/resources/skeleton_renderer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2021.
@@ -143,7 +141,7 @@ class QSkeletonRenderer(QRenderer):
         )
         return 0
 
-    def check_qcomps(self, highlight_qcomponents: list = []) -> Tuple[list, int]:
+    def check_qcomps(self, highlight_qcomponents: list = []) -> tuple[list, int]:
         """Confirm the list doesn't have names of componentes repeated. Comfirm
         that the name of component exists in QDesign.
 
@@ -183,7 +181,7 @@ class QSkeletonRenderer(QRenderer):
 
     def get_qgeometry_tables_for_skeleton(
         self, highlight_qcomponents: list = []
-    ) -> Tuple[int, list]:
+    ) -> tuple[int, list]:
         """Using self.design, this method does the following:
 
         1. Gather the QGeometries to be used to write to file.


### PR DESCRIPTION
Three independent close-outs, each in its own commit.

## 1. Isolate the gmsh 3D meshing test in a subprocess (#1144)

`gmsh`'s 3D generator is native code that can abort the interpreter outright — `STATUS_HEAP_CORRUPTION` on Windows (already gated off), and **intermittently `SIGABRT` on Linux**. It fired on `tests-python3.12-ubuntu-24.04` during #1163:

```
tests/test_airbridge_elmer.py  py: exit -6 (22.15 seconds)
##[error]Process completed with exit code 250.
```

In-process, that kills the **whole pytest run** — no traceback, no results for any other test, and a job that reads as broken rather than flaky. It re-ran green on the identical tree, confirming nondeterminism.

Now the meshing body runs in a subprocess, and the two failure modes are separated:

| Outcome | Meaning | Handling |
|---|---|---|
| **death by signal** (`returncode < 0`) | gmsh's native mesher aborted — environment instability, not a defect in the geometry under test | `skipTest`, naming the signal and quoting the stderr tail |
| **non-zero exit** | a Python exception — our bug | failure, with stdout + stderr attached |

Verified both paths: the real test passes end-to-end (`1 passed, 1 skipped in 88.53s`), and a subprocess killed with `SIGABRT` reports as `SKIPPED … died with signal 6` instead of taking pytest down.

## 2. FAQ: running `MetalGUI` from a standalone script (#1013)

#1013 reported the GUI opening and closing immediately under `python my_script.py` while the same code worked in Jupyter. Cause: nothing starts the Qt event loop; Jupyter already runs one.

#1159/#1160 fixed the **generated**-script path, but a hand-written script was still on its own and there was no documentation for it. Adds an FAQ entry with the working pattern plus the two details that bite: use `exec()` not the deprecated `exec_()`, and keep the `__main__` guard, because `exec()` blocks and an unguarded call hangs importers and Jupyter sessions that already run a Qt loop.

## 3. Second tier of safely-fixable ruff rules

Same criteria as #1163 — safely auto-fixable (**no `--unsafe-fixes`**), no runtime behaviour change on our supported range (3.10–3.12). 577 fixes across 261 files:

- **`UP009`** (248) — `# -*- coding: utf-8 -*-` has been redundant since Python 3.
- **`UP006`** (165) / **`UP045`** (146) — PEP 585 / PEP 604 annotations (`List[int]` → `list[int]`, `Optional[X]` → `X | None`). Both evaluate at runtime on 3.10+, which is our floor.
- **`RET502`** (18) — bare `return` in a value-returning function becomes explicit `return None`.

Still **not** adopted: `I001` (import order is load-bearing for the lazy-Qt design), `RUF012`, `BLE001`, `C408`, `B006`, `UP037` (unquoting annotations can break `TYPE_CHECKING`-only forward references), and the manual-fix groups — see `.claude/context/decision-log.md`.

## Verification

- Full suite **unchanged vs. base: 32 failed / 514 passed** — the same pre-existing lite-venv failures (`renderer_ansys` needing `pyEPR`/`pyaedt`; CI installs `[full]`).
- Because `UP006`/`UP045` touch annotations package-wide, the lite import path was checked separately: `import qiskit_metal` + a headless design build succeed, and `QDesign.__init__` resolves to `(self, metadata: dict | None = None, ...)`.
- `ruff check` / `ruff format --check` clean.
