### PR TITLE
expanding_toolbar: sync toggle state, fix vertical dock, add tests

### DIFF
--- a/src/qiskit_metal/_gui/widgets/bases/expanding_toolbar.py
+++ b/src/qiskit_metal/_gui/widgets/bases/expanding_toolbar.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-from PySide6 import QtCore, QtGui
+from PySide6 import QtCore
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QToolBar, QWidget, QSizePolicy, QToolButton
 
@@ -28,6 +28,10 @@ class QToolBarExpanding(QToolBar):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._toggle_btn_added = False
+        # The spacer that pins the toggle to the end has to expand along
+        # whichever axis the toolbar currently runs, so re-docking to a side
+        # area has to re-point it.
+        self.orientationChanged.connect(self._on_orientation_changed)
 
     def showEvent(self, event: QtCore.QEvent) -> None:
         """Add the toggle button to the far right the first time it is shown."""
@@ -35,19 +39,49 @@ class QToolBarExpanding(QToolBar):
         if not self._toggle_btn_added:
             self._toggle_btn_added = True
 
-            # Spacer to push button to the right
+            # Spacer to push button to the far end
             self._spacer = QWidget()
-            self._spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
             self.addWidget(self._spacer)
+            self._sync_spacer_policy()
 
             self._toggle_btn = QToolButton(self)
             self._toggle_btn.setCheckable(True)
+            self._toggle_btn.setToolTip("Expand/collapse the toolbar")
             self._toggle_btn.clicked.connect(self.on_toggle_clicked)
             self.addWidget(self._toggle_btn)
 
             # Initialize in the contracted state
-            self._toggle_btn.setChecked(False)
             self.contract_me()
+
+    def _sync_spacer_policy(self):
+        """Point the spacer's expanding axis along the toolbar's orientation."""
+        spacer = getattr(self, "_spacer", None)
+        if spacer is None:
+            return
+        if self.orientation() == Qt.Vertical:
+            spacer.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        else:
+            spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+
+    def _on_orientation_changed(self, _orientation):
+        """Re-point the spacer and redraw the arrow after a re-dock."""
+        self._sync_spacer_policy()
+        self.update_arrow_icon()
+
+    def _sync_toggle_state(self, expanded: bool):
+        """Keep the toggle button's checked state in step with the toolbar.
+
+        ``expand_me`` / ``contract_me`` are public and can be called directly,
+        not just from the button. Without this the button and the toolbar drift
+        apart and the next user click re-applies the state it is already in --
+        so the toolbar looks stuck until it is clicked a second time.
+        """
+        btn = getattr(self, "_toggle_btn", None)
+        if btn is None or btn.isChecked() == expanded:
+            return
+        was_blocked = btn.blockSignals(True)
+        btn.setChecked(expanded)
+        btn.blockSignals(was_blocked)
 
     def update_arrow_icon(self):
         """Update the toggle button arrow to reflect the current expansion state."""
@@ -87,6 +121,7 @@ class QToolBarExpanding(QToolBar):
         self.setToolButtonStyle(tool_style)
 
         # update toggle button visual state
+        self._sync_toggle_state(True)
         self.update_arrow_icon()
 
         # align icons and text
@@ -117,24 +152,5 @@ class QToolBarExpanding(QToolBar):
     def contract_me(self):
         """Contract the toolbar."""
         self.setToolButtonStyle(Qt.ToolButtonIconOnly)
+        self._sync_toggle_state(False)
         self.update_arrow_icon()
-
-    def enterEvent(self, evt: QtCore.QEvent) -> None:
-        """enterEvent() is called when the mouse enters the widget's screen
-        space. (This excludes screen space owned by any of the widget's
-        children.)
-
-        Args:
-            evt (QtCore.QEvent): QtCore event
-        """
-        super().enterEvent(evt)
-
-    def leaveEvent(self, evt: QtCore.QEvent) -> None:
-        """leaveEvent() is called when the mouse leaves the widget's screen
-        space. If the mouse enters a child widget it will not cause a
-        leaveEvent().
-
-        Args:
-            evt (QtCore.QEvent): QtCore event
-        """
-        super().leaveEvent(evt)

--- a/tests/test_gui_expanding_toolbar.py
+++ b/tests/test_gui_expanding_toolbar.py
@@ -1,0 +1,151 @@
+# This code is part of Quantum Metal.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+"""Tests for :class:`QToolBarExpanding` -- the plot-window ribbon.
+
+Until #1170 this widget expanded on hover and, worse, called
+``time.sleep(0.25)`` from ``leaveEvent`` -- a blocking sleep on the Qt event
+loop, so the whole window froze for a quarter second every time the pointer
+left the toolbar. It shipped unnoticed because nothing exercised the widget.
+These tests close that gap.
+
+Runs under the ``offscreen`` platform when no display is present, so it is
+covered by the plain GUI-extras job and not only the Xvfb ones. Skips
+entirely on a lite install with no PySide6.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+import pytest
+
+pytest.importorskip("PySide6")
+
+
+def _display_available() -> bool:
+    if sys.platform.startswith("win") or sys.platform == "darwin":
+        return True
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+if not _display_available():
+    # Must be set before the first QApplication is constructed. If another
+    # test already built one, Qt ignores this and we reuse that instance.
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import QEvent, QPointF, Qt  # noqa: E402
+from PySide6.QtGui import QEnterEvent  # noqa: E402
+from PySide6.QtWidgets import QApplication, QMainWindow  # noqa: E402
+
+from qiskit_metal._gui.widgets.bases.expanding_toolbar import (  # noqa: E402
+    QToolBarExpanding,
+)
+
+EXPANDED_STYLES = (Qt.ToolButtonTextUnderIcon, Qt.ToolButtonTextBesideIcon)
+
+
+class TestExpandingToolbar(unittest.TestCase):
+    """The ribbon expands only when asked, and never blocks the event loop."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+
+    def setUp(self):
+        self.win = QMainWindow()
+        self.toolbar = QToolBarExpanding(self.win)
+        for label in ("Help", "Autoscale", "Zoom"):
+            self.toolbar.addAction(label)
+        self.win.addToolBar(Qt.TopToolBarArea, self.toolbar)
+        self.win.show()
+        self.app.processEvents()
+
+    def tearDown(self):
+        self.win.close()
+        self.app.processEvents()
+
+    def _expanded(self) -> bool:
+        return self.toolbar.toolButtonStyle() in EXPANDED_STYLES
+
+    def test_starts_contracted(self):
+        self.assertFalse(self._expanded())
+
+    def test_hover_does_not_expand(self):
+        """The defect users reported: the ribbon opening on mouse-over."""
+        pos = QPointF(1, 1)
+        self.toolbar.enterEvent(QEnterEvent(pos, pos, pos))
+        self.app.processEvents()
+        self.assertFalse(self._expanded())
+
+    def test_leave_does_not_block_the_event_loop(self):
+        """Regression guard for the ``time.sleep(0.25)`` that used to live in
+        ``leaveEvent``. The old code took ~251 ms here; anything near that
+        means a blocking call is back on the GUI thread."""
+        start = time.perf_counter()
+        self.toolbar.leaveEvent(QEvent(QEvent.Leave))
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        self.assertLess(
+            elapsed_ms,
+            50,
+            msg=f"leaveEvent blocked the event loop for {elapsed_ms:.1f} ms",
+        )
+
+    def test_toggle_button_expands_and_contracts(self):
+        btn = self.toolbar._toggle_btn
+        btn.click()
+        self.app.processEvents()
+        self.assertTrue(self._expanded())
+        self.assertEqual(btn.arrowType(), Qt.UpArrow)
+
+        btn.click()
+        self.app.processEvents()
+        self.assertFalse(self._expanded())
+        self.assertEqual(btn.arrowType(), Qt.DownArrow)
+
+    def test_programmatic_calls_keep_the_button_in_sync(self):
+        """``expand_me`` / ``contract_me`` are public. If the button does not
+        follow them, the next user click re-applies the current state and the
+        toolbar appears stuck until clicked twice."""
+        btn = self.toolbar._toggle_btn
+
+        self.toolbar.expand_me()
+        self.app.processEvents()
+        self.assertTrue(btn.isChecked())
+
+        # One click must now collapse it -- not expand it again.
+        btn.click()
+        self.app.processEvents()
+        self.assertFalse(self._expanded())
+
+        self.toolbar.contract_me()
+        self.app.processEvents()
+        self.assertFalse(btn.isChecked())
+
+    def test_spacer_expands_along_the_toolbar_axis(self):
+        """A toolbar dragged to a side dock runs vertically; the spacer that
+        pins the toggle to the end has to expand along that axis instead."""
+        from PySide6.QtWidgets import QSizePolicy
+
+        spacer = self.toolbar._spacer
+        self.assertEqual(spacer.sizePolicy().horizontalPolicy(), QSizePolicy.Expanding)
+
+        self.win.addToolBar(Qt.LeftToolBarArea, self.toolbar)
+        self.app.processEvents()
+        self.assertEqual(self.toolbar.orientation(), Qt.Vertical)
+        self.assertEqual(spacer.sizePolicy().verticalPolicy(), QSizePolicy.Expanding)
+
+    def test_vertical_expand_does_not_raise(self):
+        self.win.addToolBar(Qt.LeftToolBarArea, self.toolbar)
+        self.app.processEvents()
+        self.toolbar.expand_me()
+        self.app.processEvents()
+        self.assertTrue(self._expanded())
+        self.assertEqual(self.toolbar._toggle_btn.arrowType(), Qt.LeftArrow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up to #1170 (thanks @LisithaDiz) — the two loose ends I flagged while reviewing it, plus the test coverage whose absence let a blocking sleep on the GUI thread live in this widget unnoticed.

## 1. Toggle button drifted out of sync with the toolbar

`expand_me` / `contract_me` are public and can be called directly, not only through the button. When they were, `_toggle_btn` kept its old checked state — so the user's next click re-applied the state the toolbar was already in, and it looked stuck until clicked a second time.

Both now call `_sync_toggle_state()`, with signals blocked so the sync doesn't re-enter `on_toggle_clicked`.

Not reachable from the app as it stands — nothing outside the widget calls either method today. It's a trap for the next caller, which is why it's worth closing now rather than after someone hits it.

## 2. Toggle stopped being pinned when the toolbar was re-docked

`_spacer` was created once with a fixed `(Expanding, Preferred)` policy — horizontal only. `QToolBar` is movable by default, so dragging the ribbon to a left/right dock flips it vertical, at which point the spacer stops pushing and the toggle sits immediately after the actions instead of at the end.

The policy now follows `orientation()`, re-pointed on the `orientationChanged` signal.

## 3. Tests — `tests/test_gui_expanding_toolbar.py`

This widget had **zero** coverage, which is how the original `time.sleep(0.25)` in `leaveEvent` — a blocking sleep on the Qt event loop, freezing the whole window for a quarter second on every mouse-leave — survived as long as it did.

Seven tests: starts contracted, hover doesn't expand, toggle works both ways with the right arrow, the two fixes above, and vertical expand doesn't raise.

Both new behaviours are covered by tests that **fail against the pre-fix code** — verified by stashing the source change and re-running:

```
FAILED test_programmatic_calls_keep_the_button_in_sync
FAILED test_spacer_expands_along_the_toolbar_axis
2 failed, 5 passed
```

There's also a timing guard on `leaveEvent`: the pre-#1170 version took ~251 ms there, and the test fails above 50 ms, so a blocking call cannot come back unnoticed.

The module sets `QT_QPA_PLATFORM=offscreen` when no display is present, so it runs in the plain `tests-extras-gui` job rather than only the Xvfb ones, and `importorskip`s on a lite install.

## Also

Drops the `enterEvent` / `leaveEvent` overrides, which after #1170 only called `super()`, and the now-unused `QtGui` import.

## Test status

- Full suite: **595 passed, 6 skipped** (7 new).
- `ruff check` / `ruff format --check` clean.

Draft until CI reports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQtt5kz9M1Jt9Dr7NtfHiX)_