### PR TITLE
fix(TransmonCross): support connector_location='270' for south arm

### DIFF
--- a/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
+++ b/src/qiskit_metal/qlibrary/qubits/transmon_cross.py
@@ -64,7 +64,7 @@ class TransmonCross(BaseQubit):
             * claw_width: '10um' -- The width of the CPW center trace making up the claw/gap connector
             * claw_width_back: None -- The width of the back (towards the incoming CPW) of the claw connector. Defaults to claw_width when None
             * claw_gap: '6um' -- The gap of the CPW center trace making up the claw/gap connector
-            * connector_location: '0' -- 0 => 'west' arm, 90 => 'north' arm, 180 => 'east' arm
+            * connector_location: '0' -- 0 => 'west' arm, 90 => 'north' arm, 180 => 'east' arm, 270 => 'south' arm
     """
 
     default_options = Dict(
@@ -82,7 +82,7 @@ class TransmonCross(BaseQubit):
             claw_gap="6um",
             claw_cpw_length="40um",
             claw_cpw_width="10um",
-            connector_location="0",  # 0 => 'west' arm, 90 => 'north' arm, 180 => 'east' arm
+            connector_location="0",  # 0 => 'west' arm, 90 => 'north' arm, 180 => 'east' arm, 270 => 'south' arm
         ),
     )
     """Default options."""
@@ -220,7 +220,9 @@ class TransmonCross(BaseQubit):
         )
 
         claw_rotate = 0
-        if con_loc > 135:
+        if con_loc > 225:
+            claw_rotate = 90
+        elif con_loc > 135:
             claw_rotate = 180
         elif con_loc > 45:
             claw_rotate = -90


### PR DESCRIPTION
Fixes #1052 

## Summary

`TransmonCross.make_connection_pad()` silently misplaces the connector when
`connector_location='270'` is passed — it lands on the **east** arm instead
of the **south** arm.

## Root Cause

The `claw_rotate` if/elif chain only handled three cases:

```python
claw_rotate = 0
if con_loc > 135:        # 270 > 135 is True → east arm!
    claw_rotate = 180
elif con_loc > 45:
    claw_rotate = -90
```

Because `270 > 135`, it hits the first branch and rotates 180° (east).
There is no branch for angles above 225°.

## Design Note

The original code intentionally supported only 3 connector arms (west/0°,
north/90°, east/180°) because the **south arm is reserved for the Josephson
Junction** (DC SQUID). The docstring states:

> "Creates the X cross-shaped island, the 'junction' on the south end,
> and **up to 3 connectors** on the remaining arms."

However, the code **silently misplaces** the connector instead of raising an
error. Users reasonably expect 270° to work (placing a connector alongside
the junction), and the connector geometry does not physically overlap the
junction. This fix adds proper support for 270° rather than silently
producing incorrect output.

## Changes

**`src/qiskit_metal/qlibrary/qubits/transmon_cross.py`**

- Add `if con_loc > 225: claw_rotate = 90` before the existing `> 135` check
- Update docstring and inline comments to document `270 => 'south' arm`

## Before / After

| `connector_location` | Before (bug) | After (fix) |
|---|---|---|
| `'270'` | Pin at `(+0.281, 2.000)` — **east arm** | Pin at `(0.000, 1.719)` — **south arm** ✅ |

### Before 
<img width="552" height="392" alt="image" src="https://github.com/user-attachments/assets/32976427-d95e-49ee-bcfd-f02d35219e9f" />

### After

<img width="552" height="392" alt="image" src="https://github.com/user-attachments/assets/78db5f0f-1fa9-4338-81e3-e3ce677ce572" />

